### PR TITLE
onViewStateChange callback for viewers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Property `onViewStateChange` of all viewers accepts a callback for deck.gl view state changes.
+
 ### Changed
 
 - Fix documentation of instances where spreading is used in the arguments for a function.
@@ -12,7 +14,7 @@
 
 ### Added
 
-- Export a `getDefaultInitialViewState` function for getting a deafult inital view state given a loader and desired size of view.
+- Export a `getDefaultInitialViewState` function for getting a default initial view state given a loader and desired size of view.
 - Support interleaved RGB OME-TIFF files.
 - Added a README file for Avivator at `avivator/README.md`.
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
     "zarr": "^0.3.0"
   },
   "prettier": {
-    "singleQuote": true
+    "singleQuote": true,
+    "trailingComma": "none",
+    "arrowParens": "avoid"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ import {
   MultiscaleImageLayer,
   ImageLayer,
   ScaleBarLayer,
-  XRLayer
+  XRLayer,
+  OverviewLayer
 } from './layers';
 import { VivViewer, PictureInPictureViewer, SideBySideViewer } from './viewers';
 import {
@@ -29,6 +30,7 @@ export {
   ScaleBarLayer,
   MultiscaleImageLayer,
   XRLayer,
+  OverviewLayer,
   VivViewer,
   VivView,
   OverviewView,

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -3,11 +3,6 @@ import VivViewer from './VivViewer';
 import { DetailView, OverviewView, getDefaultInitialViewState } from '../views';
 
 /**
- * @callback ViewStateChange
- * @param {Object} event
- */
-
-/**
  * This component provides a component for an overview-detail VivViewer of an image (i.e picture-in-picture).
  * @param {Object} props
  * @param {Array} props.sliderValues List of [begin, end] values to control each channel's ramp function.
@@ -30,7 +25,7 @@ import { DetailView, OverviewView, getDefaultInitialViewState } from '../views';
  * @param {Array} [props.lensBorderColor] RGB color of the border of the lens (default [255, 255, 255]).
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
- * @param {ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state.
+ * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state.
  */
 
 const PictureInPictureViewer = props => {

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -3,6 +3,11 @@ import VivViewer from './VivViewer';
 import { DetailView, OverviewView, getDefaultInitialViewState } from '../views';
 
 /**
+ * @callback ViewStateChange
+ * @param {Object} event
+ */
+
+/**
  * This component provides a component for an overview-detail VivViewer of an image (i.e picture-in-picture).
  * @param {Object} props
  * @param {Array} props.sliderValues List of [begin, end] values to control each channel's ramp function.
@@ -16,14 +21,16 @@ import { DetailView, OverviewView, getDefaultInitialViewState } from '../views';
  * @param {Boolean} props.overviewOn Whether or not to show the OverviewView.
  * @param {Object} props.hoverHooks Object including the allowable hooks - right now only accepting a function with key handleValue like { handleValue: (valueArray) => {} } where valueArray
  * has the pixel values for the image under the hover location.
- * @param {number} props.initialViewState Object like { target: [x, y, 0], zoom: -zoom } for initializing where the viewer looks (optional - this can be inferred from height/width/loader).
+ * @param {Object} props.initialViewState Object like { target: [x, y, 0], zoom: -zoom } for initializing where the viewer looks (optional - this can be inferred from height/width/loader).
  * @param {number} props.height Current height of the component.
  * @param {number} props.width Current width of the component.
- * @param {boolean} props.isLensOn Whether or not to use the lens (deafult false).
- * @param {number} props.lensSelection Numeric index of the channel to be focused on by the lens (default 0).
- * @param {number} props.lensRadius Pixel radius of the lens (default: 100).
- * @param {number} props.lensBorderColor RGB color of the border of the lens (default [255, 255, 255]).
- * @param {number} props.lensBorderRadius Percentage of the radius of the lens for a border (default 0.02).
+ * @param {boolean} [props.isLensOn] Whether or not to use the lens (deafult false).
+ * @param {number} [props.lensSelection] Numeric index of the channel to be focused on by the lens (default 0).
+ * @param {number} [props.lensRadius] Pixel radius of the lens (default: 100).
+ * @param {Array} [props.lensBorderColor] RGB color of the border of the lens (default [255, 255, 255]).
+ * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
+ * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
+ * @param {ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state.
  */
 
 const PictureInPictureViewer = props => {
@@ -44,7 +51,8 @@ const PictureInPictureViewer = props => {
     lensSelection = 0,
     lensRadius = 100,
     lensBorderColor = [255, 255, 255],
-    lensBorderRadius = 0.02
+    lensBorderRadius = 0.02,
+    onViewStateChange
   } = props;
   const viewState =
     initialViewState || getDefaultInitialViewState(loader, { height, width });
@@ -83,7 +91,7 @@ const PictureInPictureViewer = props => {
   }
   if (!loader) return null;
   return (
-    <VivViewer layerProps={layerProps} views={views} hoverHooks={hoverHooks} />
+    <VivViewer layerProps={layerProps} views={views} hoverHooks={hoverHooks} onViewStateChange={onViewStateChange} />
   );
 };
 

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -32,7 +32,7 @@ import {
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
  * @param {Boolean} [props.clickCenter] Click to center the default view. Default is true.
- * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state.
+ * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
  */
 
 const PictureInPictureViewer = props => {

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -86,7 +86,12 @@ const PictureInPictureViewer = props => {
   }
   if (!loader) return null;
   return (
-    <VivViewer layerProps={layerProps} views={views} hoverHooks={hoverHooks} onViewStateChange={onViewStateChange} />
+    <VivViewer
+      layerProps={layerProps}
+      views={views}
+      hoverHooks={hoverHooks}
+      onViewStateChange={onViewStateChange}
+    />
   );
 };
 

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -3,6 +3,11 @@ import VivViewer from './VivViewer';
 import { SideBySideView, getDefaultInitialViewState } from '../views';
 
 /**
+ * @callback ViewStateChange
+ * @param {Object} event
+ */
+
+/**
  * This component provides a side-by-side VivViewer with linked zoom/pan.
  * @param {Object} props
  * @param {Array} props.sliderValues List of [begin, end] values to control each channel's ramp function.
@@ -13,14 +18,15 @@ import { SideBySideView, getDefaultInitialViewState } from '../views';
  * @param {Array} props.loaderSelection Selection to be used for fetching data.
  * @param {Boolean} props.zoomLock Whether or not lock the zooms of the two views.
  * @param {Boolean} props.panLock Whether or not lock the pans of the two views.
- * @param {number} props.initialViewState Object like { target: [x, y, 0], zoom: -zoom } for initializing where the viewer looks (optional - this can be inferred from height/width/loader).
+ * @param {Object} props.initialViewState Object like { target: [x, y, 0], zoom: -zoom } for initializing where the viewer looks (optional - this can be inferred from height/width/loader).
  * @param {number} props.height Current height of the component.
  * @param {number} props.width Current width of the component.
- * @param {boolean} props.isLensOn Whether or not to use the lens deafult (false).
- * @param {number} props.lensSelection Numeric index of the channel to be focused on by the lens (default 0).
- * @param {number} props.lensBorderColor RGB color of the border of the lens (default [255, 255, 255]).
- * @param {number} props.lensBorderRadius Percentage of the radius of the lens for a border (default 0.02).
- */
+ * @param {boolean} [props.isLensOn] Whether or not to use the lens deafult (false).
+ * @param {number} [props.lensSelection] Numeric index of the channel to be focused on by the lens (default 0).
+ * @param {Array} [props.lensBorderColor] RGB color of the border of the lens (default [255, 255, 255]).
+ * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
+ * @param {ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state.
+*/
 const SideBySideViewer = props => {
   const {
     loader,
@@ -38,7 +44,8 @@ const SideBySideViewer = props => {
     lensSelection = 0,
     lensRadius = 100,
     lensBorderColor = [255, 255, 255],
-    lensBorderRadius = 0.02
+    lensBorderRadius = 0.02,
+    onViewStateChange
   } = props;
   const viewState =
     initialViewState || getDefaultInitialViewState(loader, { height, width });
@@ -75,7 +82,7 @@ const SideBySideViewer = props => {
   const views = [detailViewRight, detailViewLeft];
   const layerProps = [layerConfig, layerConfig];
   return loader ? (
-    <VivViewer layerProps={layerProps} views={views} randomize />
+    <VivViewer layerProps={layerProps} views={views} randomize onViewStateChange={onViewStateChange} />
   ) : null;
 };
 

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -21,7 +21,7 @@ import { SideBySideView, getDefaultInitialViewState } from '../views';
  * @param {Array} [props.lensBorderColor] RGB color of the border of the lens (default [255, 255, 255]).
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
  * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state.
-*/
+ */
 const SideBySideViewer = props => {
   const {
     loader,
@@ -77,7 +77,12 @@ const SideBySideViewer = props => {
   const views = [detailViewRight, detailViewLeft];
   const layerProps = [layerConfig, layerConfig];
   return loader ? (
-    <VivViewer layerProps={layerProps} views={views} randomize onViewStateChange={onViewStateChange} />
+    <VivViewer
+      layerProps={layerProps}
+      views={views}
+      randomize
+      onViewStateChange={onViewStateChange}
+    />
   ) : null;
 };
 

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -20,7 +20,7 @@ import { SideBySideView, getDefaultInitialViewState } from '../views';
  * @param {number} [props.lensSelection] Numeric index of the channel to be focused on by the lens (default 0).
  * @param {Array} [props.lensBorderColor] RGB color of the border of the lens (default [255, 255, 255]).
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
- * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state.
+ * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
  */
 const SideBySideViewer = props => {
   const {

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -3,11 +3,6 @@ import VivViewer from './VivViewer';
 import { SideBySideView, getDefaultInitialViewState } from '../views';
 
 /**
- * @callback ViewStateChange
- * @param {Object} event
- */
-
-/**
  * This component provides a side-by-side VivViewer with linked zoom/pan.
  * @param {Object} props
  * @param {Array} props.sliderValues List of [begin, end] values to control each channel's ramp function.
@@ -25,7 +20,7 @@ import { SideBySideView, getDefaultInitialViewState } from '../views';
  * @param {number} [props.lensSelection] Numeric index of the channel to be focused on by the lens (default 0).
  * @param {Array} [props.lensBorderColor] RGB color of the border of the lens (default [255, 255, 255]).
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
- * @param {ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state.
+ * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state.
 */
 const SideBySideViewer = props => {
   const {

--- a/src/viewers/VivViewer.js
+++ b/src/viewers/VivViewer.js
@@ -3,11 +3,17 @@ import DeckGL from '@deck.gl/react';
 import { getVivId } from '../views/utils';
 
 /**
+ * @callback ViewStateChange
+ * @param {Object} event
+ */
+
+/**
  * This component handles rendering the various views within the DeckGL contenxt.
  * @param {Object} props
  * @param {Array} props.layerProps  Props for the layers in each view.
  * @param {Array} props.randomize Whether or not to randomize which view goes first (for dynamic rendering).
  * @param {VivView} props.views Various VivViews to render.
+ * @param {ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
  * */
 export default class VivViewer extends PureComponent {
   constructor(props) {
@@ -44,9 +50,11 @@ export default class VivViewer extends PureComponent {
    * This updates the viewState as a callback to the viewport changing in DeckGL
    * (hence the need for storing viewState in state).
    */
-  _onViewStateChange({ viewId, viewState, oldViewState }) {
+  _onViewStateChange({ viewId, viewState, interactionState, oldViewState }) {
     // Save the view state and trigger rerender.
-    const { views } = this.props;
+    const { views, onViewStateChange } = this.props;
+    // eslint-disable-next-line no-param-reassign
+    viewState = (onViewStateChange && onViewStateChange({ viewId, viewState, interactionState, oldViewState })) || viewState;
     this.setState(prevState => {
       const viewStates = {};
       views.forEach(view => {
@@ -59,6 +67,7 @@ export default class VivViewer extends PureComponent {
       });
       return { viewStates };
     });
+    return viewState;
   }
 
   /**

--- a/src/viewers/VivViewer.js
+++ b/src/viewers/VivViewer.js
@@ -54,7 +54,15 @@ export default class VivViewer extends PureComponent {
     // Save the view state and trigger rerender.
     const { views, onViewStateChange } = this.props;
     // eslint-disable-next-line no-param-reassign
-    viewState = (onViewStateChange && onViewStateChange({ viewId, viewState, interactionState, oldViewState })) || viewState;
+    viewState =
+      (onViewStateChange &&
+        onViewStateChange({
+          viewId,
+          viewState,
+          interactionState,
+          oldViewState
+        })) ||
+      viewState;
     this.setState(prevState => {
       const viewStates = {};
       views.forEach(view => {


### PR DESCRIPTION
This addresses #329. The callback may change the view state, just like the [deck.gl callback](https://deck.gl/docs/api-reference/core/deck#onviewstatechange).

Add "onViewStateChange" to VivViewer, PictureInPictureViewer, SideBySideViewer.
Fix JSDoc `@param` and indicate optional parameters.
Export OverviewLayer.