### PR TITLE
Transparent Color Prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## In Progress
 
 ### Added
+
 - Issue templates for Github.
+- Add `transparentColor` and `useTransparentColor` to allow the deck.gl to set a color to be "transparent."
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Issue templates for Github.
-- Add `transparentColor` and `useTransparentColor` to allow the deck.gl to set a color to be "transparent."
+- Add `transparentColor` and `useTransparentColor` to allow the layer to set a color to be "transparent" (or use the automatically calculated one when colormaps are set).
 
 ### Changed
 

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -57,7 +57,7 @@ const defaultProps = {
  * @param {array} props.transparentColor A color to be considered "transparent" when useTransparentColor is true.
  * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
  * This parameter is ignored when using colormaps because each colormap has its own transparent color that is calculated on the shader (default is [0, 0, 0, 0]).
- * @param {boolean} props.useTransparentColor Whether or nor to use the transparentColor prop (or the automatically calculated transparent color when)
+ * @param {boolean} props.useTransparentColor Whether or nor to use the transparentColor prop or the automatically calculated transparent color when
  * colormap is set (default is false).
  */
 export default class ImageLayer extends CompositeLayer {

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -56,6 +56,7 @@ const defaultProps = {
  * @param {number} props.modelMatrix Math.gl Matrix4 object containing an affine transformation to be applied to the image.
  * @param {number} props.transparentColor A color to be considered "transparent" when useTransparentColor is true.
  * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
+ * This parameter is ignored when using colormaps (because each colormap has its own transparent color that is calculated on the shader).
  * @param {number} props.useTransparentColor Math.gl Matrix4 object containing an affine transformation to be applied to the image.
  */
 export default class ImageLayer extends CompositeLayer {

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -46,18 +46,19 @@ const defaultProps = {
  * @param {Array} props.domain Override for the possible max/min values (i.e something different than 65535 for uint16/'<u2').
  * @param {string} props.viewportId Id for the current view.  This needs to match the viewState id in deck.gl and is necessary for the lens.
  * @param {Object} props.loader Loader to be used for fetching data.  It must implement/return `getRaster` and `dtype`.
- * @param {String} props.onHover Hook function from deck.gl to handle hover objects.
+ * @param {function} props.onHover Hook function from deck.gl to handle hover objects.
  * @param {boolean} props.isLensOn Whether or not to use the lens.
  * @param {number} props.lensSelection Numeric index of the channel to be focused on by the lens.
  * @param {number} props.lensRadius Pixel radius of the lens (default: 100).
- * @param {number} props.lensBorderColor RGB color of the border of the lens.
+ * @param {Array} props.lensBorderColor RGB color of the border of the lens.
  * @param {number} props.lensBorderRadius Percentage of the radius of the lens for a border (default 0.02).
- * @param {number} props.onClick Hook function from deck.gl to handle clicked-on objects.
- * @param {number} props.modelMatrix Math.gl Matrix4 object containing an affine transformation to be applied to the image.
- * @param {number} props.transparentColor A color to be considered "transparent" when useTransparentColor is true.
+ * @param {function} props.onClick Hook function from deck.gl to handle clicked-on objects.
+ * @param {Object} props.modelMatrix Math.gl Matrix4 object containing an affine transformation to be applied to the image.
+ * @param {array} props.transparentColor A color to be considered "transparent" when useTransparentColor is true.
  * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
- * This parameter is ignored when using colormaps (because each colormap has its own transparent color that is calculated on the shader).
- * @param {number} props.useTransparentColor Math.gl Matrix4 object containing an affine transformation to be applied to the image.
+ * This parameter is ignored when using colormaps because each colormap has its own transparent color that is calculated on the shader (default is [0, 0, 0, 0]).
+ * @param {boolean} props.useTransparentColor Whether or nor to use the transparentColor prop (or the automatically calculated transparent color when)
+ * colormap is set (default is false).
  */
 export default class ImageLayer extends CompositeLayer {
   initializeState() {

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -30,7 +30,9 @@ const defaultProps = {
   lensRadius: { type: 'number', value: 100, compare: true },
   lensBorderColor: { type: 'array', value: [255, 255, 255], compare: true },
   lensBorderRadius: { type: 'number', value: 0.02, compare: true },
-  onClick: { type: 'function', value: null, compare: true }
+  onClick: { type: 'function', value: null, compare: true },
+  transparentColor: { type: 'array', value: [0, 0, 0, 0], compare: true },
+  useTransparentColor: { type: 'boolean', value: false, compare: true }
 };
 
 /**
@@ -52,6 +54,9 @@ const defaultProps = {
  * @param {number} props.lensBorderRadius Percentage of the radius of the lens for a border (default 0.02).
  * @param {number} props.onClick Hook function from deck.gl to handle clicked-on objects.
  * @param {number} props.modelMatrix Math.gl Matrix4 object containing an affine transformation to be applied to the image.
+ * @param {number} props.transparentColor A color to be considered "transparent" when useTransparentColor is true.
+ * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
+ * @param {number} props.useTransparentColor Math.gl Matrix4 object containing an affine transformation to be applied to the image.
  */
 export default class ImageLayer extends CompositeLayer {
   initializeState() {
@@ -129,7 +134,9 @@ export default class ImageLayer extends CompositeLayer {
       id,
       onClick,
       onHover,
-      modelMatrix
+      modelMatrix,
+      transparentColor,
+      useTransparentColor
     } = this.props;
     const { dtype } = loader;
     const { width, height, data, unprojectLensBounds } = this.state;
@@ -172,7 +179,9 @@ export default class ImageLayer extends CompositeLayer {
       onClick,
       modelMatrix,
       opacity,
-      visible
+      visible,
+      transparentColor,
+      useTransparentColor
     });
   }
 }

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -31,8 +31,7 @@ const defaultProps = {
   lensBorderColor: { type: 'array', value: [255, 255, 255], compare: true },
   lensBorderRadius: { type: 'number', value: 0.02, compare: true },
   onClick: { type: 'function', value: null, compare: true },
-  transparentColor: { type: 'array', value: [0, 0, 0, 0], compare: true },
-  useTransparentColor: { type: 'boolean', value: false, compare: true }
+  transparentColor: { type: 'array', value: null, compare: true }
 };
 
 /**
@@ -54,11 +53,10 @@ const defaultProps = {
  * @param {number} props.lensBorderRadius Percentage of the radius of the lens for a border (default 0.02).
  * @param {function} props.onClick Hook function from deck.gl to handle clicked-on objects.
  * @param {Object} props.modelMatrix Math.gl Matrix4 object containing an affine transformation to be applied to the image.
- * @param {array} props.transparentColor A color to be considered "transparent" when useTransparentColor is true.
- * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
- * This parameter is ignored when using colormaps because each colormap has its own transparent color that is calculated on the shader (default is [0, 0, 0, 0]).
- * @param {boolean} props.useTransparentColor Whether or nor to use the transparentColor prop or the automatically calculated transparent color when
- * colormap is set (default is false).
+ * @param {Array} props.transparentColor An RGB (0-255 range) color to be considered "transparent" if provided.
+ * In other words, any fragment shader output equal transparentColor (before applying opacity) will have opacity 0.
+ * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
+ * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  */
 export default class ImageLayer extends CompositeLayer {
   initializeState() {
@@ -137,8 +135,7 @@ export default class ImageLayer extends CompositeLayer {
       onClick,
       onHover,
       modelMatrix,
-      transparentColor,
-      useTransparentColor
+      transparentColor
     } = this.props;
     const { dtype } = loader;
     const { width, height, data, unprojectLensBounds } = this.state;
@@ -182,8 +179,7 @@ export default class ImageLayer extends CompositeLayer {
       modelMatrix,
       opacity,
       visible,
-      transparentColor,
-      useTransparentColor
+      transparentColor
     });
   }
 }

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -25,7 +25,7 @@ const defaultProps = {
   maxRequests: { type: 'number', value: 10, compare: true },
   onClick: { type: 'function', value: null, compare: true },
   transparentColor: { type: 'array', value: [0, 0, 0, 0], compare: true },
-  useTransparentColor: { type: 'boolean', value: true, compare: true }
+  useTransparentColor: { type: 'boolean', value: false, compare: true }
 };
 
 /**
@@ -182,9 +182,9 @@ export default class MultiscaleImageLayer extends CompositeLayer {
         visible:
           opacity === 1 &&
           (!viewportId || this.context.viewport.id === viewportId) &&
-          // If we are using transparent color to be opacity 0, we shouldn't show the background image
+          // If we are using a transparent color, we shouldn't show the background image
           // since the background image might not have the same color output from the fragment shader
-          // as the tiled layer at a high resolution level.
+          // as the tiled layer at a higher resolution level.
           !useTransparentColor,
         z: numLevels - 1,
         pickable: true,

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -25,7 +25,7 @@ const defaultProps = {
   maxRequests: { type: 'number', value: 10, compare: true },
   onClick: { type: 'function', value: null, compare: true },
   transparentColor: { type: 'array', value: [0, 0, 0, 0], compare: true },
-  useTransparentColor: { type: 'boolean', value: false, compare: true }
+  useTransparentColor: { type: 'boolean', value: true, compare: true }
 };
 
 /**
@@ -53,6 +53,7 @@ const defaultProps = {
  * @param {number} props.modelMatrix Math.gl Matrix4 object containing an affine transformation to be applied to the image.
  * @param {number} props.transparentColor A color to be considered "transparent" when useTransparentColor is true.
  * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
+ * This parameter is ignored when using colormaps (because each colormap has its own transparent color that is calculated on the shader).
  * @param {number} props.useTransparentColor Math.gl Matrix4 object containing an affine transformation to be applied to the image.
  */
 

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -54,7 +54,7 @@ const defaultProps = {
  * @param {Array} props.transparentColor A RGBA color to be considered "transparent" when useTransparentColor is true.
  * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
  * This parameter is ignored when using colormaps because each colormap has its own transparent color that is calculated on the shader (default is [0, 0, 0, 0]).
- * @param {boolean} props.useTransparentColor Whether or nor to use the transparentColor prop (or the automatically calculated transparent color when)
+ * @param {boolean} props.useTransparentColor Whether or nor to use the transparentColor prop or the automatically calculated transparent color when
  * colormap is set (default is false).
  */
 

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -24,8 +24,7 @@ const defaultProps = {
   lensBorderRadius: { type: 'number', value: 0.02, compare: true },
   maxRequests: { type: 'number', value: 10, compare: true },
   onClick: { type: 'function', value: null, compare: true },
-  transparentColor: { type: 'array', value: [0, 0, 0, 0], compare: true },
-  useTransparentColor: { type: 'boolean', value: false, compare: true }
+  transparentColor: { type: 'array', value: null, compare: true }
 };
 
 /**
@@ -51,11 +50,10 @@ const defaultProps = {
  * @param {number} props.maxRequests Maximum parallel ongoing requests allowed before aborting.
  * @param {function} props.onClick Hook function from deck.gl to handle clicked-on objects.
  * @param {Object} props.modelMatrix Math.gl Matrix4 object containing an affine transformation to be applied to the image.
- * @param {Array} props.transparentColor A RGBA color to be considered "transparent" when useTransparentColor is true.
- * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
- * This parameter is ignored when using colormaps because each colormap has its own transparent color that is calculated on the shader (default is [0, 0, 0, 0]).
- * @param {boolean} props.useTransparentColor Whether or nor to use the transparentColor prop or the automatically calculated transparent color when
- * colormap is set (default is false).
+ * @param {Array} props.transparentColor An RGB (0-255 range) color to be considered "transparent" if provided.
+ * In other words, any fragment shader output equal transparentColor (before applying opacity) will have opacity 0.
+ * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
+ * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  */
 
 export default class MultiscaleImageLayer extends CompositeLayer {
@@ -94,8 +92,7 @@ export default class MultiscaleImageLayer extends CompositeLayer {
       maxRequests,
       onClick,
       modelMatrix,
-      transparentColor,
-      useTransparentColor
+      transparentColor
     } = this.props;
     const { tileSize, numLevels, dtype, isInterleaved, isRgb } = loader;
     const { unprojectLensBounds } = this.state;
@@ -166,8 +163,7 @@ export default class MultiscaleImageLayer extends CompositeLayer {
       lensBorderColor,
       lensBorderRadius,
       modelMatrix,
-      transparentColor,
-      useTransparentColor
+      transparentColor
     });
     // This gives us a background image and also solves the current
     // minZoom funny business.  We don't use it for the background if we have an opacity
@@ -186,7 +182,7 @@ export default class MultiscaleImageLayer extends CompositeLayer {
           // If we are using a transparent color, we shouldn't show the background image
           // since the background image might not have the same color output from the fragment shader
           // as the tiled layer at a higher resolution level.
-          !useTransparentColor,
+          !transparentColor,
         z: numLevels - 1,
         pickable: true,
         onHover,

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -41,20 +41,21 @@ const defaultProps = {
  * @param {Object} props.loader Loader to be used for fetching data.  It must implement/return `getTile`, `dtype`, `numLevels`, and `tileSize`, and `getRaster`.
  * @param {Array} props.loaderSelection Selection to be used for fetching data.
  * @param {String} props.id Unique identifier for this layer.
- * @param {String} props.onTileError Custom override for handle tile fetching errors.
- * @param {String} props.onHover Hook function from deck.gl to handle hover objects.
+ * @param {function} props.onTileError Custom override for handle tile fetching errors.
+ * @param {function} props.onHover Hook function from deck.gl to handle hover objects.
  * @param {boolean} props.isLensOn Whether or not to use the lens.
  * @param {number} props.lensSelection Numeric index of the channel to be focused on by the lens.
  * @param {number} props.lensRadius Pixel radius of the lens (default: 100).
- * @param {number} props.lensBorderColor RGB color of the border of the lens (default [255, 255, 255]).
+ * @param {Array} props.lensBorderColor RGB color of the border of the lens (default [255, 255, 255]).
  * @param {number} props.lensBorderRadius Percentage of the radius of the lens for a border (default 0.02).
  * @param {number} props.maxRequests Maximum parallel ongoing requests allowed before aborting.
- * @param {number} props.onClick Hook function from deck.gl to handle clicked-on objects.
- * @param {number} props.modelMatrix Math.gl Matrix4 object containing an affine transformation to be applied to the image.
- * @param {number} props.transparentColor A color to be considered "transparent" when useTransparentColor is true.
+ * @param {function} props.onClick Hook function from deck.gl to handle clicked-on objects.
+ * @param {Object} props.modelMatrix Math.gl Matrix4 object containing an affine transformation to be applied to the image.
+ * @param {Array} props.transparentColor A RGBA color to be considered "transparent" when useTransparentColor is true.
  * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
- * This parameter is ignored when using colormaps (because each colormap has its own transparent color that is calculated on the shader).
- * @param {number} props.useTransparentColor Math.gl Matrix4 object containing an affine transformation to be applied to the image.
+ * This parameter is ignored when using colormaps because each colormap has its own transparent color that is calculated on the shader (default is [0, 0, 0, 0]).
+ * @param {boolean} props.useTransparentColor Whether or nor to use the transparentColor prop (or the automatically calculated transparent color when)
+ * colormap is set (default is false).
  */
 
 export default class MultiscaleImageLayer extends CompositeLayer {

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayerBase.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayerBase.js
@@ -21,7 +21,9 @@ const defaultProps = {
   lensSelection: { type: 'number', value: 0, compare: true },
   lensRadius: { type: 'number', value: 100, compare: true },
   lensBorderColor: { type: 'array', value: [255, 255, 255], compare: true },
-  lensBorderRadius: { type: 'number', value: 0.02, compare: true }
+  lensBorderRadius: { type: 'number', value: 0.02, compare: true },
+  transparentColor: { type: 'array', value: [0, 0, 0, 0], compare: true },
+  useTransparentColor: { type: 'boolean', value: false, compare: true }
 };
 
 /**

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayerBase.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayerBase.js
@@ -22,8 +22,7 @@ const defaultProps = {
   lensRadius: { type: 'number', value: 100, compare: true },
   lensBorderColor: { type: 'array', value: [255, 255, 255], compare: true },
   lensBorderRadius: { type: 'number', value: 0.02, compare: true },
-  transparentColor: { type: 'array', value: [0, 0, 0, 0], compare: true },
-  useTransparentColor: { type: 'boolean', value: false, compare: true }
+  transparentColor: { type: 'array', value: null, compare: true }
 };
 
 /**

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -49,8 +49,7 @@ const defaultProps = {
   lensBorderColor: { type: 'array', value: [255, 255, 255], compare: true },
   lensBorderRadius: { type: 'number', value: 0.02, compare: true },
   unprojectLensBounds: { type: 'array', value: [0, 0, 0, 0], compare: true },
-  transparentColor: { type: 'array', value: [0, 0, 0, 0], compare: true },
-  useTransparentColor: { type: 'boolean', value: false, compare: true }
+  transparentColor: { type: 'array', value: null, compare: true }
 };
 
 /**
@@ -214,8 +213,7 @@ export default class XRLayer extends Layer {
         lensSelection,
         lensBorderColor,
         lensBorderRadius,
-        transparentColor,
-        useTransparentColor
+        transparentColor
       } = this.props;
       // Check number of textures not null.
       const numTextures = Object.values(textures).filter(t => t).length;
@@ -258,8 +256,8 @@ export default class XRLayer extends Layer {
           lensSelection,
           lensBorderColor,
           lensBorderRadius,
-          transparentColor,
-          useTransparentColor,
+          transparentColor: (transparentColor || [0, 0, 0]).map(i => i / 255),
+          useTransparentColor: Boolean(transparentColor),
           ...textures
         })
         .draw();

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -48,7 +48,9 @@ const defaultProps = {
   lensSelection: { type: 'number', value: 0, compare: true },
   lensBorderColor: { type: 'array', value: [255, 255, 255], compare: true },
   lensBorderRadius: { type: 'number', value: 0.02, compare: true },
-  unprojectLensBounds: { type: 'array', value: [0, 0, 0, 0], compare: true }
+  unprojectLensBounds: { type: 'array', value: [0, 0, 0, 0], compare: true },
+  transparentColor: { type: 'array', value: [0, 0, 0, 0], compare: true },
+  useTransparentColor: { type: 'boolean', value: false, compare: true }
 };
 
 /**
@@ -211,7 +213,9 @@ export default class XRLayer extends Layer {
         isLensOn,
         lensSelection,
         lensBorderColor,
-        lensBorderRadius
+        lensBorderRadius,
+        transparentColor,
+        useTransparentColor
       } = this.props;
       // Check number of textures not null.
       const numTextures = Object.values(textures).filter(t => t).length;
@@ -254,6 +258,8 @@ export default class XRLayer extends Layer {
           lensSelection,
           lensBorderColor,
           lensBorderRadius,
+          transparentColor,
+          useTransparentColor,
           ...textures
         })
         .draw();

--- a/src/layers/XRLayer/shader-modules/channel-intensity.glsl
+++ b/src/layers/XRLayer/shader-modules/channel-intensity.glsl
@@ -90,6 +90,10 @@ vec3 process_channel_intensity(float intensity, vec3 colorValues, int channelInd
   return hsv_to_rgb(hsvCombo);
 }
 
+vec4 apply_transparency(vec3 color, bool useTransparentColor, vec4 transparentColor, float opacity){
+  return vec4(color, (color == transparentColor.rgb && useTransparentColor) ? 0.0 : opacity);
+}
+
 vec4 colormap(float intensity, float opacity) {
   return vec4(COLORMAP_FUNCTION(min(1.0,intensity)).xyz, opacity);
 }

--- a/src/layers/XRLayer/shader-modules/channel-intensity.glsl
+++ b/src/layers/XRLayer/shader-modules/channel-intensity.glsl
@@ -90,10 +90,10 @@ vec3 process_channel_intensity(float intensity, vec3 colorValues, int channelInd
   return hsv_to_rgb(hsvCombo);
 }
 
-vec4 apply_opacity(vec3 color, bool useTransparentColor, vec4 transparentColor, float opacity){
-  return vec4(color, (color == transparentColor.rgb && useTransparentColor) ? 0.0 : opacity);
+vec4 apply_opacity(vec3 color, bool useTransparentColor, vec3 transparentColor, float opacity){
+  return vec4(color, (color == transparentColor && useTransparentColor) ? 0.0 : opacity);
 }
 
 vec4 colormap(float intensity, float opacity, bool useTransparentColor) {
-  return apply_opacity(COLORMAP_FUNCTION(min(1.0,intensity)).xyz, useTransparentColor, COLORMAP_FUNCTION(0.0), opacity);
+  return apply_opacity(COLORMAP_FUNCTION(min(1.0,intensity)).xyz, useTransparentColor, COLORMAP_FUNCTION(0.0).xyz, opacity);
 }

--- a/src/layers/XRLayer/shader-modules/channel-intensity.glsl
+++ b/src/layers/XRLayer/shader-modules/channel-intensity.glsl
@@ -94,6 +94,6 @@ vec4 apply_transparency(vec3 color, bool useTransparentColor, vec4 transparentCo
   return vec4(color, (color == transparentColor.rgb && useTransparentColor) ? 0.0 : opacity);
 }
 
-vec4 colormap(float intensity, float opacity) {
-  return vec4(COLORMAP_FUNCTION(min(1.0,intensity)).xyz, opacity);
+vec4 colormap(float intensity, float opacity, bool useTransparentColor) {
+  return apply_transparency(COLORMAP_FUNCTION(min(1.0,intensity)).xyz, useTransparentColor, COLORMAP_FUNCTION(0.0), opacity);
 }

--- a/src/layers/XRLayer/shader-modules/channel-intensity.glsl
+++ b/src/layers/XRLayer/shader-modules/channel-intensity.glsl
@@ -90,10 +90,10 @@ vec3 process_channel_intensity(float intensity, vec3 colorValues, int channelInd
   return hsv_to_rgb(hsvCombo);
 }
 
-vec4 apply_transparency(vec3 color, bool useTransparentColor, vec4 transparentColor, float opacity){
+vec4 apply_opacity(vec3 color, bool useTransparentColor, vec4 transparentColor, float opacity){
   return vec4(color, (color == transparentColor.rgb && useTransparentColor) ? 0.0 : opacity);
 }
 
 vec4 colormap(float intensity, float opacity, bool useTransparentColor) {
-  return apply_transparency(COLORMAP_FUNCTION(min(1.0,intensity)).xyz, useTransparentColor, COLORMAP_FUNCTION(0.0), opacity);
+  return apply_opacity(COLORMAP_FUNCTION(min(1.0,intensity)).xyz, useTransparentColor, COLORMAP_FUNCTION(0.0), opacity);
 }

--- a/src/layers/XRLayer/xr-layer-fragment-colormap.webgl1.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment-colormap.webgl1.glsl
@@ -17,6 +17,9 @@ uniform vec2 sliderValues[6];
 uniform float opacity;
 uniform float divisor;
 
+// uniforms for making a transparent color.
+uniform bool useTransparentColor;
+
 varying vec2 vTexCoord;
 
 
@@ -37,7 +40,7 @@ void main() {
   intensityCombo += max(0.0,intensityValue4);
   intensityCombo += max(0.0,intensityValue5);
 
-  gl_FragColor = colormap(intensityCombo, opacity);
+  gl_FragColor = colormap(intensityCombo, opacity, useTransparentColor);
   geometry.uv = vTexCoord;
   DECKGL_FILTER_COLOR(gl_FragColor, geometry);
 }

--- a/src/layers/XRLayer/xr-layer-fragment-colormap.webgl2.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment-colormap.webgl2.glsl
@@ -18,6 +18,9 @@ uniform vec2 sliderValues[6];
 // opacity
 uniform float opacity;
 
+// uniforms for making a transparent color.
+uniform bool useTransparentColor;
+
 in vec2 vTexCoord;
 
 out vec4 color;
@@ -37,7 +40,7 @@ void main() {
   for(int i = 0; i < 6; i++) {
     intensityCombo += max(0.0,intensityArray[i]);
   }
-  color = colormap(intensityCombo, opacity);
+  color = colormap(intensityCombo, opacity, useTransparentColor);
   geometry.uv = vTexCoord;
   DECKGL_FILTER_COLOR(color, geometry);
 }

--- a/src/layers/XRLayer/xr-layer-fragment.webgl1.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment.webgl1.glsl
@@ -61,7 +61,7 @@ void main() {
 
   // Ternaries are faster than checking this first and then returning/breaking out of shader.
   rgbCombo = (isLensOn && isFragOnLensBounds) ? lensBorderColor : rgbCombo;
-  gl_FragColor = apply_transparency(rgbCombo, useTransparentColor, transparentColor, opacity);
+  gl_FragColor = apply_opacity(rgbCombo, useTransparentColor, transparentColor, opacity);
   geometry.uv = vTexCoord;
   DECKGL_FILTER_COLOR(gl_FragColor, geometry);
 }

--- a/src/layers/XRLayer/xr-layer-fragment.webgl1.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment.webgl1.glsl
@@ -30,9 +30,9 @@ uniform int lensSelection;
 uniform vec3 lensBorderColor;
 uniform float lensBorderRadius;
 
-// uniforms for making a transparent color.
+// uniform for making a transparent color.
+uniform vec3 transparentColor;
 uniform bool useTransparentColor;
-uniform vec4 transparentColor;
 
 varying vec2 vTexCoord;
 

--- a/src/layers/XRLayer/xr-layer-fragment.webgl1.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment.webgl1.glsl
@@ -30,6 +30,10 @@ uniform int lensSelection;
 uniform vec3 lensBorderColor;
 uniform float lensBorderRadius;
 
+// uniforms for making a transparent color.
+uniform bool useTransparentColor;
+uniform vec4 transparentColor;
+
 varying vec2 vTexCoord;
 
 void main() {
@@ -57,8 +61,7 @@ void main() {
 
   // Ternaries are faster than checking this first and then returning/breaking out of shader.
   rgbCombo = (isLensOn && isFragOnLensBounds) ? lensBorderColor : rgbCombo;
-
-  gl_FragColor = vec4(rgbCombo, opacity);
+  gl_FragColor = apply_transparency(rgbCombo, useTransparentColor, transparentColor, opacity);
   geometry.uv = vTexCoord;
   DECKGL_FILTER_COLOR(gl_FragColor, geometry);
 }

--- a/src/layers/XRLayer/xr-layer-fragment.webgl2.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment.webgl2.glsl
@@ -66,7 +66,7 @@ void main() {
 
   // Ternaries are faster than checking this first and then returning/breaking out of shader.
   rgbCombo = (isLensOn && isFragOnLensBounds) ? lensBorderColor : rgbCombo;
-  color = apply_transparency(rgbCombo, useTransparentColor, transparentColor, opacity);
+  color = apply_opacity(rgbCombo, useTransparentColor, transparentColor, opacity);
   geometry.uv = vTexCoord;
   DECKGL_FILTER_COLOR(color, geometry);
 }

--- a/src/layers/XRLayer/xr-layer-fragment.webgl2.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment.webgl2.glsl
@@ -32,6 +32,9 @@ uniform int lensSelection;
 uniform vec3 lensBorderColor;
 uniform float lensBorderRadius;
 
+// uniforms for making a transparent color.
+uniform bool useTransparentColor;
+uniform vec4 transparentColor;
 
 in vec2 vTexCoord;
 
@@ -63,8 +66,7 @@ void main() {
 
   // Ternaries are faster than checking this first and then returning/breaking out of shader.
   rgbCombo = (isLensOn && isFragOnLensBounds) ? lensBorderColor : rgbCombo;
-
-  color = vec4(rgbCombo, opacity);
+  color = apply_transparency(rgbCombo, useTransparentColor, transparentColor, opacity);
   geometry.uv = vTexCoord;
   DECKGL_FILTER_COLOR(color, geometry);
 }

--- a/src/layers/XRLayer/xr-layer-fragment.webgl2.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment.webgl2.glsl
@@ -32,9 +32,9 @@ uniform int lensSelection;
 uniform vec3 lensBorderColor;
 uniform float lensBorderRadius;
 
-// uniforms for making a transparent color.
+// uniform for making a transparent color.
+uniform vec3 transparentColor;
 uniform bool useTransparentColor;
-uniform vec4 transparentColor;
 
 in vec2 vTexCoord;
 

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -32,11 +32,10 @@ import {
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
  * @param {Boolean} [props.clickCenter] Click to center the default view. Default is true.
- * @param {Array} [props.transparentColor] A RGBA color to be considered "transparent" when useTransparentColor is true.
- * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
- * This parameter is ignored when using colormaps because each colormap has its own transparent color that is calculated on the shader (default is [0, 0, 0, 0]).
- * @param {boolean} [props.useTransparentColor] Whether or nor to use the transparentColor prop or the automatically calculated transparent color when
- * colormap is set (default is false).
+ * @param {Array} [props.transparentColor] An RGB (0-255 range) color to be considered "transparent" if provided.
+ * In other words, any fragment shader output equal transparentColor (before applying opacity) will have opacity 0.
+ * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
+ * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
  */
 
@@ -60,8 +59,7 @@ const PictureInPictureViewer = props => {
     lensBorderColor = [255, 255, 255],
     lensBorderRadius = 0.02,
     clickCenter = true,
-    transparentColor = [0, 0, 0, 0],
-    useTransparentColor = false,
+    transparentColor,
     onViewStateChange
   } = props;
   const viewState =
@@ -84,8 +82,7 @@ const PictureInPictureViewer = props => {
     lensRadius,
     lensBorderColor,
     lensBorderRadius,
-    transparentColor,
-    useTransparentColor
+    transparentColor
   };
   const views = [detailView];
   const layerProps = [layerConfig];

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -32,6 +32,11 @@ import {
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
  * @param {Boolean} [props.clickCenter] Click to center the default view. Default is true.
+ * @param {Array} [props.transparentColor] A RGBA color to be considered "transparent" when useTransparentColor is true.
+ * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
+ * This parameter is ignored when using colormaps because each colormap has its own transparent color that is calculated on the shader (default is [0, 0, 0, 0]).
+ * @param {boolean} [props.useTransparentColor] Whether or nor to use the transparentColor prop or the automatically calculated transparent color when
+ * colormap is set (default is false).
  * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
  */
 
@@ -55,6 +60,8 @@ const PictureInPictureViewer = props => {
     lensBorderColor = [255, 255, 255],
     lensBorderRadius = 0.02,
     clickCenter = true,
+    transparentColor = [0, 0, 0, 0],
+    useTransparentColor = false,
     onViewStateChange
   } = props;
   const viewState =
@@ -76,7 +83,9 @@ const PictureInPictureViewer = props => {
     lensSelection,
     lensRadius,
     lensBorderColor,
-    lensBorderRadius
+    lensBorderRadius,
+    transparentColor,
+    useTransparentColor
   };
   const views = [detailView];
   const layerProps = [layerConfig];

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -20,6 +20,11 @@ import { SideBySideView, getDefaultInitialViewState } from '../views';
  * @param {number} [props.lensSelection] Numeric index of the channel to be focused on by the lens (default 0).
  * @param {Array} [props.lensBorderColor] RGB color of the border of the lens (default [255, 255, 255]).
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
+ * @param {Array} [props.transparentColor] A RGBA color to be considered "transparent" when useTransparentColor is true.
+ * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
+ * This parameter is ignored when using colormaps because each colormap has its own transparent color that is calculated on the shader (default is [0, 0, 0, 0]).
+ * @param {boolean} [props.useTransparentColor] Whether or nor to use the transparentColor prop or the automatically calculated transparent color when
+ * colormap is set (default is false).
  * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
  */
 const SideBySideViewer = props => {
@@ -40,6 +45,8 @@ const SideBySideViewer = props => {
     lensRadius = 100,
     lensBorderColor = [255, 255, 255],
     lensBorderRadius = 0.02,
+    transparentColor = [0, 0, 0, 0],
+    useTransparentColor = false,
     onViewStateChange
   } = props;
   const viewState =
@@ -72,7 +79,9 @@ const SideBySideViewer = props => {
     lensSelection,
     lensRadius,
     lensBorderColor,
-    lensBorderRadius
+    lensBorderRadius,
+    transparentColor,
+    useTransparentColor
   };
   const views = [detailViewRight, detailViewLeft];
   const layerProps = [layerConfig, layerConfig];

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -20,11 +20,10 @@ import { SideBySideView, getDefaultInitialViewState } from '../views';
  * @param {number} [props.lensSelection] Numeric index of the channel to be focused on by the lens (default 0).
  * @param {Array} [props.lensBorderColor] RGB color of the border of the lens (default [255, 255, 255]).
  * @param {number} [props.lensBorderRadius] Percentage of the radius of the lens for a border (default 0.02).
- * @param {Array} [props.transparentColor] A RGBA color to be considered "transparent" when useTransparentColor is true.
- * In other words, any fragment shader output equal to transparentColor will have opacity 0 when useTransparentColor is true.
- * This parameter is ignored when using colormaps because each colormap has its own transparent color that is calculated on the shader (default is [0, 0, 0, 0]).
- * @param {boolean} [props.useTransparentColor] Whether or nor to use the transparentColor prop or the automatically calculated transparent color when
- * colormap is set (default is false).
+ * @param {Array} [props.transparentColor] An RGB (0-255 range) color to be considered "transparent" if provided.
+ * In other words, any fragment shader output equal transparentColor (before applying opacity) will have opacity 0.
+ * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
+ * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
  */
 const SideBySideViewer = props => {
@@ -45,8 +44,7 @@ const SideBySideViewer = props => {
     lensRadius = 100,
     lensBorderColor = [255, 255, 255],
     lensBorderRadius = 0.02,
-    transparentColor = [0, 0, 0, 0],
-    useTransparentColor = false,
+    transparentColor,
     onViewStateChange
   } = props;
   const viewState =
@@ -80,8 +78,7 @@ const SideBySideViewer = props => {
     lensRadius,
     lensBorderColor,
     lensBorderRadius,
-    transparentColor,
-    useTransparentColor
+    transparentColor
   };
   const views = [detailViewRight, detailViewLeft];
   const layerProps = [layerConfig, layerConfig];


### PR DESCRIPTION
Fixes #343.

To test this out you can use [the Vanderbilt Kidney image](http://localhost:8080/?image_url=https://viv-demo.storage.googleapis.com/Vanderbilt-Spraggins-Kidney-MxIF.ome.tif) and then set the [default prop](https://github.com/hms-dbmi/viv/blob/ilan-gold/transparent_color/src/viewers/PictureInPictureViewer.js#L64) to `true` and the [background color to white](https://github.com/hms-dbmi/viv/blob/ilan-gold/transparent_color/avivator/src/index.css#L8) in Avivator or use the colormaps with the normal black background. 

The use case is mainly for IMS images from the portal [like this one](http://localhost:8080/?image_url=https://assets.hubmapconsortium.org/be503a021ed910c0918842e318e6efa2/ometiff-pyramids/ometiffs/VAN0006-LK-2-85-IMS_PosMode_multilayer.ome.tif?token=) which you can also use to test: 

<img width="1680" alt="Screen Shot 2021-01-08 at 8 41 55 PM" src="https://user-images.githubusercontent.com/43999641/104080572-dc043500-51f6-11eb-8007-901fc9b9dcfd.png">
<img width="1680" alt="Screen Shot 2021-01-08 at 8 39 52 PM" src="https://user-images.githubusercontent.com/43999641/104080573-ddcdf880-51f6-11eb-95b1-72601ee29cbb.png">
and
<img width="1680" alt="Screen Shot 2021-01-08 at 9 19 06 PM" src="https://user-images.githubusercontent.com/43999641/104080622-2be2fc00-51f7-11eb-9a63-7357e282ddfd.png">
<img width="1680" alt="Screen Shot 2021-01-08 at 9 18 43 PM" src="https://user-images.githubusercontent.com/43999641/104080626-2eddec80-51f7-11eb-89d3-3bbaef9fd861.png">
 
cc: @nhpatterson