### PR TITLE
Fix Opacity Calculation for YCbCr Images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Fix opacity with photometric interpretations.
+
 ## 0.8.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Property `onViewStateChange` of all viewers accepts a callback for deck.gl view state changes.
 - Add a click handler to the overview that centers the detail view on the click position. The handler can be turned off by setting the `PictureInPictureViewer` property `clickCenter` to `false`.
+- Support interleaved RGB OME-TIFF files.
 
 ### Changed
 
@@ -25,7 +26,6 @@
 ### Added
 
 - Export a `getDefaultInitialViewState` function for getting a default initial view state given a loader and desired size of view.
-- Support interleaved RGB OME-TIFF files.
 - Added a README file for Avivator at `avivator/README.md`.
 
 ### Changed

--- a/src/layers/BitmapLayer.js
+++ b/src/layers/BitmapLayer.js
@@ -74,7 +74,6 @@ const getTransparentColor = photometricInterpretation => {
 };
 
 class BitmapLayerWrapper extends BaseBitmapLayer {
-
   _getModel(gl) {
     const { photometricInterpretation } = this.props;
     // This is a port to the GPU of a subset of https://github.com/geotiffjs/geotiff.js/blob/master/src/rgb.js
@@ -116,7 +115,7 @@ export default class BitmapLayer extends CompositeLayer {
     // See: https://github.com/visgl/deck.gl/pull/5197
     gl.pixelStorei(GL.UNPACK_ALIGNMENT, 1);
     gl.pixelStorei(GL.PACK_ALIGNMENT, 1);
-    super.initializeState(args)
+    super.initializeState(args);
   }
 
   renderLayers() {

--- a/src/layers/BitmapLayer.js
+++ b/src/layers/BitmapLayer.js
@@ -1,5 +1,6 @@
+// eslint-disable-next-line max-classes-per-file
 import { BitmapLayer as BaseBitmapLayer } from '@deck.gl/layers';
-import { COORDINATE_SYSTEM } from '@deck.gl/core';
+import { COORDINATE_SYSTEM, CompositeLayer } from '@deck.gl/core';
 import { Model, Geometry } from '@luma.gl/core';
 import GL from '@luma.gl/constants';
 
@@ -16,6 +17,7 @@ const PHOTOMETRIC_INTERPRETATIONS = {
 };
 
 const defaultProps = {
+  ...BaseBitmapLayer.defaultProps,
   pickable: true,
   coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
   bounds: { type: 'array', value: [0, 0, 1, 1], compare: true },
@@ -53,7 +55,25 @@ const getPhotometricInterpretationShader = photometricInterpretation => {
   }
 };
 
-export default class BitmapLayer extends BaseBitmapLayer {
+const getTransparentColor = photometricInterpretation => {
+  switch (photometricInterpretation) {
+    case PHOTOMETRIC_INTERPRETATIONS.RGB:
+      return [0, 0, 0, 0];
+    case PHOTOMETRIC_INTERPRETATIONS.WhiteIsZero:
+      return [255, 255, 255, 0];
+    case PHOTOMETRIC_INTERPRETATIONS.BlackIsZero:
+      return [0, 0, 0, 0];
+    case PHOTOMETRIC_INTERPRETATIONS.YCbCr:
+      return [16, 128, 128, 0];
+    default:
+      console.error(
+        'Unsupported photometric interpretation or none provided.  No transformation will be done to image data'
+      );
+      return [0, 0, 0, 0];
+  }
+};
+
+class BitmapLayerWrapper extends BaseBitmapLayer {
   _getModel(gl) {
     const { photometricInterpretation } = this.props;
     // This is a port to the GPU of a subset of https://github.com/geotiffjs/geotiff.js/blob/master/src/rgb.js
@@ -90,8 +110,19 @@ export default class BitmapLayer extends BaseBitmapLayer {
     });
   }
 }
+export default class BitmapLayer extends CompositeLayer {
+  renderLayers() {
+    const { photometricInterpretation } = this.props;
+    const transparentColor = getTransparentColor(photometricInterpretation);
+    return new BitmapLayerWrapper(this.props, {
+      transparentColor,
+      id: `${this.props.id}-wrapped`
+    });
+  }
+}
 
 BitmapLayer.layerName = 'BitmapLayer';
 // From https://github.com/geotiffjs/geotiff.js/blob/8ef472f41b51d18074aece2300b6a8ad91a21ae1/src/globals.js#L202-L213
 BitmapLayer.PHOTOMETRIC_INTERPRETATIONS = PHOTOMETRIC_INTERPRETATIONS;
 BitmapLayer.defaultProps = defaultProps;
+BitmapLayerWrapper.defaultProps = defaultProps;

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -169,9 +169,9 @@ export default class MultiscaleImageLayer extends CompositeLayer {
         id: `Background-Image-${id}`,
         modelMatrix: layerModelMatrix.scale(2 ** (numLevels - 1)),
         visible:
-          opacity === 1 ||
-          (-numLevels > this.context.viewport.zoom &&
-            (!viewportId || this.context.viewport.id === viewportId)),
+          opacity === 1 &&
+          -numLevels > this.context.viewport.zoom &&
+            (!viewportId || this.context.viewport.id === viewportId),
         z: numLevels - 1,
         pickable: true,
         onHover,


### PR DESCRIPTION
This came up with @nhpatterson but because deck.gl does all their operations before the hook, we need to explicitly pass in a `transparentColor` in the native color space of the data.  `[16, 128, 128]` is black (`[0, 0, 0, 0]`) in that space.  In other words, they apply opacity in the YCbCr space and then we apply the transformation to the RGB space, so the `transparentColor` which is usually `[0,0,0,0]` needs to be converted ahead of time into YCbCr space.

Here is the relevant code in deck.gl:
https://github.com/visgl/deck.gl/blob/09a4bbf2041f77af18f3d54904c366f22e501f9e/modules/layers/src/bitmap-layer/bitmap-layer-fragment.js#L80-L83

To test this out without loading it into Vitessce, you can change the `opacity` prop here:
https://github.com/hms-dbmi/viv/blob/a177a0eecd4041306b3b7bf9c3ae9dd948838b0a/src/views/DetailView.js#L20-L22