### PR TITLE
Bundle UMD with Dependencies (Except React)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Removed greedy matching of dimension order in Bio-Formats Zarr output. Just check if OME-Zarr.
+- Bundle UMD build with deps.
 
 ## 0.4.2
 

--- a/webpack.config.component.js
+++ b/webpack.config.component.js
@@ -55,19 +55,19 @@ const esConfig = {
 const umdConfig = {
   ...baseConifg,
   externals: {
-      // Only because this is the library target.
-      'react': {
-          commonjs: 'react',
-          commonjs2: 'react',
-          amd: 'react',
-          root: 'React'
-      },
-      'react-dom': {
-          commonjs: 'react-dom',
-          commonjs2: 'react-dom',
-          amd: 'react-dom',
-          root: 'ReactDOM'
-      },
+    // Only because this is the library target.
+    react: {
+      commonjs: 'react',
+      commonjs2: 'react',
+      amd: 'react',
+      root: 'React'
+    },
+    'react-dom': {
+      commonjs: 'react-dom',
+      commonjs2: 'react-dom',
+      amd: 'react-dom',
+      root: 'ReactDOM'
+    }
   },
   output: {
     path: path.join(__dirname, '/dist/'),

--- a/webpack.config.component.js
+++ b/webpack.config.component.js
@@ -56,18 +56,8 @@ const umdConfig = {
   ...baseConifg,
   externals: {
     // Only because this is the library target.
-    react: {
-      commonjs: 'react',
-      commonjs2: 'react',
-      amd: 'react',
-      root: 'React'
-    },
-    'react-dom': {
-      commonjs: 'react-dom',
-      commonjs2: 'react-dom',
-      amd: 'react-dom',
-      root: 'ReactDOM'
-    }
+    react: 'react',
+    'react-dom': 'react-dom',
   },
   output: {
     path: path.join(__dirname, '/dist/'),

--- a/webpack.config.component.js
+++ b/webpack.config.component.js
@@ -5,8 +5,6 @@ const nodeExternals = require('webpack-node-externals');
 const baseConifg = {
   devtool: 'source-map',
   entry: './src/index.js',
-  // Bundle geotiff so we can use workers with its code.
-  externals: [nodeExternals({ whitelist: 'geotiff' })],
   module: {
     rules: [
       {
@@ -42,6 +40,8 @@ const baseConifg = {
 
 const esConfig = {
   ...baseConifg,
+  // Bundle geotiff so we can use workers with its code.
+  externals: [nodeExternals({ whitelist: 'geotiff' })],
   output: {
     path: path.join(__dirname, '/dist/'),
     filename: 'bundle.es.js',
@@ -54,6 +54,21 @@ const esConfig = {
 
 const umdConfig = {
   ...baseConifg,
+  externals: {
+      // Only because this is the library target.
+      'react': {
+          commonjs: 'react',
+          commonjs2: 'react',
+          amd: 'react',
+          root: 'React'
+      },
+      'react-dom': {
+          commonjs: 'react-dom',
+          commonjs2: 'react-dom',
+          amd: 'react-dom',
+          root: 'ReactDOM'
+      },
+  },
   output: {
     path: path.join(__dirname, '/dist/'),
     filename: 'bundle.umd.js',

--- a/webpack.config.component.js
+++ b/webpack.config.component.js
@@ -57,7 +57,7 @@ const umdConfig = {
   externals: {
     // Only because this is the library target.
     react: 'react',
-    'react-dom': 'react-dom',
+    'react-dom': 'react-dom'
   },
   output: {
     path: path.join(__dirname, '/dist/'),


### PR DESCRIPTION
The UMD is in theory supposed to be used in a `script` tag so bundling it with its dependencies makes more sense than not (except React, which should never be bundled except for a web page AFAIK).