### PR TITLE
Add click handler to OverviewView that centers the detail view

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "none"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Add a click handler to the overview that centers the detail view on the click position. The handler can be turned off by setting the `PictureInPictureViewer` property `clickCenter` to `false`.
+
 ### Changed
 
 - Fix documentation of instances where spreading is used in the arguments for a function.

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -1,6 +1,6 @@
 import React from 'react'; // eslint-disable-line import/no-unresolved
 import VivViewer from './VivViewer';
-import { DetailView, OverviewView, getDefaultInitialViewState } from '../views';
+import { DetailView, OverviewView, getDefaultInitialViewState, DETAIL_VIEW_ID, OVERVIEW_VIEW_ID } from '../views';
 
 /**
  * This component provides a component for an overview-detail VivViewer of an image (i.e picture-in-picture).
@@ -50,7 +50,7 @@ const PictureInPictureViewer = props => {
   } = props;
   const viewState =
     initialViewState || getDefaultInitialViewState(loader, { height, width });
-  const detailViewState = { ...viewState, id: 'detail' };
+  const detailViewState = { ...viewState, id: DETAIL_VIEW_ID };
   const detailView = new DetailView({
     initialViewState: detailViewState,
     height,
@@ -72,7 +72,7 @@ const PictureInPictureViewer = props => {
   const views = [detailView];
   const layerProps = [layerConfig];
   if (overviewOn && loader) {
-    const overviewViewState = { ...viewState, id: 'overview' };
+    const overviewViewState = { ...viewState, id: OVERVIEW_VIEW_ID };
     const overviewView = new OverviewView({
       initialViewState: overviewViewState,
       loader,

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -5,7 +5,7 @@ import {
   OverviewView,
   getDefaultInitialViewState,
   DETAIL_VIEW_ID,
-  OVERVIEW_VIEW_ID,
+  OVERVIEW_VIEW_ID
 } from '../views';
 
 /**
@@ -33,7 +33,7 @@ import {
  * @param {Boolean} [props.clickCenter] Click to center the default view. Default is true.
  */
 
