### PR TITLE
Allow for PR GH Actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Node.js CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-windows:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
       matrix:
         node-version: [14.x]
 
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -29,6 +32,9 @@ jobs:
       matrix:
         node-version: [14.x]
 
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Fix documentation of instances where spreading is used in the arguments for a function.
+- GH actions allow for running on PR as well as push (so that forked repos run tests).
 
 ## 0.8.0
 


### PR DESCRIPTION
This allows PR events to trigger our tests/builds on GH actions.  I think this is the way to go for handling forked repos so that our tests run against them but maybe I have this wrong?

See: https://github.com/visgl/deck.gl/blob/6136d93d19ef098685f3e9b5ecd74ea5a8d701fa/.github/workflows/test.yml#L4-L8