### PR TITLE
Fix keys issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Fix keys issue in lens.
+
 ## 0.4.2
 
 ### Added

--- a/avivator/src/Avivator.js
+++ b/avivator/src/Avivator.js
@@ -371,6 +371,7 @@ export default function Avivator(props) {
               channelOptions={selections.map(
                 sel => channelOptions[sel.channel]
               )}
+              ids={ids}
               lensSelection={lensSelection}
             />
           )}

--- a/avivator/src/components/LensSelect.js
+++ b/avivator/src/components/LensSelect.js
@@ -9,6 +9,7 @@ function LensSelect({
   handleToggle,
   handleSelection,
   channelOptions,
+  ids,
   lensSelection
 }) {
   const checkboxColor = `rgb(${[255, 255, 255]})`;
@@ -36,7 +37,7 @@ function LensSelect({
           onChange={e => handleSelection(e.target.value)}
         >
           {channelOptions.map((opt, i) => (
-            <option key={opt} value={i}>
+            <option key={`${opt}-${ids[i]}`} value={i}>
               {opt}
             </option>
           ))}


### PR DESCRIPTION
Previously `opt` could be the same thing twice when you added a new channel since it would appear twice in the lens selector.