-const PictureInPictureViewer = (props) => {
+const PictureInPictureViewer = props => {
   const {
     loader,
     sliderValues,
@@ -52,7 +52,7 @@ const PictureInPictureViewer = (props) => {
     lensRadius = 100,
     lensBorderColor = [255, 255, 255],
     lensBorderRadius = 0.02,
-    clickCenter = true,
+    clickCenter = true
   } = props;
   const viewState =
     initialViewState || getDefaultInitialViewState(loader, { height, width });
@@ -60,7 +60,7 @@ const PictureInPictureViewer = (props) => {
   const detailView = new DetailView({
     initialViewState: detailViewState,
     height,
-    width,
+    width
   });
   const layerConfig = {
     loader,
@@ -73,7 +73,7 @@ const PictureInPictureViewer = (props) => {
     lensSelection,
     lensRadius,
     lensBorderColor,
-    lensBorderRadius,
+    lensBorderRadius
   };
   const views = [detailView];
   const layerProps = [layerConfig];
@@ -85,7 +85,7 @@ const PictureInPictureViewer = (props) => {
       detailHeight: height,
       detailWidth: width,
       clickCenter,
-      ...overview,
+      ...overview
     });
     views.push(overviewView);
     layerProps.push(layerConfig);

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -24,6 +24,7 @@ import { DetailView, OverviewView, getDefaultInitialViewState } from '../views';
  * @param {number} props.lensRadius Pixel radius of the lens (default: 100).
  * @param {number} props.lensBorderColor RGB color of the border of the lens (default [255, 255, 255]).
  * @param {number} props.lensBorderRadius Percentage of the radius of the lens for a border (default 0.02).
+ * @param {Boolean} [props.clickCenter] Click to center the default view. Default is true.
  */
 
 const PictureInPictureViewer = props => {
@@ -44,7 +45,8 @@ const PictureInPictureViewer = props => {
     lensSelection = 0,
     lensRadius = 100,
     lensBorderColor = [255, 255, 255],
-    lensBorderRadius = 0.02
+    lensBorderRadius = 0.02,
+    clickCenter = true
   } = props;
   const viewState =
     initialViewState || getDefaultInitialViewState(loader, { height, width });
@@ -76,6 +78,7 @@ const PictureInPictureViewer = props => {
       loader,
       detailHeight: height,
       detailWidth: width,
+      clickCenter,
       ...overview
     });
     views.push(overviewView);

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -1,6 +1,12 @@
 import React from 'react'; // eslint-disable-line import/no-unresolved
 import VivViewer from './VivViewer';
-import { DetailView, OverviewView, getDefaultInitialViewState, DETAIL_VIEW_ID, OVERVIEW_VIEW_ID } from '../views';
+import {
+  DetailView,
+  OverviewView,
+  getDefaultInitialViewState,
+  DETAIL_VIEW_ID,
+  OVERVIEW_VIEW_ID,
+} from '../views';
 
 /**
  * This component provides a component for an overview-detail VivViewer of an image (i.e picture-in-picture).
@@ -27,7 +33,7 @@ import { DetailView, OverviewView, getDefaultInitialViewState, DETAIL_VIEW_ID, O
  * @param {Boolean} [props.clickCenter] Click to center the default view. Default is true.
  */
 
-const PictureInPictureViewer = props => {
+const PictureInPictureViewer = (props) => {
   const {
     loader,
     sliderValues,
@@ -46,7 +52,7 @@ const PictureInPictureViewer = props => {
     lensRadius = 100,
     lensBorderColor = [255, 255, 255],
     lensBorderRadius = 0.02,
-    clickCenter = true
+    clickCenter = true,
   } = props;
   const viewState =
     initialViewState || getDefaultInitialViewState(loader, { height, width });
@@ -54,7 +60,7 @@ const PictureInPictureViewer = props => {
   const detailView = new DetailView({
     initialViewState: detailViewState,
     height,
-    width
+    width,
   });
   const layerConfig = {
     loader,
@@ -67,7 +73,7 @@ const PictureInPictureViewer = props => {
     lensSelection,
     lensRadius,
     lensBorderColor,
-    lensBorderRadius
+    lensBorderRadius,
   };
   const views = [detailView];
   const layerProps = [layerConfig];
@@ -79,7 +85,7 @@ const PictureInPictureViewer = props => {
       detailHeight: height,
       detailWidth: width,
       clickCenter,
-      ...overview
+      ...overview,
     });
     views.push(overviewView);
     layerProps.push(layerConfig);

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -19,11 +19,11 @@ export default class DetailView extends VivView {
     const detailLayer = loader.isPyramid
       ? new MultiscaleImageLayer(props, {
           id: `${loader.type}${getVivId(id)}`,
-          viewportId: id
+          viewportId: id,
         })
       : new ImageLayer(props, {
           id: `${loader.type}${getVivId(id)}`,
-          viewportId: id
+          viewportId: id,
         });
     layers.push(detailLayer);
 
@@ -38,7 +38,7 @@ export default class DetailView extends VivView {
             loader,
             unit,
             size: value,
-            viewState: { ...layerViewState, height, width }
+            viewState: { ...layerViewState, height, width },
           })
         );
       }

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -52,7 +52,7 @@ export default class DetailView extends VivView {
    */
   filterViewState({ viewState, currentViewState }) {
     if (viewState.id === 'overview') {
-      const target = viewState.navigation?.target;
+      const { target } = viewState;
       if (target) {
         return { ...currentViewState, target };
       }

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -43,4 +43,20 @@ export default class DetailView extends VivView {
 
     return layers;
   }
+
+  /**
+   * Create a viewState for this class, checking the id to make sure this class and viewState match.
+   * @param {Object} args
+   * @param {ViewState} args.ViewState ViewState object.
+   * @returns {ViewState} ViewState for this class (or null by default if the ids do not match).
+   */
+  filterViewState({ viewState, currentViewState }) {
+    if (viewState.id === 'overview') {
+      const target = viewState.navigation?.target;
+      if (target) {
+        return { ...currentViewState, target };
+      }
+    }
+    return super.filterViewState({ viewState });
+  }
 }

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -19,11 +19,11 @@ export default class DetailView extends VivView {
     const detailLayer = loader.isPyramid
       ? new MultiscaleImageLayer(props, {
           id: `${loader.type}${getVivId(id)}`,
-          viewportId: id,
+          viewportId: id
         })
       : new ImageLayer(props, {
           id: `${loader.type}${getVivId(id)}`,
-          viewportId: id,
+          viewportId: id
         });
     layers.push(detailLayer);
 
@@ -38,7 +38,7 @@ export default class DetailView extends VivView {
             loader,
             unit,
             size: value,
-            viewState: { ...layerViewState, height, width },
+            viewState: { ...layerViewState, height, width }
           })
         );
       }

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -1,6 +1,9 @@
 import { MultiscaleImageLayer, ImageLayer, ScaleBarLayer } from '../layers';
 import VivView from './VivView';
 import { getVivId } from './utils';
+import { OVERVIEW_VIEW_ID } from './OverviewView';
+
+export const DETAIL_VIEW_ID = 'detail';
 
 /**
  * This class generates a MultiscaleImageLayer and a view for use in the VivViewer as a detailed view.
@@ -51,7 +54,7 @@ export default class DetailView extends VivView {
    * @returns {ViewState} ViewState for this class (or null by default if the ids do not match).
    */
   filterViewState({ viewState, currentViewState }) {
-    if (viewState.id === 'overview') {
+    if (viewState.id === OVERVIEW_VIEW_ID) {
       const { target } = viewState;
       if (target) {
         return { ...currentViewState, target };

--- a/src/views/OverviewView.js
+++ b/src/views/OverviewView.js
@@ -6,8 +6,7 @@ import { makeBoundingBox, getVivId } from './utils';
 
 export const OVERVIEW_VIEW_ID = 'overview';
 
-class OverviewState {
-}
+class OverviewState {}
 
 class OverviewController extends Controller {
   constructor(props) {
@@ -64,7 +63,7 @@ export default class OverviewView extends VivView {
     maximumWidth = 350,
     minimumHeight = 150,
     maximumHeight = 350,
-    clickCenter = true
+    clickCenter = true,
   }) {
     super({ initialViewState });
     this.margin = margin;
@@ -79,7 +78,7 @@ export default class OverviewView extends VivView {
       minimumWidth,
       maximumWidth,
       minimumHeight,
-      maximumHeight
+      maximumHeight,
     });
     this._setXY();
     this.clickCenter = clickCenter;
@@ -95,12 +94,12 @@ export default class OverviewView extends VivView {
     minimumWidth,
     maximumWidth,
     minimumHeight,
-    maximumHeight
+    maximumHeight,
   }) {
     const { loader } = this;
     const { numLevels } = loader;
     const { width: rasterWidth, height: rasterHeight } = loader.getRasterSize({
-      z: 0
+      z: 0,
     });
     this._imageWidth = rasterWidth;
     this._imageHeight = rasterHeight;
@@ -167,7 +166,7 @@ export default class OverviewView extends VivView {
       width,
       x,
       y,
-      clear: true
+      clear: true,
     });
   }
 
@@ -180,7 +179,7 @@ export default class OverviewView extends VivView {
       id,
       loader,
       height,
-      width
+      width,
     } = this;
     const { numLevels } = loader;
     return {
@@ -189,7 +188,7 @@ export default class OverviewView extends VivView {
       width,
       id,
       target: [(_imageWidth * scale) / 2, (_imageHeight * scale) / 2, 0],
-      zoom: -(numLevels - 1)
+      zoom: -(numLevels - 1),
     };
   }
 
@@ -200,14 +199,14 @@ export default class OverviewView extends VivView {
     }
     const { id, scale, loader } = this;
     // Scale the bounding box.
-    const boundingBox = makeBoundingBox(detail).map(coords =>
-      coords.map(e => e * scale)
+    const boundingBox = makeBoundingBox(detail).map((coords) =>
+      coords.map((e) => e * scale)
     );
     const overviewLayer = new OverviewLayer(props, {
       id: `${loader.type}${getVivId(id)}`,
       boundingBox,
       overviewScale: scale,
-      zoom: -overview.zoom
+      zoom: -overview.zoom,
     });
     return [overviewLayer];
   }

--- a/src/views/OverviewView.js
+++ b/src/views/OverviewView.js
@@ -4,17 +4,19 @@ import VivView from './VivView';
 import { OverviewLayer } from '../layers';
 import { makeBoundingBox, getVivId } from './utils';
 
+export const OVERVIEW_VIEW_ID = 'overview';
+
 class OverviewState {
 }
 
 class OverviewController extends Controller {
   constructor(props) {
     super(OverviewState, props);
-    this.events = ["click"];
+    this.events = ['click'];
   }
 
   handleEvent(event) {
-    if (event.type !== "click") {
+    if (event.type !== 'click') {
       return;
     }
     let [x, y] = this.getCenter(event);
@@ -26,7 +28,7 @@ class OverviewController extends Controller {
     x *= scaleFactor;
     y *= scaleFactor;
     if (this.onViewStateChange) {
-      this.onViewStateChange({ viewState: { Overview: { target: [x, y, 0] } } });
+      this.onViewStateChange({ viewState: { target: [x, y, 0] } });
     }
   }
 }

--- a/src/views/OverviewView.js
+++ b/src/views/OverviewView.js
@@ -1,25 +1,53 @@
-import { OrthographicView } from '@deck.gl/core';
+/* eslint-disable max-classes-per-file */
+import { Controller, OrthographicView } from '@deck.gl/core';
 import VivView from './VivView';
 import { OverviewLayer } from '../layers';
 import { makeBoundingBox, getVivId } from './utils';
+
+class OverviewState {
+}
+
+class OverviewController extends Controller {
+  constructor(props) {
+    super(OverviewState, props);
+    this.events = ["click"];
+  }
+
+  handleEvent(event) {
+    if (event.type !== "click") {
+      return;
+    }
+    let [x, y] = this.getCenter(event);
+    const { width, height, zoom, scale } = this.controllerStateProps;
+    if (x < 0 || y < 0 || x > width || y > height) {
+      return;
+    }
+    const scaleFactor = 1 / (2 ** zoom * scale);
+    x *= scaleFactor;
+    y *= scaleFactor;
+    if (this.onViewStateChange) {
+      this.onViewStateChange({ viewState: { Overview: { target: [x, y, 0] } } });
+    }
+  }
+}
 
 /**
  * This class generates a OverviewLayer and a view for use in the VivViewer as an overview to a Detailview (they must be used in conjection).
  * From the base class VivView, only the initialViewState argument is used.  This class uses private methods to position its x and y from the
  * additional arguments:
  * @param {Object} args
- * @param {Object} args.height Width of the view.
- * @param {Object} args.width Height of the view.
+ * @param {Object} args.initialViewState ViewState object: { target: [x, y, 0], zoom: -zoom }.
  * @param {Object} args.loader Loader to be used for inferring zoom level and fetching data.  It must have the properies `dtype`, `numLevels`, and `tileSize` and implement `getTile` and `getRaster`.
  * @param {number} args.detailHeight Height of the detail view.
  * @param {number} args.detailWidth Width of the detail view.
- * @param {number} args.scale Scale of this viewport relative to the detail. Default is .2.
- * @param {number} args.margin Margin to be offset from the the corner of the other viewport. Default is 25.
- * @param {string} args.position Location of the viewport - one of "bottom-right", "top-right", "top-left", "bottom-left."  Default is 'bottom-right'.
- * @param {number} args.minimumWidth Absolute lower bound for how small the viewport should scale. Default is 150.
- * @param {number} args.maximumWidth Absolute upper bound for how large the viewport should scale. Default is 350.
- * @param {number} args.minimumHeight Absolute lower bound for how small the viewport should scale. Default is 150.
- * @param {number} args.maximumHeight Absolute upper bound for how large the viewport should scale. Default is 350.
+ * @param {number} [args.scale] Scale of this viewport relative to the detail. Default is .2.
+ * @param {number} [args.margin] Margin to be offset from the the corner of the other viewport. Default is 25.
+ * @param {string} [args.position] Location of the viewport - one of "bottom-right", "top-right", "top-left", "bottom-left."  Default is 'bottom-right'.
+ * @param {number} [args.minimumWidth] Absolute lower bound for how small the viewport should scale. Default is 150.
+ * @param {number} [args.maximumWidth] Absolute upper bound for how large the viewport should scale. Default is 350.
+ * @param {number} [args.minimumHeight] Absolute lower bound for how small the viewport should scale. Default is 150.
+ * @param {number} [args.maximumHeight] Absolute upper bound for how large the viewport should scale. Default is 350.
+ * @param {Boolean} [args.clickCenter] Click to center the default view. Default is true.
  * */
 export default class OverviewView extends VivView {
   constructor({
@@ -33,7 +61,8 @@ export default class OverviewView extends VivView {
     minimumWidth = 150,
     maximumWidth = 350,
     minimumHeight = 150,
-    maximumHeight = 350
+    maximumHeight = 350,
+    clickCenter = true
   }) {
     super({ initialViewState });
     this.margin = margin;
@@ -51,6 +80,7 @@ export default class OverviewView extends VivView {
       maximumHeight
     });
     this._setXY();
+    this.clickCenter = clickCenter;
   }
 
   /**
@@ -126,10 +156,11 @@ export default class OverviewView extends VivView {
   }
 
   getDeckGlView() {
-    const { x, y, id, height, width } = this;
+    const { x, y, id, height, width, scale, clickCenter } = this;
+    const controller = clickCenter && { type: OverviewController, scale };
     return new OrthographicView({
       id,
-      controller: false,
+      controller,
       height,
       width,
       x,

--- a/src/views/OverviewView.js
+++ b/src/views/OverviewView.js
@@ -63,7 +63,7 @@ export default class OverviewView extends VivView {
     maximumWidth = 350,
     minimumHeight = 150,
     maximumHeight = 350,
-    clickCenter = true,
+    clickCenter = true
   }) {
     super({ initialViewState });
     this.margin = margin;
@@ -78,7 +78,7 @@ export default class OverviewView extends VivView {
       minimumWidth,
       maximumWidth,
       minimumHeight,
-      maximumHeight,
+      maximumHeight
     });
     this._setXY();
     this.clickCenter = clickCenter;
@@ -94,12 +94,12 @@ export default class OverviewView extends VivView {
     minimumWidth,
     maximumWidth,
     minimumHeight,
-    maximumHeight,
+    maximumHeight
   }) {
     const { loader } = this;
     const { numLevels } = loader;
     const { width: rasterWidth, height: rasterHeight } = loader.getRasterSize({
-      z: 0,
+      z: 0
     });
     this._imageWidth = rasterWidth;
     this._imageHeight = rasterHeight;
@@ -166,7 +166,7 @@ export default class OverviewView extends VivView {
       width,
       x,
       y,
-      clear: true,
+      clear: true
     });
   }
 
@@ -179,7 +179,7 @@ export default class OverviewView extends VivView {
       id,
       loader,
       height,
-      width,
+      width
     } = this;
     const { numLevels } = loader;
     return {
@@ -188,7 +188,7 @@ export default class OverviewView extends VivView {
       width,
       id,
       target: [(_imageWidth * scale) / 2, (_imageHeight * scale) / 2, 0],
-      zoom: -(numLevels - 1),
+      zoom: -(numLevels - 1)
     };
   }
 
@@ -199,14 +199,14 @@ export default class OverviewView extends VivView {
     }
     const { id, scale, loader } = this;
     // Scale the bounding box.
-    const boundingBox = makeBoundingBox(detail).map((coords) =>
-      coords.map((e) => e * scale)
+    const boundingBox = makeBoundingBox(detail).map(coords =>
+      coords.map(e => e * scale)
     );
     const overviewLayer = new OverviewLayer(props, {
       id: `${loader.type}${getVivId(id)}`,
       boundingBox,
       overviewScale: scale,
-      zoom: -overview.zoom,
+      zoom: -overview.zoom
     });
     return [overviewLayer];
   }

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1,5 +1,5 @@
-export { default as DetailView } from './DetailView';
-export { default as OverviewView } from './OverviewView';
+export { default as DetailView, DETAIL_VIEW_ID } from './DetailView';
+export { default as OverviewView, OVERVIEW_VIEW_ID } from './OverviewView';
 export { default as VivView } from './VivView';
 export { default as SideBySideView } from './SideBySideView';
 export { getDefaultInitialViewState } from './utils';

--- a/tests/layers_views/views/DetailView.spec.js
+++ b/tests/layers_views/views/DetailView.spec.js
@@ -1,10 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies, no-unused-expressions */
 import test from 'tape-catch';
-import { DetailView } from '../../../src/views';
+import { DetailView, DETAIL_VIEW_ID } from '../../../src/views';
 import { generateViewTests, defaultArguments } from './VivView.spec';
 import { MultiscaleImageLayer, ScaleBarLayer } from '../../../src/layers';
 
-const id = 'detail';
+const id = DETAIL_VIEW_ID;
 const detailViewArguments = { ...defaultArguments };
 detailViewArguments.initialViewState = { ...defaultArguments.initialViewState };
 detailViewArguments.initialViewState.id = id;

--- a/tests/layers_views/views/OverviewView.spec.js
+++ b/tests/layers_views/views/OverviewView.spec.js
@@ -1,10 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies, no-unused-expressions */
 import test from 'tape-catch';
-import { OverviewView } from '../../../src/views';
+import { OverviewView, DETAIL_VIEW_ID, OVERVIEW_VIEW_ID } from '../../../src/views';
 import { generateViewTests, defaultArguments } from './VivView.spec';
 import { OverviewLayer } from '../../../src/layers';
 
-const id = 'overview';
+const id = OVERVIEW_VIEW_ID;
 const loader = {
   type: 'loads',
   numLevels: 7,
@@ -21,9 +21,9 @@ const overviewViewArguments = {
 overviewViewArguments.initialViewState = {
   ...defaultArguments.initialViewState
 };
-overviewViewArguments.initialViewState.id = 'overview';
+overviewViewArguments.initialViewState.id = OVERVIEW_VIEW_ID;
 
-const linkedViewIds = ['detail'];
+const linkedViewIds = [DETAIL_VIEW_ID];
 
 generateViewTests(OverviewView, overviewViewArguments, linkedViewIds);
 


### PR DESCRIPTION
This addresses #330. I don't have an easy way to test this but a very similar implementation with subclasses worked in my app. I only tried it with one image but there the combination of `zoom` and `scale` properly transformed the coordinates such that the mouse was in the center of the red bounding rectangle after a click.