### PR TITLE
Fix minZoom Bug and Simplify Opacity Conidition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 ### Changed
 
 - Fix opacity with photometric interpretations.
-- Only show background image when opacity is 1 (and viewport is correct).
-- Fix `minZoom` calculation bug in `MultiscaleImageLayer`
+- Only show background image when opacity is 1 (and viewport id prop matches that of the current viewport).
+- Fix `minZoom` calculation bug in `MultiscaleImageLayer`.
 
 ## 0.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Changed
 
 - Fix opacity with photometric interpretations.
-- Only show background image when opacity is 1 and we are within the higher levels of the image pyramid.
+- Only show background image when opacity is 1 (and viewport is correct).
+- Fix `minZoom` calculation bug in `MultiscaleImageLayer`
 
 ## 0.8.1
 

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -128,7 +128,7 @@ export default class MultiscaleImageLayer extends CompositeLayer {
       tileSize,
       onClick,
       extent: [0, 0, width, height],
-      // See the above note within getTileData for why these are necessary.
+      // See the above note within getTileData for why the division with 512 and the rounding necessary.
       minZoom: Math.round(-(numLevels - 1) + Math.log2(512 / tileSize)),
       maxZoom: Math.min(0, Math.round(Math.log2(512 / tileSize))),
       colorValues,

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -128,7 +128,7 @@ export default class MultiscaleImageLayer extends CompositeLayer {
       tileSize,
       onClick,
       extent: [0, 0, width, height],
-      minZoom: -(numLevels - 1),
+      minZoom: Math.round(-(numLevels - 1) + Math.log2(512 / tileSize)),
       maxZoom: Math.min(0, Math.round(Math.log2(512 / tileSize))),
       colorValues,
       sliderValues,
@@ -170,8 +170,7 @@ export default class MultiscaleImageLayer extends CompositeLayer {
         modelMatrix: layerModelMatrix.scale(2 ** (numLevels - 1)),
         visible:
           opacity === 1 &&
-          -numLevels < this.context.viewport.zoom &&
-            (!viewportId || this.context.viewport.id === viewportId),
+          (!viewportId || this.context.viewport.id === viewportId),
         z: numLevels - 1,
         pickable: true,
         onHover,

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -128,6 +128,7 @@ export default class MultiscaleImageLayer extends CompositeLayer {
       tileSize,
       onClick,
       extent: [0, 0, width, height],
+      // See the above note within getTileData for why these are necessary.
       minZoom: Math.round(-(numLevels - 1) + Math.log2(512 / tileSize)),
       maxZoom: Math.min(0, Math.round(Math.log2(512 / tileSize))),
       colorValues,


### PR DESCRIPTION
#339 revealed a bug in our `minZoom` calculation.  It should be transformed [just like `maxZoom`](https://github.com/hms-dbmi/viv/blob/master/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js#L132) and our [tile fetching zoom level](https://github.com/hms-dbmi/viv/blob/master/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js#L104) to account for deck.gl's zoom level calculation [by tile size](https://github.com/hms-dbmi/viv/blob/9b02611363c0cc20732190e77a4cec12ef0502db/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js#L98-L103).  Also, I think the visibility condition can be simplified further - no reason not to just show the image always when opacity is 1.  This makes things clearer.