### PR TITLE
Refactor Tiff Loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Create a `TiffLoader` base class that `OmeTiffLoader` inherits from and extends.
+
 ### Changed
 
 ## 0.8.1

--- a/avivator/src/components/ColorPalette.js
+++ b/avivator/src/components/ColorPalette.js
@@ -4,7 +4,7 @@ import LensIcon from '@material-ui/icons/Lens';
 
 import { makeStyles } from '@material-ui/core/styles';
 
-import { COLOR_PALLETE } from '../constants';
+import { COLOR_PALETTE } from '../constants';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -30,7 +30,7 @@ const ColorPalette = ({ handleChange }) => {
   const classes = useStyles();
   return (
     <div className={classes.container} aria-label="color-swatch">
-      {COLOR_PALLETE.map(color => {
+      {COLOR_PALETTE.map(color => {
         return (
           <IconButton
             className={classes.button}

--- a/avivator/src/constants.js
+++ b/avivator/src/constants.js
@@ -16,7 +16,7 @@ export const COLORMAP_OPTIONS = [
   'density',
   'inferno'
 ];
-export const COLOR_PALLETE = [
+export const COLOR_PALETTE = [
   [0, 0, 255],
   [0, 255, 0],
   [255, 0, 255],

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -5,7 +5,7 @@ import {
   getChannelStats
 } from '../../dist';
 
-import { GLOBAL_SLIDER_DIMENSION_FIELDS, COLOR_PALLETE } from './constants';
+import { GLOBAL_SLIDER_DIMENSION_FIELDS, COLOR_PALETTE } from './constants';
 
 const MAX_CHANNELS_FOR_SNACKBAR_WARNING = 40;
 
@@ -233,7 +233,7 @@ export function channelsReducer(state, { index, value, type }) {
         selections,
         sliders,
         domains,
-        colors: colors || selections.map((sel, i) => COLOR_PALLETE[i]),
+        colors: colors || selections.map((sel, i) => COLOR_PALETTE[i]),
         isOn: isOn || Array(n).fill(true),
         ids: range(n).map(() => String(Math.random()))
       };

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -65,7 +65,7 @@ export async function createLoader(
       // Non-Bioformats6 pyramids use Image tags for pyramid levels and do not have offsets
       // built in to the format for them, hence the ternary.
       const {
-        omexml: { SizeZ, SizeT, SizeC },
+        metadata: { SizeZ, SizeT, SizeC },
         isBioFormats6Pyramid,
         isPyramid
       } = loader;

--- a/documentation.yml
+++ b/documentation.yml
@@ -24,6 +24,7 @@ toc:
 - ScaleBarLayer
 - name: Loaders
 - createOMETiffLoader
+- TiffLoader
 - OMETiffLoader
 - ZarrLoader
 - name: Internal

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,8 @@ import {
   ZarrLoader,
   createOMETiffLoader,
   OMETiffLoader,
-  getChannelStats
+  getChannelStats,
+  TiffLoader
 } from './loaders';
 import HTTPStore from './loaders/httpStore';
 import { DTYPE_VALUES, MAX_SLIDERS_AND_CHANNELS } from './constants';
@@ -43,6 +44,7 @@ export {
   ImageLayer,
   ZarrLoader,
   OMETiffLoader,
+  TiffLoader,
   createOMETiffLoader,
   createZarrLoader,
   createBioformatsZarrLoader,

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -1,16 +1,4 @@
-import OMEXML from './omeXML';
-import { isInTileBounds, dimensionsFromOMEXML } from './utils';
-
-const DTYPE_LOOKUP = {
-  uint8: '<u1',
-  uint16: '<u2',
-  uint32: '<u4',
-  float: '<f4',
-  // TODO: we currently need to cast these dtypes to their uint counterparts.
-  int8: '<u1',
-  int16: '<u2',
-  int32: '<u4'
-};
+import TiffLoader from './TiffLoader';
 
 /**
  * This class serves as a wrapper for fetching tiff data from a file server.
@@ -21,51 +9,15 @@ const DTYPE_LOOKUP = {
  * @param {String} args.omexmlString Raw OMEXML as a string.
  * @param {Array} args.offsets The offsets of each IFD in the tiff.
  * */
-export default class OMETiffLoader {
-  constructor({ tiff, pool, firstImage, omexmlString, offsets }) {
-    this.pool = pool;
-    this.tiff = tiff;
-    this.type = 'ome-tiff';
-    // get first image's description, which contains OMEXML
-    this.omexml = new OMEXML(omexmlString);
-    this.physicalSizes = {
-      x: {
-        value: this.omexml.PhysicalSizeX,
-        unit: this.omexml.PhysicalSizeXUnit
-      },
-      y: {
-        value: this.omexml.PhysicalSizeY,
-        unit: this.omexml.PhysicalSizeYUnit
+export default class OMETiffLoader extends TiffLoader {
+  constructor(args) {
+    super(args);
+    const {
+      firstImage: {
+        fileDirectory: { SubIFDs }
       }
-    };
-    this.software = firstImage.fileDirectory.Software;
-    this.photometricInterpretation =
-      firstImage.fileDirectory.PhotometricInterpretation;
-    this.offsets = offsets || [];
-    this.channelNames = this.omexml.getChannelNames();
-    this.width = this.omexml.SizeX;
-    this.height = this.omexml.SizeY;
-    this.tileSize = firstImage.getTileWidth();
-    const { SubIFDs } = firstImage.fileDirectory;
-    this.numLevels = SubIFDs?.length
-      ? SubIFDs.length + 1
-      : this.omexml.getNumberOfImages();
+    } = args;
     this.isBioFormats6Pyramid = SubIFDs;
-    this.isPyramid = this.numLevels > 1;
-    this.dimensions = dimensionsFromOMEXML(this.omexml);
-    // We use zarr's internal format.  It encodes endianness, but we leave it little for now
-    // since javascript is little endian.
-    this.dtype = DTYPE_LOOKUP[this.omexml.Type];
-    // This is experimental and will take some tuning to properly detect.  For now,
-    // if the SamplesPerPixel is 3 (i.e interleaved) or if there are three uint8 channels,
-    // we flag that as rgb.
-    this.isRgb =
-      this.omexml.SamplesPerPixel === 3 ||
-      (this.channelNames.length === 3 && this.omexml.Type === 'uint8') ||
-      (this.omexml.SizeC === 3 &&
-        this.channelNames.length === 1 &&
-        this.omexml.Interleaved);
-    this.isInterleaved = this.omexml.Interleaved;
   }
 
   /**
@@ -157,99 +109,36 @@ export default class OMETiffLoader {
     return Promise.all(imageRequests);
   }
 
-  /**
-   * Handles `onTileError` within deck.gl
-   * @param {Error} err Error thrown in tile layer
-   */
-  // eslint-disable-next-line class-methods-use-this
-  onTileError(err) {
-    console.error(err);
-  }
-
-  /**
-   * Returns image tiles at tile-position (x, y) at pyramidal level z.
-   * @param {Object} args
-   * @param {number} args.x positive integer
-   * @param {number} args.y positive integer
-   * @param {number} args.z positive integer (0 === highest zoom level)
-   * @param {Array} args.loaderSelection, Array of number Arrays specifying channel selections
-   * @param {Array} args.signal AbortSignal object
-   * @returns {Object} data: TypedArray[], width: number (tileSize), height: number (tileSize).
-   * Default is `{data: [], width: tileSize, height: tileSize}`.
-   */
-  async getTile({ x, y, z, loaderSelection = [], signal }) {
-    if (!this._tileInBounds({ x, y, z })) {
-      return null;
-    }
-    const images = await this.getImages(loaderSelection, z);
-    const tileRequests = images.map(async image => {
-      return this._getChannel({ image, x, y, z, signal });
-    });
-    const data = await Promise.all(tileRequests);
-    const { height, width } = this._getTileExtent({
-      x,
-      y,
-      z
-    });
-    if (signal?.aborted) return null;
-    return {
-      data,
-      height,
-      width
-    };
-  }
-
-  /**
-   * Returns full image panes (at level z if pyramid)
-   * @param {Object} args
-   * @param {number} args.z positive integer (0 === highest zoom level)
-   * @param {Array} args.loaderSelection, Array of number Arrays specifying channel selections
-   * @returns {Object} data: TypedArray[], width: number, height: number
-   * Default is `{data: [], width, height}`.
-   */
-  async getRaster({ z, loaderSelection }) {
-    const { pool, isInterleaved } = this;
-    const images = await this.getImages(loaderSelection, z);
-    const rasters = await Promise.all(
-      images.map(async image => {
-        const raster = await image.readRasters({
-          pool,
-          interleave: isInterleaved
-        });
-        return isInterleaved ? raster : raster[0];
-      })
-    );
-    // Get first selection * SizeZ * SizeT * SizeC + loaderSelection[0] size as proxy for image size.
-    if (!loaderSelection || loaderSelection.length === 0) {
-      return { data: [], ...this.getRasterSize({ z }) };
-    }
-    const [image] = images;
-    const width = image.getWidth();
-    const height = image.getHeight();
-
+  _convertIntRasters(rasters) {
     let data;
-    if (this.dtype === '<f4') {
-      // GeoTiff.js returns 32 bit uint when the tiff has 32 significant bits.
-      data = rasters.map(r => new Float32Array(r.buffer));
-    } else if (this.omexml.Type.startsWith('int')) {
+    if (this.metadata.Type.startsWith('int')) {
       // geotiff.js returns the correct typedarray but need to cast to Uint for viv.
-      const b = rasters[0].BYTES_PER_ELEMENT;
+      const b = rasters.data[0].BYTES_PER_ELEMENT;
       // eslint-disable-next-line no-nested-ternary
       const T = b === 1 ? Uint8Array : b === 2 ? Uint16Array : Uint32Array;
-      data = rasters.map(r => new T(r));
+      data = rasters.data.map(r => new T(r));
     } else {
-      data = rasters;
+      data = rasters.data;
     }
     return {
-      data,
-      width,
-      height
+      ...rasters,
+      data
     };
+  }
+
+  async getTile(args) {
+    const tiles = await super.getTile(args);
+    return this._convertIntRasters(tiles);
+  }
+
+  async getRaster({ z, loaderSelection }) {
+    const rasters = await super.getRaster({ z, loaderSelection });
+    return this._convertIntRasters(rasters);
   }
 
   /**
    * Returns image width and height (at pyramid level z) without fetching data.
-   * This information is inferrable from the provided omexml.
+   * This information is inferrable from the provided metadata.
    * It is NOT the actual pixel-size but rather the image size
    * without any padding.
    * @param {Object} args
@@ -257,7 +146,8 @@ export default class OMETiffLoader {
    * @returns {Object} width: number, height: number
    */
   getRasterSize({ z }) {
-    const { width, height } = this;
+    const { metadata } = this;
+    const { SizeX: width, SizeY: height } = metadata;
     /* eslint-disable no-bitwise */
     return {
       height: height >> z,
@@ -271,7 +161,7 @@ export default class OMETiffLoader {
    * @returns {Object} Metadata keys mapped to values.
    */
   getMetadata() {
-    const { omexml } = this;
+    const { metadata } = this;
     const {
       metadataOMEXML: {
         Image: { AcquisitionDate },
@@ -289,7 +179,7 @@ export default class OMETiffLoader {
       PhysicalSizeYUnit,
       PhysicalSizeZ,
       PhysicalSizeZUnit
-    } = omexml;
+    } = metadata;
 
     const physicalSizeAndUnitX =
       PhysicalSizeX && PhysicalSizeXUnit
@@ -320,89 +210,5 @@ export default class OMETiffLoader {
       Channels: SizeC,
       'ROI Count': roiCount
     };
-  }
-
-  async _getChannel({ image, x, y, z, signal }) {
-    const { tileSize, pool, isInterleaved: interleave } = this;
-    const { height, width } = this._getTileExtent({
-      x,
-      y,
-      z
-    });
-    // Passing in the height and width explicitly prevents resampling that geotiff does without such parameters.
-    const rasters = await image.readRasters({
-      window: [
-        x * tileSize,
-        y * tileSize,
-        x * tileSize + width,
-        y * tileSize + height
-      ],
-      pool,
-      signal,
-      width,
-      height,
-      interleave
-    });
-    const data = interleave ? rasters : rasters[0];
-    if (signal?.aborted) return null;
-    if (this.omexml.Type.startsWith('int')) {
-      // Uint view isn't correct for underling buffer, need to take an
-      // IntXArray view and cast to UintXArray.
-      if (data.BYTES_PER_ELEMENT === 1) {
-        return new Uint8Array(new Int8Array(data.buffer));
-      }
-      if (data.BYTES_PER_ELEMENT === 2) {
-        return new Uint16Array(new Int16Array(data.buffer));
-      }
-      return new Uint32Array(new Int32Array(data.buffer));
-    }
-    return data;
-  }
-
-  _tileInBounds({ x, y, z }) {
-    const { width, height, tileSize, numLevels } = this;
-    return isInTileBounds({
-      x,
-      y,
-      z,
-      width,
-      height,
-      tileSize,
-      numLevels
-    });
-  }
-
-  _parseIFD(index) {
-    const { tiff, offsets } = this;
-    if (offsets.length > 0) {
-      tiff.ifdRequests[index] = tiff.parseFileDirectoryAt(offsets[index]);
-    }
-  }
-
-  /**
-   * For a given resolution level, z, the expected tile size on the boundary
-   * of the image should be exactly enough to fit the image bounds at the resolution level.
-   * This function returns that size or the parametrized tileSize from TIFF file.
-   * @param {tileData: TypedArray[]} data The array to be filled in.
-   * @param {Object} tile { x, y, z }
-   * @returns {TypedArray} TypedArray
-   */
-  _getTileExtent({ x, y, z }) {
-    const { tileSize } = this;
-    let height = tileSize;
-    let width = tileSize;
-    const {
-      height: zoomLevelHeight,
-      width: zoomLevelWidth
-    } = this.getRasterSize({ z });
-    const maxXTileCoord = Math.floor(zoomLevelWidth / tileSize);
-    const maxYTileCoord = Math.floor(zoomLevelHeight / tileSize);
-    if (x === maxXTileCoord) {
-      width = zoomLevelWidth % tileSize;
-    }
-    if (y === maxYTileCoord) {
-      height = zoomLevelHeight % tileSize;
-    }
-    return { height, width };
   }
 }

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -116,6 +116,12 @@ export default class OMETiffLoader {
     }
   }
 
+  /**
+   * Returns a tiff image object for a given loader selection + pyramid level.
+   * @param {Object} loaderSelection A lodaer selection
+   * @param {number} z Pyramidal resolution level.
+   * @returns {Object} Tiff Image object containing parsed IFD.
+   */
   async getImages(loaderSelection, z) {
     const { tiff, isBioFormats6Pyramid } = this;
     const imageRequests = loaderSelection.map(async sel => {
@@ -194,7 +200,6 @@ export default class OMETiffLoader {
   async getRaster({ z, loaderSelection }) {
     const { pool, isInterleaved } = this;
     const images = await this.getImages(loaderSelection, z);
-    console.log(images);
     const rasters = await Promise.all(
       images.map(async image => {
         const raster = await image.readRasters({

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -12,7 +12,7 @@ export default class OMETiffLoader extends TiffLoader {
         fileDirectory: { SubIFDs }
       }
     } = args;
-    this.isBioFormats6Pyramid = SubIFDs;
+    this.isBioFormats6Pyramid = Boolean(SubIFDs);
     this.type = 'ome-tiff';
   }
 

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -20,12 +20,107 @@ export default class OMETiffLoader extends TiffLoader {
     this.isBioFormats6Pyramid = SubIFDs;
   }
 
-  /**
-   * Returns an IFD index for a given loader selection + pyramid leel..
-   * @param {Object} loaderSelection A lodaer selection
-   * @param {number} zIndex Pyramidal resolution level.
-   * @returns {number} IFD index.
-   */
+  async getImages(loaderSelection, z) {
+    const { tiff, isBioFormats6Pyramid } = this;
+    const imageRequests = loaderSelection.map(async sel => {
+      const pyramidIndex = this._getIFDIndex(sel, z);
+      const index = this._getIFDIndex(sel);
+      // We need to put the request for parsing the file directory into this array.
+      // This allows us to get tiff pages directly based on offset without parsing everything.
+      if (!isBioFormats6Pyramid) {
+        this._parseIFD(pyramidIndex);
+      } else {
+        // Pyramids with large z-stacks + large numbers of channels could get slow
+        // so we allow for offsets for the lowest-resolution images ("parentImage").
+        this._parseIFD(index);
+        const parentImage = await tiff.getImage(index);
+        if (z !== 0) {
+          tiff.ifdRequests[pyramidIndex] = tiff.parseFileDirectoryAt(
+            parentImage.fileDirectory.SubIFDs[z - 1]
+          );
+        }
+      }
+      return tiff.getImage(pyramidIndex);
+    });
+    return Promise.all(imageRequests);
+  }
+
+  async getTile(args) {
+    const tiles = await super.getTile(args);
+    return this._convertIntRasters(tiles);
+  }
+
+  async getRaster({ z, loaderSelection }) {
+    const rasters = await super.getRaster({
+      z,
+      loaderSelection
+    });
+    return this._convertIntRasters(rasters);
+  }
+
+  getRasterSize({ z }) {
+    const { metadata } = this;
+    const { SizeX: width, SizeY: height } = metadata;
+    /* eslint-disable no-bitwise */
+    return {
+      height: height >> z,
+      width: width >> z
+    };
+    /* eslint-disable no-bitwise */
+  }
+
+  getMetadata() {
+    const { metadata } = this;
+    const {
+      metadataOMEXML: {
+        Image: { AcquisitionDate },
+        StructuredAnnotations
+      },
+      SizeX,
+      SizeY,
+      SizeZ,
+      SizeT,
+      SizeC,
+      Type,
+      PhysicalSizeX,
+      PhysicalSizeXUnit,
+      PhysicalSizeY,
+      PhysicalSizeYUnit,
+      PhysicalSizeZ,
+      PhysicalSizeZUnit
+    } = metadata;
+
+    const physicalSizeAndUnitX =
+      PhysicalSizeX && PhysicalSizeXUnit
+        ? `${PhysicalSizeX} (${PhysicalSizeXUnit})`
+        : '-';
+    const physicalSizeAndUnitY =
+      PhysicalSizeY && PhysicalSizeYUnit
+        ? `${PhysicalSizeY} (${PhysicalSizeYUnit})`
+        : '-';
+    const physicalSizeAndUnitZ =
+      PhysicalSizeZ && PhysicalSizeZUnit
+        ? `${PhysicalSizeZ} (${PhysicalSizeZUnit})`
+        : '-';
+    let roiCount;
+    if (StructuredAnnotations) {
+      const { MapAnnotation } = StructuredAnnotations;
+      roiCount =
+        MapAnnotation && MapAnnotation.Value
+          ? Object.entries(MapAnnotation.Value).length
+          : 0;
+    }
+    return {
+      'Acquisition Date': AcquisitionDate,
+      'Dimensions (XY)': `${SizeX} x ${SizeY}`,
+      'Pixels Type': Type,
+      'Pixels Size (XYZ)': `${physicalSizeAndUnitX} x ${physicalSizeAndUnitY} x ${physicalSizeAndUnitZ}`,
+      'Z-sections/Timepoints': `${SizeZ} x ${SizeT}`,
+      Channels: SizeC,
+      'ROI Count': roiCount
+    };
+  }
+
   _getIFDIndex({ z = 0, channel, time = 0 }, zIndex = 0) {
     let channelIndex;
     // Without names, enforce a numeric channel indexing scheme
@@ -78,37 +173,6 @@ export default class OMETiffLoader extends TiffLoader {
     }
   }
 
-  /**
-   * Returns a tiff image object for a given loader selection + pyramid level.
-   * @param {Object} loaderSelection A lodaer selection
-   * @param {number} z Pyramidal resolution level.
-   * @returns {Object} Tiff Image object containing parsed IFD.
-   */
-  async getImages(loaderSelection, z) {
-    const { tiff, isBioFormats6Pyramid } = this;
-    const imageRequests = loaderSelection.map(async sel => {
-      const pyramidIndex = this._getIFDIndex(sel, z);
-      const index = this._getIFDIndex(sel);
-      // We need to put the request for parsing the file directory into this array.
-      // This allows us to get tiff pages directly based on offset without parsing everything.
-      if (!isBioFormats6Pyramid) {
-        this._parseIFD(pyramidIndex);
-      } else {
-        // Pyramids with large z-stacks + large numbers of channels could get slow
-        // so we allow for offsets for the lowest-resolution images ("parentImage").
-        this._parseIFD(index);
-        const parentImage = await tiff.getImage(index);
-        if (z !== 0) {
-          tiff.ifdRequests[pyramidIndex] = tiff.parseFileDirectoryAt(
-            parentImage.fileDirectory.SubIFDs[z - 1]
-          );
-        }
-      }
-      return tiff.getImage(pyramidIndex);
-    });
-    return Promise.all(imageRequests);
-  }
-
   _convertIntRasters(rasters) {
     let data;
     if (this.metadata.Type.startsWith('int')) {
@@ -123,92 +187,6 @@ export default class OMETiffLoader extends TiffLoader {
     return {
       ...rasters,
       data
-    };
-  }
-
-  async getTile(args) {
-    const tiles = await super.getTile(args);
-    return this._convertIntRasters(tiles);
-  }
-
-  async getRaster({ z, loaderSelection }) {
-    const rasters = await super.getRaster({ z, loaderSelection });
-    return this._convertIntRasters(rasters);
-  }
-
-  /**
-   * Returns image width and height (at pyramid level z) without fetching data.
-   * This information is inferrable from the provided metadata.
-   * It is NOT the actual pixel-size but rather the image size
-   * without any padding.
-   * @param {Object} args
-   * @param {number} args.z positive integer (0 === highest zoom level)
-   * @returns {Object} width: number, height: number
-   */
-  getRasterSize({ z }) {
-    const { metadata } = this;
-    const { SizeX: width, SizeY: height } = metadata;
-    /* eslint-disable no-bitwise */
-    return {
-      height: height >> z,
-      width: width >> z
-    };
-    /* eslint-disable no-bitwise */
-  }
-
-  /**
-   * Get the metadata associated with an OMETiff image layer, in a human-readable format.
-   * @returns {Object} Metadata keys mapped to values.
-   */
-  getMetadata() {
-    const { metadata } = this;
-    const {
-      metadataOMEXML: {
-        Image: { AcquisitionDate },
-        StructuredAnnotations
-      },
-      SizeX,
-      SizeY,
-      SizeZ,
-      SizeT,
-      SizeC,
-      Type,
-      PhysicalSizeX,
-      PhysicalSizeXUnit,
-      PhysicalSizeY,
-      PhysicalSizeYUnit,
-      PhysicalSizeZ,
-      PhysicalSizeZUnit
-    } = metadata;
-
-    const physicalSizeAndUnitX =
-      PhysicalSizeX && PhysicalSizeXUnit
-        ? `${PhysicalSizeX} (${PhysicalSizeXUnit})`
-        : '-';
-    const physicalSizeAndUnitY =
-      PhysicalSizeY && PhysicalSizeYUnit
-        ? `${PhysicalSizeY} (${PhysicalSizeYUnit})`
-        : '-';
-    const physicalSizeAndUnitZ =
-      PhysicalSizeZ && PhysicalSizeZUnit
-        ? `${PhysicalSizeZ} (${PhysicalSizeZUnit})`
-        : '-';
-    let roiCount;
-    if (StructuredAnnotations) {
-      const { MapAnnotation } = StructuredAnnotations;
-      roiCount =
-        MapAnnotation && MapAnnotation.Value
-          ? Object.entries(MapAnnotation.Value).length
-          : 0;
-    }
-    return {
-      'Acquisition Date': AcquisitionDate,
-      'Dimensions (XY)': `${SizeX} x ${SizeY}`,
-      'Pixels Type': Type,
-      'Pixels Size (XYZ)': `${physicalSizeAndUnitX} x ${physicalSizeAndUnitY} x ${physicalSizeAndUnitZ}`,
-      'Z-sections/Timepoints': `${SizeZ} x ${SizeT}`,
-      Channels: SizeC,
-      'ROI Count': roiCount
     };
   }
 }

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -1,7 +1,7 @@
 import TiffLoader from './TiffLoader';
 
 /**
- * This class serves as a wrapper for fetching tiff data from a file server.
+ * This class serves as a wrapper for reading ome-tiff data.
  * Inherites from TiffLoader and implements the necessary methods.
  * */
 export default class OMETiffLoader extends TiffLoader {

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -15,7 +15,7 @@ export default class OMETiffLoader extends TiffLoader {
     this.isBioFormats6Pyramid = SubIFDs;
   }
 
-  async getImages(loaderSelection, z) {
+  async getImages(loaderSelection, z = 0) {
     const { _tiff, isBioFormats6Pyramid } = this;
     const imageRequests = loaderSelection.map(async sel => {
       const pyramidIndex = this._getIFDIndex(sel, z);

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -2,12 +2,7 @@ import TiffLoader from './TiffLoader';
 
 /**
  * This class serves as a wrapper for fetching tiff data from a file server.
- * @param {Object} args
- * @param {Object} args.tiff geotiffjs tiff object.
- * @param {Object} args.pool Pool that implements a `decode` function.
- * @param {Object} args.firstImage First image (geotiff Image object) in the tiff (containing base-resolution data).
- * @param {String} args.omexmlString Raw OMEXML as a string.
- * @param {Array} args.offsets The offsets of each IFD in the tiff.
+ * Inherites from TiffLoader and implements the necessary methods.
  * */
 export default class OMETiffLoader extends TiffLoader {
   constructor(args) {
@@ -21,7 +16,7 @@ export default class OMETiffLoader extends TiffLoader {
   }
 
   async getImages(loaderSelection, z) {
-    const { tiff, isBioFormats6Pyramid } = this;
+    const { _tiff, isBioFormats6Pyramid } = this;
     const imageRequests = loaderSelection.map(async sel => {
       const pyramidIndex = this._getIFDIndex(sel, z);
       const index = this._getIFDIndex(sel);
@@ -33,14 +28,14 @@ export default class OMETiffLoader extends TiffLoader {
         // Pyramids with large z-stacks + large numbers of channels could get slow
         // so we allow for offsets for the lowest-resolution images ("parentImage").
         this._parseIFD(index);
-        const parentImage = await tiff.getImage(index);
+        const parentImage = await _tiff.getImage(index);
         if (z !== 0) {
-          tiff.ifdRequests[pyramidIndex] = tiff.parseFileDirectoryAt(
+          _tiff.ifdRequests[pyramidIndex] = _tiff.parseFileDirectoryAt(
             parentImage.fileDirectory.SubIFDs[z - 1]
           );
         }
       }
-      return tiff.getImage(pyramidIndex);
+      return _tiff.getImage(pyramidIndex);
     });
     return Promise.all(imageRequests);
   }

--- a/src/loaders/OMETiffLoader.js
+++ b/src/loaders/OMETiffLoader.js
@@ -13,6 +13,7 @@ export default class OMETiffLoader extends TiffLoader {
       }
     } = args;
     this.isBioFormats6Pyramid = SubIFDs;
+    this.type = 'ome-tiff';
   }
 
   async getImages(loaderSelection, z = 0) {

--- a/src/loaders/TiffLoader.js
+++ b/src/loaders/TiffLoader.js
@@ -54,7 +54,7 @@ export default class TiffLoader {
    * Returns a tiff image object for a given loader selection + pyramid level.
    * This is implemented by all classes that inherit from the tiff loader.
    * @param {Object} loaderSelection A lodaer selection
-   * @param {number} z Pyramidal resolution level.
+   * @param {number} z Pyramidal resolution level (default is implemented by loader, should be 0 unless noted otherwise).
    * @returns {Object} Tiff Image object containing parsed IFD.
    */
   // eslint-disable-next-line class-methods-use-this,no-unused-vars,no-empty-function

--- a/src/loaders/TiffLoader.js
+++ b/src/loaders/TiffLoader.js
@@ -1,7 +1,7 @@
 import { isInTileBounds } from './utils';
 
 /**
- * This class serves as a wrapper for fetching tiff data from a file server.
+ * This class serves as a wrapper for reading tiff data.
  * @param {Object} args
  * @param {Object} args.tiff geotiffjs tiff object.
  * @param {Object} args.pool Pool that implements a `decode` function.

--- a/src/loaders/TiffLoader.js
+++ b/src/loaders/TiffLoader.js
@@ -30,7 +30,6 @@ export default class TiffLoader {
     physicalSizes
   }) {
     this.physicalSizes = physicalSizes;
-    this.type = 'ome-tiff';
     // get first image's description, which contains OMEXML
     this.metadata = metadata;
     this.dimensions = dimensions;

--- a/src/loaders/TiffLoader.js
+++ b/src/loaders/TiffLoader.js
@@ -71,6 +71,27 @@ export default class TiffLoader {
   }
 
   /**
+   * Returns image width and height (at pyramid level z) without fetching data.
+   * This information is inferrable from the provided metadata.
+   * It is NOT the actual pixel-size but rather the image size
+   * without any padding.
+   * This needs to be implemented by all classes inheriting this loader.
+   * @param {Object} args
+   * @param {number} args.z positive integer (0 === highest zoom level)
+   * @returns {Object} width: number, height: number
+   */
+  // eslint-disable-next-line class-methods-use-this,no-unused-vars,no-empty-function
+  getRasterSize({ z }) {}
+
+  /**
+   * Get the metadata associated with an OMETiff image layer, in a human-readable format.
+   * This needs to be implemented by all classes inheriting this loader.
+   * @returns {Object} Metadata keys mapped to values.
+   */
+  // eslint-disable-next-line class-methods-use-this,no-unused-vars,no-empty-function
+  getMetadata() {}
+
+  /**
    * Returns image tiles at tile-position (x, y) at pyramidal level z.
    * @param {Object} args
    * @param {number} args.x positive integer
@@ -136,27 +157,6 @@ export default class TiffLoader {
       height
     };
   }
-
-  /**
-   * Returns image width and height (at pyramid level z) without fetching data.
-   * This information is inferrable from the provided metadata.
-   * It is NOT the actual pixel-size but rather the image size
-   * without any padding.
-   * This needs to be implemented by all classes inheriting this loader.
-   * @param {Object} args
-   * @param {number} args.z positive integer (0 === highest zoom level)
-   * @returns {Object} width: number, height: number
-   */
-  // eslint-disable-next-line class-methods-use-this,no-unused-vars,no-empty-function
-  getRasterSize({ z }) {}
-
-  /**
-   * Get the metadata associated with an OMETiff image layer, in a human-readable format.
-   * This needs to be implemented by all classes inheriting this loader.
-   * @returns {Object} Metadata keys mapped to values.
-   */
-  // eslint-disable-next-line class-methods-use-this,no-unused-vars,no-empty-function
-  getMetadata() {}
 
   async _getChannel({ image, x, y, z, signal }) {
     const { tileSize, pool, isInterleaved: interleave } = this;

--- a/src/loaders/TiffLoader.js
+++ b/src/loaders/TiffLoader.js
@@ -1,0 +1,234 @@
+import { isInTileBounds } from './utils';
+
+/**
+ * This class serves as a wrapper for fetching tiff data from a file server.
+ * @param {Object} args
+ * @param {Object} args.tiff geotiffjs tiff object.
+ * @param {Object} args.pool Pool that implements a `decode` function.
+ * @param {Object} args.firstImage First image (geotiff Image object) in the tiff (containing base-resolution data).
+ * @param {String} args.omexmlString Raw OMEXML as a string.
+ * @param {Array} args.offsets The offsets of each IFD in the tiff.
+ * */
+export default class TiffLoader {
+  constructor({
+    tiff,
+    pool,
+    firstImage,
+    dimensions,
+    offsets,
+    metadata,
+    isRgb,
+    isInterleaved,
+    dtype
+  }) {
+    this.pool = pool;
+    this.tiff = tiff;
+    this.type = 'ome-tiff';
+    // get first image's description, which contains OMEXML
+    this.metadata = metadata;
+    this.physicalSizes = {
+      x: {
+        value: this.metadata.PhysicalSizeX,
+        unit: this.metadata.PhysicalSizeXUnit
+      },
+      y: {
+        value: this.metadata.PhysicalSizeY,
+        unit: this.metadata.PhysicalSizeYUnit
+      }
+    };
+    this.photometricInterpretation =
+      firstImage.fileDirectory.PhotometricInterpretation;
+    this.offsets = offsets || [];
+    this.tileSize = firstImage.getTileWidth();
+    const { SubIFDs } = firstImage.fileDirectory;
+    this.numLevels = SubIFDs?.length
+      ? SubIFDs.length + 1
+      : this.metadata.getNumberOfImages();
+    this.isPyramid = this.numLevels > 1;
+    this.dimensions = dimensions;
+    this.dtype = dtype;
+    this.isRgb = isRgb;
+    this.isInterleaved = isInterleaved;
+  }
+
+  /**
+   * Returns a tiff image object for a given loader selection + pyramid level.
+   * This is implemented by all classes that inherit from the tiff loader.
+   * @param {Object} loaderSelection A lodaer selection
+   * @param {number} z Pyramidal resolution level.
+   * @returns {Object} Tiff Image object containing parsed IFD.
+   */
+  // eslint-disable-next-line class-methods-use-this,no-unused-vars,no-empty-function
+  async getImages(loaderSelection, z) {}
+
+  /**
+   * Handles `onTileError` within deck.gl
+   * @param {Error} err Error thrown in tile layer
+   */
+  // eslint-disable-next-line class-methods-use-this
+  onTileError(err) {
+    console.error(err);
+  }
+
+  /**
+   * Returns image tiles at tile-position (x, y) at pyramidal level z.
+   * @param {Object} args
+   * @param {number} args.x positive integer
+   * @param {number} args.y positive integer
+   * @param {number} args.z positive integer (0 === highest zoom level)
+   * @param {Array} args.loaderSelection, Array of number Arrays specifying channel selections
+   * @param {Array} args.signal AbortSignal object
+   * @returns {Object} data: TypedArray[], width: number (tileSize), height: number (tileSize).
+   * Default is `{data: [], width: tileSize, height: tileSize}`.
+   */
+  async getTile({ x, y, z, loaderSelection = [], signal }) {
+    if (!this._tileInBounds({ x, y, z })) {
+      return null;
+    }
+    const images = await this.getImages(loaderSelection, z);
+    const tileRequests = images.map(async image => {
+      return this._getChannel({ image, x, y, z, signal });
+    });
+    const data = await Promise.all(tileRequests);
+    const { height, width } = this._getTileExtent({
+      x,
+      y,
+      z
+    });
+    if (signal?.aborted) return null;
+    return {
+      data,
+      height,
+      width
+    };
+  }
+
+  /**
+   * Returns full image panes (at level z if pyramid)
+   * @param {Object} args
+   * @param {number} args.z positive integer (0 === highest zoom level)
+   * @param {Array} args.loaderSelection, Array of number Arrays specifying channel selections
+   * @returns {Object} data: TypedArray[], width: number, height: number
+   * Default is `{data: [], width, height}`.
+   */
+  async getRaster({ z, loaderSelection }) {
+    const { pool, isInterleaved } = this;
+    const images = await this.getImages(loaderSelection, z);
+    const data = await Promise.all(
+      images.map(async image => {
+        const raster = await image.readRasters({
+          pool,
+          interleave: isInterleaved
+        });
+        return isInterleaved ? raster : raster[0];
+      })
+    );
+    // Get first selection * SizeZ * SizeT * SizeC + loaderSelection[0] size as proxy for image size.
+    if (!loaderSelection || loaderSelection.length === 0) {
+      return { data: [], ...this.getRasterSize({ z }) };
+    }
+    const [image] = images;
+    const width = image.getWidth();
+    const height = image.getHeight();
+    return {
+      data,
+      width,
+      height
+    };
+  }
+
+  /**
+   * Returns image width and height (at pyramid level z) without fetching data.
+   * This information is inferrable from the provided metadata.
+   * It is NOT the actual pixel-size but rather the image size
+   * without any padding.
+   * This needs to be implemented by all classes inheriting this loader.
+   * @param {Object} args
+   * @param {number} args.z positive integer (0 === highest zoom level)
+   * @returns {Object} width: number, height: number
+   */
+  // eslint-disable-next-line class-methods-use-this,no-unused-vars,no-empty-function
+  getRasterSize({ z }) {}
+
+  /**
+   * Get the metadata associated with an OMETiff image layer, in a human-readable format.
+   * This needs to be implemented by all classes inheriting this loader.
+   * @returns {Object} Metadata keys mapped to values.
+   */
+  // eslint-disable-next-line class-methods-use-this,no-unused-vars,no-empty-function
+  getMetadata() {}
+
+  async _getChannel({ image, x, y, z, signal }) {
+    const { tileSize, pool, isInterleaved: interleave } = this;
+    const { height, width } = this._getTileExtent({
+      x,
+      y,
+      z
+    });
+    // Passing in the height and width explicitly prevents resampling that geotiff does without such parameters.
+    const rasters = await image.readRasters({
+      window: [
+        x * tileSize,
+        y * tileSize,
+        x * tileSize + width,
+        y * tileSize + height
+      ],
+      pool,
+      signal,
+      width,
+      height,
+      interleave
+    });
+    const data = interleave ? rasters : rasters[0];
+    if (signal?.aborted) return null;
+    return data;
+  }
+
+  _tileInBounds({ x, y, z }) {
+    const { tileSize, numLevels } = this;
+    const { width, height } = this.getRasterSize({ z: 0 });
+    return isInTileBounds({
+      x,
+      y,
+      z,
+      width,
+      height,
+      tileSize,
+      numLevels
+    });
+  }
+
+  _parseIFD(index) {
+    const { tiff, offsets } = this;
+    if (offsets.length > 0) {
+      tiff.ifdRequests[index] = tiff.parseFileDirectoryAt(offsets[index]);
+    }
+  }
+
+  /**
+   * For a given resolution level, z, the expected tile size on the boundary
+   * of the image should be exactly enough to fit the image bounds at the resolution level.
+   * This function returns that size or the parametrized tileSize from TIFF file.
+   * @param {tileData: TypedArray[]} data The array to be filled in.
+   * @param {Object} tile { x, y, z }
+   * @returns {TypedArray} TypedArray
+   */
+  _getTileExtent({ x, y, z }) {
+    const { tileSize } = this;
+    let height = tileSize;
+    let width = tileSize;
+    const {
+      height: zoomLevelHeight,
+      width: zoomLevelWidth
+    } = this.getRasterSize({ z });
+    const maxXTileCoord = Math.floor(zoomLevelWidth / tileSize);
+    const maxYTileCoord = Math.floor(zoomLevelHeight / tileSize);
+    if (x === maxXTileCoord) {
+      width = zoomLevelWidth % tileSize;
+    }
+    if (y === maxYTileCoord) {
+      height = zoomLevelHeight % tileSize;
+    }
+    return { height, width };
+  }
+}

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -3,6 +3,7 @@ import { fromBlob, fromUrl } from 'geotiff';
 import Pool from './Pool';
 import ZarrLoader from './zarrLoader';
 import OMETiffLoader from './OMETiffLoader';
+import TiffLoader from './TiffLoader';
 import { getChannelStats, getJson, dimensionsFromOMEXML } from './utils';
 import OMEXML from './omeXML';
 import FileStore from './fileStore';
@@ -214,4 +215,4 @@ export async function createOMETiffLoader({
   });
 }
 
-export { ZarrLoader, OMETiffLoader, getChannelStats };
+export { ZarrLoader, OMETiffLoader, TiffLoader, getChannelStats };

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -190,6 +190,16 @@ export async function createOMETiffLoader({
     int32: '<u4'
   };
   const dtype = DTYPE_LOOKUP[metadata.Type];
+  const physicalSizes = {
+    x: {
+      value: metadata.PhysicalSizeX,
+      unit: metadata.PhysicalSizeXUnit
+    },
+    y: {
+      value: metadata.PhysicalSizeY,
+      unit: metadata.PhysicalSizeYUnit
+    }
+  };
   return new OMETiffLoader({
     tiff,
     pool,
@@ -199,7 +209,8 @@ export async function createOMETiffLoader({
     metadata,
     isRgb,
     isInterleaved,
-    dtype
+    dtype,
+    physicalSizes
   });
 }
 

--- a/tests/loaders/OMETiffLoader.spec.js
+++ b/tests/loaders/OMETiffLoader.spec.js
@@ -2,47 +2,44 @@ import test from 'tape';
 import { fromFile } from 'geotiff';
 
 import OMETiffLoader from '../../src/loaders/OMETiffLoader';
-
-test('OME-TIFF Properties', async t => {
-  t.plan(4);
-  try {
-    const tiff = await fromFile('tests/loaders/fixtures/multi-channel.ome.tif');
-    const firstImage = await tiff.getImage();
-    const { ImageDescription: omexmlString } = firstImage.fileDirectory;
-    const loader = new OMETiffLoader({
-      tiff,
-      pool: { decode: () => new Promise([]) },
-      firstImage,
-      omexmlString,
-      offsets: [8, 2712, 4394]
-    });
-    const { width, height, isPyramid, offsets } = loader;
-    t.equal(width, 439);
-    t.equal(height, 167);
-    t.equal(isPyramid, false);
-    t.deepEqual(offsets, [8, 2712, 4394]);
-    t.end();
-  } catch (e) {
-    t.fail(e);
-  }
-});
+import OMEXML from '../../src/loaders/omeXML';
+import { dimensionsFromOMEXML } from '../../src/loaders/utils';
 
 test('OME-TIFF Selection', async t => {
-  t.plan(1);
+  t.plan(2);
   try {
     const tiff = await fromFile('tests/loaders/fixtures/multi-channel.ome.tif');
     const firstImage = await tiff.getImage();
     const { ImageDescription: omexmlString } = firstImage.fileDirectory;
+    const metadata = new OMEXML(omexmlString);
+    const dimensions = dimensionsFromOMEXML(metadata);
+    const physicalSizes = {
+      x: {
+        value: metadata.PhysicalSizeX,
+        unit: metadata.PhysicalSizeXUnit
+      },
+      y: {
+        value: metadata.PhysicalSizeY,
+        unit: metadata.PhysicalSizeYUnit
+      }
+    };
     const loader = new OMETiffLoader({
       tiff,
       pool: { decode: () => new Promise([]) },
       firstImage,
-      omexmlString,
-      offsets: [8, 2712, 4394]
+      metadata,
+      offsets: [8, 2712, 4394],
+      dimensions,
+      physicalSizes,
+      dtype: '<u1'
     });
     const selection = loader._getIFDIndex({ channel: 1 });
 
     t.deepEqual(selection, 1);
+
+    const [image] = await loader.getImages([{ channel: 0 }]);
+    // First image has the omexml string, in theory.
+    t.equal(image.fileDirectory.ImageDescription, omexmlString);
     t.end();
   } catch (e) {
     t.fail(e);


### PR DESCRIPTION
Fixes #312.

This is a first step towards a few things related to the discussion in #325:
1. **Having a standardized tiff interface**: The new base Tiff loader only uses "standard" methods and attributes, like `dimensions` and `getRasterSize`, and the OMETiffLoader only uses `metadata` for metadata-relevant things, like resolving size or formatting the metadata.  There is no `omexml` just a generic `metadata`
2. **An ImageJ TIFF loader**: This seems like an easy win using the above as a base - now this loader only needs to implement its "indexing" method in `getImages` and its raster size in `getRasterSize`.
3. **Standardizing Loader**:  Related to the first point, because the `TiffLoader` is much cleaned up, we should be able to create a base loader now.