### PR TITLE
Upgrade to deck.gl 8.4.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Clean up docs for OME-TIFF creation.
 - Remove OMETIFF_LOADING.md docs.
 - Upgrade deck.gl to 8.4.0-alpha.2.
+- Remove `scale` and `translate` from `ImageLayer` in favor of `modelMatrix`.
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ### Added
 
+- Support arbitrary affine transformations of `MultiscaleImageLayer`.
+
 ### Changed
 
 - Clean up docs for OME-TIFF creation.
 - Remove OMETIFF_LOADING.md docs.
+- Upgrade deck.gl to 8.4.0-alpha.2.
 
 ## 0.6.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1399,9 +1399,9 @@
       }
     },
     "@deck.gl/core": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.3.5.tgz",
-      "integrity": "sha512-m086Q1bfGd/VEhPrtYvoJojN8u/hZICO068H+eQquJsqYyUW//RXM5nA7Y7vvZ15oKbYbfwVWLP92pUQW8kUSA==",
+      "version": "8.4.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.4.0-alpha.2.tgz",
+      "integrity": "sha512-WoIPL+Q/mWVym/AeB8EUiV/khdofo/KVB5vD0gqbuQJeiqRxG/gm26hq+jEXKpUqJ90jy4du7vXiEOdMc/jZXQ==",
       "requires": {
         "@loaders.gl/core": "^2.3.0",
         "@loaders.gl/images": "^2.3.0",
@@ -1414,9 +1414,9 @@
       }
     },
     "@deck.gl/geo-layers": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.3.5.tgz",
-      "integrity": "sha512-lQj/vBprNRDVwTglPNejUm7HiYC0Yaj5NtWQBmy0x/bpxmNK7fStod4sVxzK/C/4CrcS6fIGZ8u4IaDZfNQR3g==",
+      "version": "8.4.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.4.0-alpha.2.tgz",
+      "integrity": "sha512-qNvcQ8s6fmJmp65gYiqu/TcMDMw2ZZVIXxbEFlMapuk86J2LA09XB7yBy192ryj1oXxKkgsrf8NtA2i1C0Z/JA==",
       "requires": {
         "@loaders.gl/3d-tiles": "^2.3.0",
         "@loaders.gl/loader-utils": "^2.3.0",
@@ -1431,9 +1431,9 @@
       }
     },
     "@deck.gl/layers": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.3.5.tgz",
-      "integrity": "sha512-liFshEaLVS1+n843WYoJ2sulWBJxR9kQ3N/HRHoeYuGQ1ebhVkc+kPGfJ0At4GmWKNE5yn7MQIPQkpizM+TUiA==",
+      "version": "8.4.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.4.0-alpha.2.tgz",
+      "integrity": "sha512-llCOxOWqVZOgDJVZbdxh8BOr9ZA6lMUsiAEhsGrh6thunFYs9HcYLqlPRvgwVDHcexWc6ewthZXbO3aI7sHOJw==",
       "requires": {
         "@loaders.gl/images": "^2.3.0",
         "@mapbox/tiny-sdf": "^1.1.0",
@@ -1442,26 +1442,26 @@
       }
     },
     "@deck.gl/mesh-layers": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.3.5.tgz",
-      "integrity": "sha512-qh8oeXwWSco1Cxh20EpGMn1jIX3qbrCFsbRe/3EZ/hyg62CxZHirpvbVdZld84FoWf+JSKdQXRMjzTJS86s6+A==",
+      "version": "8.4.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.4.0-alpha.2.tgz",
+      "integrity": "sha512-8dNJfAOxTwZxgATmv/8g5ETkm/Mx2BnbYXiINmYr8znQeQYgW/meg7ab2hFD6smzXa8mLXBfCW9DHnDrxd+oRw==",
       "requires": {
         "@luma.gl/experimental": "^8.3.1",
         "@luma.gl/shadertools": "^8.3.1"
       }
     },
     "@deck.gl/react": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.3.5.tgz",
-      "integrity": "sha512-rG8C70+q+VpTb6SvBZqaVeV0ODoZxjbZBZBlNC1PFUwQfBfnCQTTAeLCnAFQYODsXDr7fO1K5w4mdnVhp5LyDg==",
+      "version": "8.4.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.4.0-alpha.2.tgz",
+      "integrity": "sha512-NGhuC8BArdWuZOcMRMB5zw9mQtMoO7DDYKqPqfvgtERZFFX7sXzWZ+5g35UJaAMUiooEuqI1SPDKnVCX41+nlA==",
       "requires": {
         "prop-types": "^15.6.0"
       }
     },
     "@deck.gl/test-utils": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/test-utils/-/test-utils-8.3.5.tgz",
