### PR TITLE
Add support for local bfmts zarr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Support local tiff files.
+- Support local zarr directories.
 
 ### Changed
 

--- a/avivator/src/Avivator.js
+++ b/avivator/src/Avivator.js
@@ -73,7 +73,10 @@ export default function Avivator(props) {
   const [globalSelections, setGlobalSelections] = useState({ z: 0, t: 0 });
   const [initialViewState, setInitialViewState] = useState({});
   const [offsetsSnackbarOn, toggleOffsetsSnackbar] = useState(false);
-  const [loaderErrorSnackbarOn, toggleLoaderErrorSnackbar] = useState(false);
+  const [loaderErrorSnackbar, setLoaderErrorSnackbar] = useState({
+    on: false,
+    message: null
+  });
   const [noImageUrlSnackbarIsOn, toggleNoImageUrlSnackbar] = useState(
     sources.map(s => s.url).indexOf(initSource.url) >= 0
   );
@@ -93,7 +96,7 @@ export default function Avivator(props) {
       const nextLoader = await createLoader(
         urlOrFile,
         toggleOffsetsSnackbar,
-        toggleLoaderErrorSnackbar
+        message => setLoaderErrorSnackbar({ on: true, message })
       );
       if (nextLoader) {
         const { dimensions: newDimensions, isRgb } = nextLoader;
@@ -473,16 +476,16 @@ export default function Avivator(props) {
         </Alert>
       </Snackbar>
       <Snackbar
-        open={loaderErrorSnackbarOn}
+        open={loaderErrorSnackbar.on}
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         elevation={6}
         variant="filled"
       >
         <Alert
-          onClose={() => toggleLoaderErrorSnackbar(false)}
+          onClose={() => setLoaderErrorSnackbar({ on: false, message: null })}
           severity="error"
         >
-          <LoaderError />
+          <LoaderError message={loaderErrorSnackbar.message} />
         </Alert>
       </Snackbar>
 

--- a/avivator/src/Avivator.js
+++ b/avivator/src/Avivator.js
@@ -172,7 +172,7 @@ export default function Avivator(props) {
         setGlobalSelections(selections[0]);
         // eslint-disable-next-line no-unused-expressions
         history?.push(
-          urlOrFile instanceof File ? '' : `?image_url=${urlOrFile}`
+          typeof urlOrFile === 'string' ? `?image_url=${urlOrFile}` : ''
         );
       }
     }
@@ -241,11 +241,19 @@ export default function Avivator(props) {
     }
   };
   const handleSubmitFile = files => {
-    const newSource = {
-      urlOrFile: files[0],
-      // Use the trailing part of the URL (file name, presumably) as the description.
-      description: files[0].name
-    };
+    let newSource;
+    if (files.length === 1) {
+      newSource = {
+        urlOrFile: files[0],
+        // Use the trailing part of the URL (file name, presumably) as the description.
+        description: files[0].name
+      };
+    } else {
+      newSource = {
+        urlOrFile: files,
+        description: 'data.zarr'
+      };
+    }
     setSource(newSource);
   };
 

--- a/avivator/src/components/Dropzone.js
+++ b/avivator/src/components/Dropzone.js
@@ -21,8 +21,8 @@ export function DropzoneButton({ handleSubmitFile }) {
       {...getRootProps()}
     >
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-      <input {...getInputProps()} />
-      <p>Open Local OME-TIFF</p>
+      <input {...getInputProps({ accept: '.tif, .tiff' })} />
+      <p>Choose a file</p>
     </Button>
   );
 }

--- a/avivator/src/components/Menu.js
+++ b/avivator/src/components/Menu.js
@@ -129,7 +129,7 @@ function Menu({ children, ...props }) {
       <Paper className={classes.paper}>
         <Header
           handleSubmitNewUrl={handleSubmitNewUrl}
-          url={urlOrFile instanceof File ? '' : urlOrFile}
+          url={typeof urlOrFile === 'string' ? urlOrFile : ''}
           menuToggle={toggle}
           handleSubmitFile={handleSubmitFile}
         />

--- a/avivator/src/components/SnackbarAlerts.js
+++ b/avivator/src/components/SnackbarAlerts.js
@@ -5,9 +5,9 @@ import Link from '@material-ui/core/Link';
 export function OffsetsWarning() {
   return (
     <>
-      A lot of channels but have been detected in the requested OME-TIFF. To
-      learn how to speed up load times by providing byte offsets, refer to the
-      first point{' '}
+      A lot of channels have been detected in the requested OME-TIFF. To learn
+      how to speed up load times by providing byte offsets, refer to the first
+      point{' '}
       <Link
         target="_blank"
         rel="noopener noreferrer"
@@ -20,8 +20,8 @@ export function OffsetsWarning() {
   );
 }
 
-export function LoaderError() {
-  return (
+export function LoaderError({ message }) {
+  const defaultErrorMessage = (
     <>
       Something has gone wrong loading your image. Please refer to the{' '}
       <Link
@@ -34,6 +34,7 @@ export function LoaderError() {
       for information about supported file formats.
     </>
   );
+  return message ? <>{message}</> : defaultErrorMessage;
 }
 
 export function NoImageUrlInfo() {

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -45,7 +45,7 @@ export async function createLoader(
       }
       return loader;
     }
-    const loader = await createBioformatsZarrLoader({ url });
+    const loader = await createBioformatsZarrLoader({ source: urlOrFile });
     return loader;
   } catch {
     handleLoaderError(true);

--- a/src/loaders/fileStore.js
+++ b/src/loaders/fileStore.js
@@ -1,0 +1,24 @@
+import { KeyError } from 'zarr';
+
+/**
+ * A valid zarr.Store that maps keys to local a zarr.DirectoryStore.
+ * @param {Map} fileMapping, keys are zarr keys and values are File objects.
+ * */
+export default class FileStore {
+  constructor(fileMapping) {
+    this._store = fileMapping;
+  }
+
+  async getItem(key) {
+    const file = this._store.get(key);
+    if (!file) {
+      throw new KeyError(item);
+    }
+    const buffer = await file.arrayBuffer();
+    return buffer;
+  }
+
+  async containsItem(key) {
+    return this._store.has(key);
+  }
+}

--- a/src/loaders/fileStore.js
+++ b/src/loaders/fileStore.js
@@ -12,7 +12,7 @@ export default class FileStore {
   async getItem(key) {
     const file = this._store.get(key);
     if (!file) {
-      throw new KeyError(item);
+      throw new KeyError(key);
     }
     const buffer = await file.arrayBuffer();
     return buffer;

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -5,6 +5,7 @@ import ZarrLoader from './zarrLoader';
 import OMETiffLoader from './OMETiffLoader';
 import { getChannelStats, getJson, dimensionsFromOMEXML } from './utils';
 import OMEXML from './omeXML';
+import FileStore from './fileStore';
 
 export async function createZarrLoader({
   url,
@@ -38,17 +39,55 @@ export async function createZarrLoader({
   });
 }
 
-export async function createBioformatsZarrLoader({ url }) {
-  const baseUrl = url.endsWith('/') ? url : `${url}/`;
-  const metaUrl = `${baseUrl}METADATA.ome.xml`;
-  const store = new HTTPStore(`${baseUrl}data.zarr/0`); // first image
-  const rootAttrs = await getJson(store, '.zattrs');
+/**
+ * This function wraps parsing OME-XML metadata and creating a zarr loader.
+ * @param {(string | File[])}, either a string URL or array of File Objects.
+ */
+export async function createBioformatsZarrLoader({ source }) {
+  const METADATA = 'METADATA.ome.xml';
+  const ZARR_DIR = 'data.zarr/';
 
+  let store;
+  let omexmlBuffer;
+  if (typeof source === 'string') {
+    // Remote Zarr
+    const baseUrl = source.endsWith('/') ? source : `${source}/`;
+    const metaUrl = `${baseUrl}${METADATA}`;
+    store = new HTTPStore(`${baseUrl}${ZARR_DIR}`); // first image
+    omexmlBuffer = await fetch(metaUrl).then(res => res.arrayBuffer());
+  } else {
+    // Local Zarr
+    /*
+     * You can't randomly access files from a directory by path name
+     * without the Native File System API, so we need to get objects for _all_
+     * the files right away for Zarr. This is unfortunate because we need to iterate
+     * over all File objects and create an in-memory index.
+     */
+    const fMap = new Map();
+    let keyPrefixLength;
+    for (let i = 0; i < source.length; i += 1) {
+      const file = source[i];
+      if (file.name === METADATA) {
+        // Find the metadata file.
+        // eslint-disable-next-line no-await-in-loop
+        omexmlBuffer = await file.arrayBuffer();
+      } else {
+        if (!keyPrefixLength) {
+          keyPrefixLength = file.path.indexOf(ZARR_DIR) + ZARR_DIR.length;
+        }
+        const path = file.path.slice(keyPrefixLength);
+        fMap.set(path, file);
+      }
+    }
+    store = new FileStore(fMap);
+  }
+
+  const rootAttrs = await getJson(store, '0/.zattrs');
   let resolutions = ['0'];
   if ('multiscales' in rootAttrs) {
     // Get path to subresolutions if they exist
     const { datasets } = rootAttrs.multiscales[0];
-    resolutions = datasets.map(d => d.path);
+    resolutions = datasets.map(d => `0/${d.path}`);
   }
 
   const promises = resolutions.map(path => openArray({ store, path }));
@@ -65,8 +104,7 @@ export async function createBioformatsZarrLoader({ url }) {
   const data = pyramid.length > 1 || shouldUseBase ? pyramid : pyramid[0];
 
   // Get OMEXML string
-  const buffer = await fetch(metaUrl).then(res => res.arrayBuffer());
-  const omexmlString = new TextDecoder().decode(new Uint8Array(buffer));
+  const omexmlString = new TextDecoder().decode(new Uint8Array(omexmlBuffer));
   const omexml = new OMEXML(omexmlString);
   const dimensions = dimensionsFromOMEXML(omexml);
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -68,12 +68,19 @@ $ raw2ometiff n5_tile_directory/ LuCa-7color_Scan1.ome.tif --compression=zlib
 
 There are a few different ways to view your data in Avivator.
 
-If you have an OME-TIFF saved locally, you may simply drag and drop the file over the canvas or use the "Open Local OME-TIFF" button to view your data. 
-Note that this action does **NOT** necessarily load the entire OME-TIFF file into memory. Viv still works as normal and will retrieve data tiles based on the viewport for an image pyramid and/or a specific channel/z/time selection.
+If you have an OME-TIFF or Bio-Formats "raw" Zarr output saved locally, you may simply drag and drop 
+the file (or directory) over the canvas or use the "Choose file" button to view your data.
+Note that this action does **NOT** necessarily load the entire dataset into memory. Viv still works as normal and will retrieve data tiles based on the viewport for an image pyramid and/or a specific channel/z/time selection. 
 
-Otherwise Avivator relies on access to OME-TIFF and Bio-Formats Zarr data over HTTP and you can serve data locally using a simple web-server.
-requires a simple web-server. The easist option is to use [`http-server`](https://github.com/http-party/http-server#readme),
-which can be installed via `npm` or `Homebrew` if using a Mac:
+If you followed **Option 1** above, you may drag and drop the `LuCa-7color_Scan1/` directory created via `bioformats2raw`
+into Avivator. If you followed **Option 2**, simply select the `LuCa-7color_Scan1.ome.tif` to view in Avivator.
+
+> NOTE: Large Zarr-based image pyramids may take a bit longer to load initially using this method. We recommend using a simple web 
+> server (see below) if you experience issues with Zarr loading times. Additionally, support for drag-and-drop for Zarr-based 
+> images is only currently supported in Chrome, Firefox, and Microsoft Edge. If using Safari, please use a web-server.
+
+Otherwise Avivator relies on access to data over HTTP, and you can serve data locally using a simple web-server. 
+It's easiest to use [`http-server`](https://github.com/http-party/http-server#readme) to start a web-server locally, which can be installed via `npm` or `Homebrew` if using a Mac:
 
 #### Install `http-server`
 


### PR DESCRIPTION
Adds a zarr`FileStore` class which is simply a mapping of zarr keys to `File` objects. My current understanding wrt directories is that without the [Native File System API](https://developer.mozilla.org/en-US/docs/Web/API/FileSystem), you can't randomly request to read files from a directory by path name. 

That means you can't create `File` objects on-demand, and instead we need get all the files up front and create an index that maps zarr keys to blobs. With that said, the current example works well! I'd just worry if someone had a massive pyramid.  

![drag-and-drop-zarr](https://user-images.githubusercontent.com/24403730/90961663-8cf07a00-e478-11ea-94f3-ede26aa520c3.gif)
