### PR TITLE
Fix tile border issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Fix default component args API.
 - Fix tile padding issue.
+- Consistently fill in border tiles with 0's to prevent artifacting in tiffs.
+- Fix `numLevels` on tiff loader for `SubIFD`s.
 
 ## 0.7.0
 

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -52,7 +52,7 @@ export default class OMETiffLoader {
     this.height = this.omexml.SizeY;
     this.tileSize = firstImage.getTileWidth();
     const { SubIFDs } = firstImage.fileDirectory;
-    this.numLevels = SubIFDs.length
+    this.numLevels = SubIFDs?.length
       ? SubIFDs.length + 1
       : this.omexml.getNumberOfImages();
     this.isBioFormats6Pyramid = Boolean(SubIFDs);

--- a/src/loaders/utils.js
+++ b/src/loaders/utils.js
@@ -44,6 +44,15 @@ export function padTileWithZeros(tile, targetWidth, targetHeight) {
   return padded;
 }
 
+/**
+ * Fills in a tile with 0's if the tile is on the edge of an image as sometimes pyramidal tiff generators will
+ * fill this in with repeated parts of the image.
+ * and target height respectively.
+ * @param {Object} loader Loader object.
+ * @param {Object} data The array to be filled in.
+ * @param {Object} tile { x, y, z }
+ * @returns {TypedArray} TypedArray
+ */
 export function fillWithZeros(loader, data, tile) {
   const { x, y, z } = tile;
   const { tileSize } = loader;

--- a/src/loaders/utils.js
+++ b/src/loaders/utils.js
@@ -44,6 +44,35 @@ export function padTileWithZeros(tile, targetWidth, targetHeight) {
   return padded;
 }
 
+export function fillWithZeros(loader, data, tile) {
+  const { x, y, z } = tile;
+  const { tileSize } = loader;
+  const { height, width } = loader.getRasterSize({ z });
+  const numTilesX = Math.ceil(width / tileSize);
+  const numTilesY = Math.ceil(height / tileSize);
+  if (x === numTilesX - 1) {
+    const paddedWidth = numTilesX * tileSize;
+    const boundaryLength = tileSize - (paddedWidth - width);
+    for (let i = 0; i < height; i += 1) {
+      for (let j = boundaryLength; j < tileSize; j += 1) {
+        // eslint-disable-next-line no-param-reassign
+        data[i * tileSize + j] = 0;
+      }
+    }
+  }
+  if (y === numTilesY - 1) {
+    const paddedHeight = numTilesY * tileSize;
+    const boundaryLength = tileSize - (paddedHeight - height);
+    for (let i = 0; i < width; i += 1) {
+      for (let j = boundaryLength; j < tileSize; j += 1) {
+        // eslint-disable-next-line no-param-reassign
+        data[j * tileSize + i] = 0;
+      }
+    }
+  }
+  return data;
+}
+
 /**
  * Flips the bytes of TypedArray in place. Used to flipendianess
  * Adapted from https://github.com/zbjornson/node-bswap/blob/master/bswap.js


### PR DESCRIPTION
This PR adds standard fill-in values for the border of TIFF files.  I can add this to Zarr if you'd like, but it seems like something we have only seen with pyramidal tiff generators.   I also noticed I had made a silly mistake with `numLevels` which I have fixed - the `SubIFD`s are the sub resolutions and don't include the actual full resolution image.