### PR TITLE
Use ES6 Proxy to handle TIFF offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Issue templates for Github.
 
 ### Changed
+- Use an ES6 Proxy to handle OME-TIFF `offsets`.
 
 ## 0.8.2
 

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -3,7 +3,12 @@ import { fromBlob, fromUrl } from 'geotiff';
 import Pool from './Pool';
 import ZarrLoader from './zarrLoader';
 import OMETiffLoader from './OMETiffLoader';
-import { getChannelStats, getJson, dimensionsFromOMEXML, createOffsetsProxy } from './utils';
+import {
+  getChannelStats,
+  getJson,
+  dimensionsFromOMEXML,
+  createOffsetsProxy
+} from './utils';
 import OMEXML from './omeXML';
 import FileStore from './fileStore';
 import HTTPStore from './httpStore';
@@ -170,7 +175,7 @@ export async function createOMETiffLoader({
   }
 
   if (offsets.length > 0) {
-    // Performance enhancement if offsets are provided. This proxy allows 
+    // Performance enhancement if offsets are provided. This proxy allows
     // direct access of images in the tiff using the pre-computed offsets.
     tiff = createOffsetsProxy(tiff, offsets);
   }
@@ -182,7 +187,7 @@ export async function createOMETiffLoader({
     tiff,
     pool,
     firstImage,
-    omexmlString,
+    omexmlString
   });
 }
 

--- a/src/loaders/utils.js
+++ b/src/loaders/utils.js
@@ -188,9 +188,8 @@ export function joinUrlParts(...args) {
     .join('/');
 }
 
-
 /**
- * Wraps a GeoTIFF object in an ES6 Proxy to eagarly parse the fileDirectory 
+ * Wraps a GeoTIFF object in an ES6 Proxy to eagarly parse the fileDirectory
  * use suplemental pre-computed offsets.
  * @param {Object} tiff GeoTIFF
  * @param {Array} offsets pre computed offsets.
@@ -198,7 +197,7 @@ export function joinUrlParts(...args) {
 export function createOffsetsProxy(tiff, offsets) {
   const get = (target, key, reciever) => {
     if (key === 'getImage') {
-      return (index) => {
+      return index => {
         // No need to index if already requested.
         if (index in target.ifdRequests) {
           return target.getImage(index);
@@ -206,10 +205,10 @@ export function createOffsetsProxy(tiff, offsets) {
         // Directly add ifd request using offsets
         target.ifdRequests[index] = target.parseFileDirectoryAt(offsets[index]);
         return target.getImage(index);
-      }
+      };
     }
-    // restores normal behavior for all other 
+    // restores normal behavior for all other
     return Reflect.get(target, key, reciever);
-  }
+  };
   return new Proxy(tiff, { get });
 }

--- a/src/loaders/utils.js
+++ b/src/loaders/utils.js
@@ -195,7 +195,7 @@ export function joinUrlParts(...args) {
  * @param {Array} offsets pre computed offsets.
  */
 export function createOffsetsProxy(tiff, offsets) {
-  const get = (target, key, reciever) => {
+  const get = (target, key, receiver) => {
     if (key === 'getImage') {
       return index => {
         // No need to index if already requested.
@@ -203,12 +203,12 @@ export function createOffsetsProxy(tiff, offsets) {
           return target.getImage(index);
         }
         // Directly add ifd request using offsets
-        target.ifdRequests[index] = target.parseFileDirectoryAt(offsets[index]);
+        target.ifdRequests[index] = target.parseFileDirectoryAt(offsets[index]); // eslint-disable-line no-param-reassign
         return target.getImage(index);
       };
     }
-    // restores normal behavior for all other
-    return Reflect.get(target, key, reciever);
+    // Restores normal 'get' behavior for rest of target.
+    return Reflect.get(target, key, receiver);
   };
   return new Proxy(tiff, { get });
 }

--- a/tests/loaders/OMETiffLoader.spec.js
+++ b/tests/loaders/OMETiffLoader.spec.js
@@ -4,7 +4,7 @@ import { fromFile } from 'geotiff';
 import OMETiffLoader from '../../src/loaders/OMETiffLoader';
 
 test('OME-TIFF Properties', async t => {
-  t.plan(4);
+  t.plan(3);
   try {
     const tiff = await fromFile('tests/loaders/fixtures/multi-channel.ome.tif');
     const firstImage = await tiff.getImage();
@@ -14,13 +14,11 @@ test('OME-TIFF Properties', async t => {
       pool: { decode: () => new Promise([]) },
       firstImage,
       omexmlString,
-      offsets: [8, 2712, 4394]
     });
-    const { width, height, isPyramid, offsets } = loader;
+    const { width, height, isPyramid } = loader;
     t.equal(width, 439);
     t.equal(height, 167);
     t.equal(isPyramid, false);
-    t.deepEqual(offsets, [8, 2712, 4394]);
     t.end();
   } catch (e) {
     t.fail(e);
@@ -38,7 +36,6 @@ test('OME-TIFF Selection', async t => {
       pool: { decode: () => new Promise([]) },
       firstImage,
       omexmlString,
-      offsets: [8, 2712, 4394]
     });
     const selection = loader._getIFDIndex({ channel: 1 });
 

--- a/tests/loaders/OMETiffLoader.spec.js
+++ b/tests/loaders/OMETiffLoader.spec.js
@@ -13,7 +13,7 @@ test('OME-TIFF Properties', async t => {
       tiff,
       pool: { decode: () => new Promise([]) },
       firstImage,
-      omexmlString,
+      omexmlString
     });
     const { width, height, isPyramid } = loader;
     t.equal(width, 439);
@@ -35,7 +35,7 @@ test('OME-TIFF Selection', async t => {
       tiff,
       pool: { decode: () => new Promise([]) },
       firstImage,
-      omexmlString,
+      omexmlString
     });
     const selection = loader._getIFDIndex({ channel: 1 });
 


### PR DESCRIPTION
I've been experimenting in my free time with a re-write of the loader interface. That is still experimental, but this is an idea I've settled on for the TIFF loader. Rather than making the loader manage the complexity of whether or not `offsets` are provided, we can wrap the tiff source in an [ES6 proxy](https://hacks.mozilla.org/2015/07/es6-in-depth-proxies-and-reflect/) _only_ if offsets are provided. 

The proxy allows us to just treat the `tiff` like any other `GeoTIFF` instance, but just that we inject the pre-computed offsets. Let me know what you think.