### PR TITLE
Fix out of range fetch isssue for Tiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Adjust the zoom level for tile layer if scaled.
 - Update `getDefaultInitialViewState` to return floating point zoom that fills the screen by default.
+- Upgrade geotiff to fix out-of-range requests issue.
 
 ## 0.8.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6621,8 +6621,8 @@
       "dev": true
     },
     "geotiff": {
-      "version": "github:ilan-gold/geotiff.js#90e02b8f21a4edcaec2ea3f9d1098aec0da31caa",
-      "from": "github:ilan-gold/geotiff.js#ilan-gold/viv_release_080",
+      "version": "github:ilan-gold/geotiff.js#d50157fc2abbaaa63ca7d826f0853e37b36e8840",
+      "from": "github:ilan-gold/geotiff.js#ilan-gold/viv_083",
       "requires": {
         "lzw-tiff-decoder": "^0.1.0",
         "pako": "^1.0.11",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@luma.gl/core": "^8.3.1",
     "@luma.gl/shadertools": "^8.3.1",
     "fast-xml-parser": "^3.16.0",
-    "geotiff": "ilan-gold/geotiff.js#ilan-gold/viv_release_080",
+    "geotiff": "ilan-gold/geotiff.js#ilan-gold/viv_083",
     "math.gl": "^3.3.0",
     "quickselect": "^2.0.0",
     "zarr": "^0.3.0"


### PR DESCRIPTION
Addresses https://github.com/geotiffjs/geotiff.js/issues/193 on our end.  Here is the diff with our current branch: https://github.com/ilan-gold/geotiff.js/compare/ilan-gold/viv_release_080...ilan-gold:ilan-gold/viv_083?expand=1#

Basically, it is possible for tiff fetch sources to request data outside the size of the file which results in a 416 error from the server.  This PR upgrades our geotiff version to one that makes sure that no requests are made for data outside that range.

You can test this out using http://localhost:8080/?image_url=https://vitessce-demo-data.storage.googleapis.com/test-data/VAN0006-LK-2-85-IMS_PosMode_multilayer.ome.tif?token= (and on Avivator to see the difference) and then selecting the last channel - in Avivator, it will not work but here it will.