-      "integrity": "sha512-4xtCqexW6dSSm+m2lIkaU5mUk2f1or+RMweobXNfI0jbmaT9XH7aE0bYuCn2NV9vF6KIGHXUwBA/kw4M7Wp1GQ==",
+      "version": "8.4.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/test-utils/-/test-utils-8.4.0-alpha.2.tgz",
+      "integrity": "sha512-s3x7tzWNn6jXD4o3ob38fSPKMob6BHjXi7hXlkqecJIeagLO6udqdpR/6W0LDNyTE+LN2+EzC/ubE0Pyclxx7g==",
       "dev": true
     },
     "@electron/get": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-dom": "^16.12.0"
   },
   "devDependencies": {
-    "@deck.gl/test-utils": "^8.3.5",
+    "@deck.gl/test-utils": "^8.4.0-alpha.2",
     "@luma.gl/gltools": "^8.3.1",
     "@luma.gl/test-utils": "^8.3.1",
     "@probe.gl/test-utils": "^3.3.0",
@@ -73,11 +73,11 @@
     "tape-run": "^8.0.0"
   },
   "dependencies": {
-    "@deck.gl/core": "^8.3.2",
-    "@deck.gl/geo-layers": "^8.3.2",
-    "@deck.gl/layers": "^8.3.2",
-    "@deck.gl/mesh-layers": "^8.3.5",
-    "@deck.gl/react": "^8.3.2",
+    "@deck.gl/core": "^8.4.0-alpha.2",
+    "@deck.gl/geo-layers": "^8.4.0-alpha.2",
+    "@deck.gl/layers": "^8.4.0-alpha.2",
+    "@deck.gl/mesh-layers": "^8.4.0-alpha.2",
+    "@deck.gl/react": "^8.4.0-alpha.2",
     "@luma.gl/constants": "^8.3.1",
     "@luma.gl/core": "^8.3.1",
     "@luma.gl/shadertools": "^8.3.1",

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -35,13 +35,6 @@ const defaultProps = {
   onClick: { type: 'function', value: null, compare: true }
 };
 
-function scaleBounds({ width, height, translate, scale }) {
-  const [left, top] = translate;
-  const right = width * scale + left;
-  const bottom = height * scale + top;
-  return [left, bottom, right, top];
-}
-
 /*
  * For some reason data of uneven length fails to be converted to a texture (Issue #144).
  * Here we pad the width of tile by one if the data is uneven in length, which seemingly
@@ -67,8 +60,6 @@ function padEven(data, width, height, boxSize) {
  * @param {string} props.colormap String indicating a colormap (default: '').  The full list of options is here: https://github.com/glslify/glsl-colormap#glsl-colormap
  * @param {Array} props.domain Override for the possible max/min values (i.e something different than 65535 for uint16/'<u2').
  * @param {string} props.viewportId Id for the current view.  This needs to match the viewState id in deck.gl and is necessary for the lens.
- * @param {Array} props.translate Translate transformation to be applied to the bounds after scaling.
- * @param {number} props.scale Scaling factor for this layer to be used against the dimensions of the loader's `getRaster`.
  * @param {Object} props.loader Loader to be used for fetching data.  It must implement/return `getRaster` and `dtype`.
  * @param {String} props.onHover Hook function from deck.gl to handle hover objects.
  * @param {String} props.boxSize If you want to pad an incoming tile to be a certain squared pixel size, pass the number here (only used by OverviewLayer/VivViewerLayer for now).
@@ -138,8 +129,6 @@ export default class ImageLayer extends CompositeLayer {
       sliderValues,
       colorValues,
       channelIsOn,
-      translate,
-      scale,
       z,
       domain,
       pickable,
@@ -154,16 +143,10 @@ export default class ImageLayer extends CompositeLayer {
     const { dtype } = loader;
     const { data, width, height, unprojectLensBounds } = this.state;
     if (!(width && height)) return null;
-    const bounds = scaleBounds({
-      width,
-      height,
-      translate,
-      scale
-    });
     return new XRLayer(this.props, {
       channelData: { data, width, height },
       pickable,
-      bounds,
+      bounds: [0, height, width, 0],
       sliderValues,
       colorValues,
       channelIsOn,

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -69,6 +69,7 @@ function padEven(data, width, height, boxSize) {
  * @param {number} props.lensBorderColor RGB color of the border of the lens.
  * @param {number} props.lensBorderRadius Percentage of the radius of the lens for a border (default 0.02).
  * @param {number} props.onClick Hook function from deck.gl to handle clicked-on objects.
+ * @param {number} props.modelMatrix Math.gl Matrix4 object containing an affine transformation to be applied to the image.
  */
 export default class ImageLayer extends CompositeLayer {
   initializeState() {
@@ -138,7 +139,8 @@ export default class ImageLayer extends CompositeLayer {
       lensRadius,
       id,
       onClick,
-      onHover
+      onHover,
+      modelMatrix
     } = this.props;
     const { dtype } = loader;
     const { data, width, height, unprojectLensBounds } = this.state;
@@ -163,7 +165,8 @@ export default class ImageLayer extends CompositeLayer {
       lensBorderColor,
       lensRadius,
       onClick,
-      onHover
+      onHover,
+      modelMatrix
     });
   }
 }

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -46,6 +46,7 @@ const defaultProps = {
  * @param {number} props.lensBorderRadius Percentage of the radius of the lens for a border (default 0.02).
  * @param {number} props.maxRequests Maximum parallel ongoing requests allowed before aborting.
  * @param {number} props.onClick Hook function from deck.gl to handle clicked-on objects.
+ * @param {number} props.modelMatrix Math.gl Matrix4 object containing an affine transformation to be applied to the image.
  */
 
 export default class MultiscaleImageLayer extends CompositeLayer {
@@ -82,7 +83,8 @@ export default class MultiscaleImageLayer extends CompositeLayer {
       lensBorderColor,
       lensBorderRadius,
       maxRequests,
-      onClick
+      onClick,
+      modelMatrix
     } = this.props;
     const { tileSize, numLevels, dtype } = loader;
     const { unprojectLensBounds } = this.state;
@@ -145,7 +147,8 @@ export default class MultiscaleImageLayer extends CompositeLayer {
       isLensOn,
       lensSelection,
       lensBorderColor,
-      lensBorderRadius
+      lensBorderRadius,
+      modelMatrix
     });
     // This gives us a background image and also solves the current
     // minZoom funny business.  We don't use it for the background if we have an opacity


### PR DESCRIPTION
This fixes #217 by upgrading to a version of deck.gl that supports `modelMatrix` as a prop for `TileLayer`.  We should be able to handle arbitrary affine transformations (the screenshots are of rotation + translation and a shear operation) now in the `MultiscaleImageLayer` via this prop.

I also removed the `scale`  and `translate` props from `ImageLayer` so that everything is uniform across our layers using `modelMatrix`.

When implementing this for https://github.com/hms-dbmi/vizarr/pull/43 with @will-moore I gave [some notes here](https://github.com/hms-dbmi/viv/issues/217#issuecomment-719856944) to avoid the headaches I encountered about creating the transformation matrices.  Xiaoji also brought up a good point [about memory usage](https://github.com/visgl/deck.gl/issues/5047#issuecomment-717404672): for https://github.com/hms-dbmi/vizarr/pull/43 if instantiating a `MultiscaleImageLayer` off the bat for every image is too much/sluggish, we can just instantiate the layers that need the higher resolution as you zoom in using `this.context.viewport`.  The code for doing that, I imagine, will look similar to [how deck.gl fetches tiles](https://github.com/visgl/deck.gl/blob/master/modules/geo-layers/src/tile-layer/utils.js), except you are indexing what should and shouldn't be a `MultiscaleImageLayer` instead of indexing what tiles should be fetched.  I can provide help with this if need be.  Another option might be setting the cache size to 0, although I don't feel as certain about this one.


<img width="1452" alt="Screen Shot 2020-11-12 at 12 46 31 PM" src="https://user-images.githubusercontent.com/43999641/98976244-201fd580-24e5-11eb-9cdd-889fd1dcb6b6.png">
<img width="1447" alt="Screen Shot 2020-11-12 at 12 34 59 PM" src="https://user-images.githubusercontent.com/43999641/98976260-244bf300-24e5-11eb-8e35-a404c0fb6070.png">
<img width="1450" alt="Screen Shot 2020-11-12 at 12 35 15 PM" src="https://user-images.githubusercontent.com/43999641/98976257-231ac600-24e5-11eb-9608-ae057c23aaa8.png">

cc: @nhpatterson I think you had expressed interest in this at some point as well regarding image registration.