### PR TITLE
Add note about `bfconvert` and New TIFF Pyramid Spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Document support for `bfconvert` as a cli tool for generating image pyramids as well as the new pyramidal tiff spec.
+
 ### Changed
 
 ## 0.8.0

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Viv supports a subset of formats that can be generated with the [`bioformats2raw
 - OME-TIFF files (pyramidal)
 - Bioformats-compatible Zarr stores (pyramidal)
 
-For OME-TIFF, Viv supports any pyramid that implements the [OME design spec for TIFF pyramids](https://ome.github.io/design/OME005/)(which the `bioformats2raw` + `raw2ometiff` pipeline does)
-as well as any non-pyramidal OME-TIFF files provided it can be rendered as an individual texture by the GPU (< `4096 x 4096` in pixel size).
+For OME-TIFF, Viv supports any pyramid that implements the [OME design spec for TIFF pyramids](https://ome.github.io/design/OME005/)(which the `bioformats2raw` + `raw2ometiff` pipeline provides).
+Non-pyramidal images are also supported provided the individual texture can be uploaded to the GPU (< `4096 x 4096` in pixel size).
 
 Please see the [tutorial](./tutorial/README.md) for more information on these formats.
 

--- a/README.md
+++ b/README.md
@@ -5,25 +5,27 @@ Written in JavaScript and built on Deck.gl with modern web technologies.
 
 ## About
 
-Viv is a JavaScript library providing utilities for rendering primary imaging data. Viv supports WebGL-based multi-channel rendering of both pyramidal and non-pyramidal images. The rendering components of Viv are provided as Deck.gl layers, making it easy to compose images with existing layers and efficiently update rendering properties within a reactive paradigm. 
+Viv is a JavaScript library providing utilities for rendering primary imaging data. Viv supports WebGL-based multi-channel rendering of both pyramidal and non-pyramidal images. The rendering components of Viv are provided as Deck.gl layers, making it easy to compose images with existing layers and efficiently update rendering properties within a reactive paradigm.
 
 More details can be found in our preprint describing the Viv library and related work. Please cite this preprint in your research:
 
 > Trevor Manz, Ilan Gold, Nathan Heath Patterson, Chuck McCallum, Mark S Keller, Bruce W Herr II, Katy Börner, Jeffrey M Spraggins, Nils Gehlenborg, "[Viv: Multiscale Visualization of High-resolution Multiplexed Bioimaging Data on the Web](https://osf.io/wd2gu/)." **OSF Preprints** (2020), [doi:10.31219/osf.io/wd2gu](https://doi.org/10.31219/osf.io/wd2gu)
 
-### Related Software 
+### Related Software
 
-  - **Avivator** Included in this repository is [`Avivator`](http://avivator.gehlenborglab.org), a lightweight viewer for remote imaging data. Avivator is a purely client-side program that only requires access to [Bio-Formats-compatiable Zarr](./tutorial#option-1-create-a-bio-formats-raw-zarr) or OME-TIFF data over HTTP or on local disk.
-  - **Vizarr** [Vizarr](https://github.com/hms-dbmi/vizarr) is a minimal, purely client-side program for viewing Zarr-based images built with Viv. It exposes a Python API using the [imjoy-rpc](https://github.com/imjoy-team/imjoy-rpc) and can be directly embedded in Jupyter Notebooks or Google Colab Notebooks.
-  - **Viv benchmark** A [set of scripts](https://github.com/hms-dbmi/viv-tile-benchmark) to benchmark Viv's retrieval of image tiles from pyramidal OME-TIFF files and Zarr stores via HTTP1 and HTTP2.
+- **Avivator** Included in this repository is [`Avivator`](http://avivator.gehlenborglab.org), a lightweight viewer for remote imaging data. Avivator is a purely client-side program that only requires access to [Bio-Formats-compatiable Zarr](./tutorial#option-1-create-a-bio-formats-raw-zarr) or OME-TIFF data over HTTP or on local disk.
+- **Vizarr** [Vizarr](https://github.com/hms-dbmi/vizarr) is a minimal, purely client-side program for viewing Zarr-based images built with Viv. It exposes a Python API using the [imjoy-rpc](https://github.com/imjoy-team/imjoy-rpc) and can be directly embedded in Jupyter Notebooks or Google Colab Notebooks.
+- **Viv benchmark** A [set of scripts](https://github.com/hms-dbmi/viv-tile-benchmark) to benchmark Viv's retrieval of image tiles from pyramidal OME-TIFF files and Zarr stores via HTTP1 and HTTP2.
 
 ## Supported Data Formats
 
-
-Viv supports a subset of formats that can be generated with the [`bioformats2raw` + `raw2ometiff` pipeline]((https://www.glencoesoftware.com/blog/2019/12/09/converting-whole-slide-images-to-OME-TIFF.html)):
+Viv supports a subset of formats that can be generated with the [`bioformats2raw` + `raw2ometiff` pipeline](<(https://www.glencoesoftware.com/blog/2019/12/09/converting-whole-slide-images-to-OME-TIFF.html)):
 
 - OME-TIFF files (pyramidal)
 - Bioformats-compatible Zarr stores (pyramidal)
+
+For OME-TIFF, Viv supports any pyramid that implements the [OME design spec for TIFF pyramids](https://ome.github.io/design/OME005/)(which the `bioformats2raw` + `raw2ometiff` pipeline does
+as well as non-pyramidal OME-TIFF files provided they can be rendered as an individual texture by the GPU (< `4096 x 4096` in pixel size).
 
 Please see the [tutorial](./tutorial/README.md) for more information on these formats.
 
@@ -48,7 +50,7 @@ $ npm start # Starts rollup build (for Viv) & dev server for Avivator
 
 Please install the [Prettier plug-in](https://prettier.io/docs/en/editors.html) for your preferred editor. Badly formatted code will fail on Travis.
 
-To run unit and integration tests locally, use `npm test`. For full prodcution test (including linting and formatting checks), 
+To run unit and integration tests locally, use `npm test`. For full prodcution test (including linting and formatting checks),
 use `npm run test:prod`.
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Viv supports a subset of formats that can be generated with the [`bioformats2raw
 - OME-TIFF files (pyramidal)
 - Bioformats-compatible Zarr stores (pyramidal)
 
-For OME-TIFF, Viv supports any pyramid that implements the [OME design spec for TIFF pyramids](https://ome.github.io/design/OME005/)(which the `bioformats2raw` + `raw2ometiff` pipeline does
-as well as non-pyramidal OME-TIFF files provided they can be rendered as an individual texture by the GPU (< `4096 x 4096` in pixel size).
+For OME-TIFF, Viv supports any pyramid that implements the [OME design spec for TIFF pyramids](https://ome.github.io/design/OME005/)(which the `bioformats2raw` + `raw2ometiff` pipeline does)
+as well as any non-pyramidal OME-TIFF files provided it can be rendered as an individual texture by the GPU (< `4096 x 4096` in pixel size).
 
 Please see the [tutorial](./tutorial/README.md) for more information on these formats.
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -60,35 +60,53 @@ $ bioformats2raw LuCa-7color_Scan1.qptiff n5_tile_directory/
 $ raw2ometiff n5_tile_directory/ LuCa-7color_Scan1.ome.tif
 ```
 
+`LZW` is the default if you do not specify a `--compression` option (the syntax requires an "=" sign, like `--compression=zlib`).
+
+You may also use the [standard Bioformats tool (Bioformats >= 6.0.0), `bfconvert`](https://docs.openmicroscopy.org/bio-formats/6.4.0/users/comlinetools/conversion.html)
+to generate your image pyramid.
+
+```bash
+$ bfconvert -tilex 512 -tiley 512 -pyramid-resolutions 6 -pyramid-scale 2  -compression LZW LuCa-7color_Scan1.qptiff LuCa-7color_Scan1.ome.tif
+```
+
+All of the arguments `-tilex 512, -tiley 512 -pyramid-resolutions 6 -pyramid-scale 2` are necessary. The `-pyramid-scale` argument must be 2, the tile sizes must be identical (ideally
+a power of 2), and the `-pyramid-resolutions` argument should be adjusted to match the size of your image and your choice of tile size.
+For example, if you have a `4096 x 4096` and tile size of `512`, `3 = log2(ceil(4096 / 512))` resolutions should work well.
+For the `LuCa-7color_Scan1.qptiff` image, `6 = max(log2(ceil(12480 / 512)), log2(ceil(17280 / 512)))` resolutions work best as the image is `12480 x 17280` in size.
+There is currently [no "auto" feature for inferring the number of pyramid resolutions](https://github.com/ome/bioformats/issues/3644).
+Without the compression set, i.e `-compression LZW`, the output image will be uncompressed.
+
 > NOTE: Viv currently uses [`geotiff.js`](https://geotiffjs.github.io/) for accessing data from remote TIFFs
 > over HTTP and support the three lossless compression options supported
-> by `raw2ometiff` - `LZW`, `zlib`, and `Uncompressed`. `LZW` is the default if you
-> do not specify a `--compression` option (the syntax requires an "=" sign, like `--compression=zlib`).
+> by `raw2ometiff` - `LZW`, `zlib`, and `Uncompressed` as well as `jpeg` compression for 8 bit data. Support
+> for JPEG-2000 for >8 bit data is planned. Please open an issue if you would like this more immediately.
 
 ### Viewing in Avivator
 
 There are a few different ways to view your data in Avivator.
 
-If you have an OME-TIFF or Bio-Formats "raw" Zarr output saved locally, you may simply drag and drop 
+If you have an OME-TIFF or Bio-Formats "raw" Zarr output saved locally, you may simply drag and drop
 the file (or directory) over the canvas or use the "Choose file" button to view your data.
-Note that this action does **NOT** necessarily load the entire dataset into memory. Viv still works as normal and will retrieve data tiles based on the viewport for an image pyramid and/or a specific channel/z/time selection. 
+Note that this action does **NOT** necessarily load the entire dataset into memory. Viv still works as normal and will retrieve data tiles based on the viewport for an image pyramid and/or a specific channel/z/time selection.
 
 If you followed **Option 1** above, you may drag and drop the `LuCa-7color_Scan1/` directory created via `bioformats2raw`
 into Avivator. If you followed **Option 2**, simply select the `LuCa-7color_Scan1.ome.tif` to view in Avivator.
 
-> NOTE: Large Zarr-based image pyramids may take a bit longer to load initially using this method. We recommend using a simple web 
-> server (see below) if you experience issues with Zarr loading times. Additionally, support for drag-and-drop for Zarr-based 
+> NOTE: Large Zarr-based image pyramids may take a bit longer to load initially using this method. We recommend using a simple web
+> server (see below) if you experience issues with Zarr loading times. Additionally, support for drag-and-drop for Zarr-based
 > images is only currently supported in Chrome, Firefox, and Microsoft Edge. If using Safari, please use a web-server.
 
-Otherwise Avivator relies on access to data over HTTP, and you can serve data locally using a simple web-server. 
+Otherwise Avivator relies on access to data over HTTP, and you can serve data locally using a simple web-server.
 It's easiest to use [`http-server`](https://github.com/http-party/http-server#readme) to start a web-server locally, which can be installed via `npm` or `Homebrew` if using a Mac.
 
 > NOTE: If your OME-TIFF image has many [TIFF IFDs](https://en.wikipedia.org/wiki/TIFF#Multiple_subfiles), which correspond to indvidual time-z-channel sub-images, please generate an `offsets.json` file as well for remote HTTP viewing.
 > This file contains the byte offsets to each IFD and allows fast interaction with remote data:
+>
 > ```bash
 > $ pip install generate-tiff-offsets
 > $ generate_tiff_offsets --input_file my_tiff_file.ome.tiff
 > ```
+>
 > For viewing in Avivator, this file should live adjacent to the OME-TIFF file in its folder and will be automatically recognized and used.
 > For use with Viv's loaders/layers, you need to fetch the `offsets.json` and pass it in as an argument to the [loader](http://viv.gehlenborglab.org/#createometiffloader).
 > Please see [this sample](http://viv.gehlenborglab.org/#getting-started) for help getting started.
@@ -118,7 +136,7 @@ link by appending an `image_url` query parameter:
 - http://avivator.gehlenborglab.org/?image_url=http://localhost:8000/LuCa-7color_Scan1.ome.tif (OME-TIFF)
 
 > Troubleshooting: Viv relies on cross-origin requests to retrieve data from servers. The `--cors='*'` flag is important to ensure
-> that the appropriate `Access-Control-Allow-Origin` response is sent from your local server.  In addition, web servers must allow
+> that the appropriate `Access-Control-Allow-Origin` response is sent from your local server. In addition, web servers must allow
 > [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) to support viewing OME-TIFF images.
 > Range requests are allowed by default by `http-server` but may need to be enabled explicitly for your production web server.
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -76,6 +76,9 @@ For the `LuCa-7color_Scan1.qptiff` image, `6 = max(log2(ceil(12480 / 512)), log2
 There is currently [no "auto" feature for inferring the number of pyramid resolutions](https://github.com/ome/bioformats/issues/3644).
 Without the compression set, i.e `-compression LZW`, the output image will be uncompressed.
 
+There is a [2GB limit on the total amount of data](https://docs.openmicroscopy.org/bio-formats/6.4.0/about/bug-reporting.html#common-issues-to-check) that may be read into memory for the `bfconvert` cli tool.
+Therefore for larger images, please use `bioformats2raw + raw2ometiff`.
+
 > NOTE: Viv currently uses [`geotiff.js`](https://geotiffjs.github.io/) for accessing data from remote TIFFs
 > over HTTP and support the three lossless compression options supported
 > by `raw2ometiff` - `LZW`, `zlib`, and `Uncompressed` as well as `jpeg` compression for 8 bit data. Support

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -60,16 +60,20 @@ $ bioformats2raw LuCa-7color_Scan1.qptiff n5_tile_directory/
 $ raw2ometiff n5_tile_directory/ LuCa-7color_Scan1.ome.tif
 ```
 
-`LZW` is the default if you do not specify a `--compression` option (the syntax requires an "=" sign, like `--compression=zlib`).
+> Note:  `LZW` is the default if you do not specify a `--compression` option (the syntax requires an "=" sign, like `--compression=zlib`).
 
-You may also use the [standard Bioformats tool (Bioformats >= 6.0.0), `bfconvert`](https://docs.openmicroscopy.org/bio-formats/6.4.0/users/comlinetools/conversion.html)
+You may also use [`bfconvert` (Bioformats >= 6.0.0)](https://docs.openmicroscopy.org/bio-formats/6.4.0/users/comlinetools/conversion.html) to generate an image pyramid.
 to generate your image pyramid.
 
 ```bash
 $ bfconvert -tilex 512 -tiley 512 -pyramid-resolutions 6 -pyramid-scale 2  -compression LZW LuCa-7color_Scan1.qptiff LuCa-7color_Scan1.ome.tif
 ```
 
-All of the arguments `-tilex 512, -tiley 512 -pyramid-resolutions 6 -pyramid-scale 2` are necessary. The `-pyramid-scale` argument must be 2, the tile sizes must be identical (ideally
+All the above arguments are necessary except for `-compression` which is optional (default uncompressed). In order for an image to be compatible with Viv:
+
+ - `-pyramid-scale` must be 2
+ - `-tilex` must equal `-tiley` (ideally a power of 2)
+ - `-pyramid-resolutions` must be computed using the image dimensions and tile size. For example, for a `4096 x 4096` with tile size of `512`, `3 = log2(ceil(4096 / 512))` resolutions should work well.
 a power of 2), and the `-pyramid-resolutions` argument should be adjusted to match the size of your image and your choice of tile size.
 For example, if you have a `4096 x 4096` and tile size of `512`, `3 = log2(ceil(4096 / 512))` resolutions should work well.
 For the `LuCa-7color_Scan1.qptiff` image, `6 = max(log2(ceil(12480 / 512)), log2(ceil(17280 / 512)))` resolutions work best as the image is `12480 x 17280` in size.


### PR DESCRIPTION
It was recently brought to my attention that we support implementations of the new [TIFF pyramid spec](https://ome.github.io/design/OME005/) of which `bioformats2raw + raw2ometiff` is only one.  `bfconvert` is another and I have added information about this.  @nhpatterson created an implementation (maybe unintentionally?) in Python and his images work in Viv as well now.