### PR TITLE
Export HTTPStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Fix snackbars for errors and initial image.
+- Export custom zarr `HTTPStore` with abort controller signal support.
 
 ## 0.5.0
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import {
   OMETiffLoader,
   getChannelStats
 } from './loaders';
+import HTTPStore from './loaders/httpStore';
 import { DTYPE_VALUES, MAX_SLIDERS_AND_CHANNELS } from './constants';
 
 export {
@@ -35,5 +36,6 @@ export {
   OMETiffLoader,
   createOMETiffLoader,
   createZarrLoader,
-  createBioformatsZarrLoader
+  createBioformatsZarrLoader,
+  HTTPStore,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -37,5 +37,5 @@ export {
   createOMETiffLoader,
   createZarrLoader,
   createBioformatsZarrLoader,
-  HTTPStore,
+  HTTPStore
 };


### PR DESCRIPTION
Exports the custom `HTTPStore` with abort signal support.
