### PR TITLE
Fix Background Image Opacity Issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Fix opacity with photometric interpretations.
+- Only show background iamge when opacity is 1 and we are within the higher levels of the image pyramid.
 
 ## 0.8.1
 

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -170,7 +170,7 @@ export default class MultiscaleImageLayer extends CompositeLayer {
         modelMatrix: layerModelMatrix.scale(2 ** (numLevels - 1)),
         visible:
           opacity === 1 &&
-          -numLevels > this.context.viewport.zoom &&
+          -numLevels < this.context.viewport.zoom &&
             (!viewportId || this.context.viewport.id === viewportId),
         z: numLevels - 1,
         pickable: true,


### PR DESCRIPTION
Related to but separate from #338, we should not be showing the background image if we are zoomed out since if we are zoomed out, the opacities will blend producing an image with twice the opacity desired.