### PR TITLE
Smooth Global Selection Transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Adjust the zoom level for tile layer if scaled.
 - Update `getDefaultInitialViewState` to return floating point zoom that fills the screen by default.
 - Fix `maxZoom` bug.
+- Smooth transitions for global selection changes.
 
 ## 0.8.2
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -41,3 +41,5 @@ export const DTYPE_VALUES = {
     TypedArray: Float32Array
   }
 };
+
+export const GLOBAL_SLIDER_DIMENSION_FIELDS = ['z', 'time'];

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@ import {
   ImageLayer,
   ScaleBarLayer,
   XRLayer,
-  OverviewLayer
+  OverviewLayer,
+  BitmapLayer
 } from './layers';
 import { VivViewer, PictureInPictureViewer, SideBySideViewer } from './viewers';
 import {
@@ -31,6 +32,7 @@ export {
   MultiscaleImageLayer,
   XRLayer,
   OverviewLayer,
+  BitmapLayer,
   VivViewer,
   VivView,
   OverviewView,

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -95,7 +95,10 @@ export default class MultiscaleImageLayer extends CompositeLayer {
       maxRequests,
       onClick,
       modelMatrix,
-      transparentColor
+      transparentColor,
+      excludeBackground,
+      onViewportLoad,
+      refinementStrategy
     } = this.props;
     const { tileSize, numLevels, dtype, isInterleaved, isRgb } = loader;
     const { unprojectLensBounds } = this.state;
@@ -156,7 +159,8 @@ export default class MultiscaleImageLayer extends CompositeLayer {
       domain,
       // We want a no-overlap caching strategy with an opacity < 1 to prevent
       // multiple rendered sublayers (some of which have been cached) from overlapping
-      refinementStrategy: opacity === 1 ? 'best-available' : 'no-overlap',
+      refinementStrategy:
+        refinementStrategy || (opacity === 1 ? 'best-available' : 'no-overlap'),
       // TileLayer checks `changeFlags.updateTriggersChanged.getTileData` to see if tile cache
       // needs to be re-created. We want to trigger this behavior if the loader changes.
       // https://github.com/uber/deck.gl/blob/3f67ea6dfd09a4d74122f93903cb6b819dd88d52/modules/geo-layers/src/tile-layer/tile-layer.js#L50
@@ -175,7 +179,8 @@ export default class MultiscaleImageLayer extends CompositeLayer {
       lensBorderColor,
       lensBorderRadius,
       modelMatrix,
-      transparentColor
+      transparentColor,
+      onViewportLoad
     });
     // This gives us a background image and also solves the current
     // minZoom funny business.  We don't use it for the background if we have an opacity
@@ -185,6 +190,7 @@ export default class MultiscaleImageLayer extends CompositeLayer {
     const layerModelMatrix = modelMatrix ? modelMatrix.clone() : new Matrix4();
     const baseLayer =
       implementsGetRaster &&
+      !excludeBackground &&
       new ImageLayer(this.props, {
         id: `Background-Image-${id}`,
         modelMatrix: layerModelMatrix.scale(2 ** (numLevels - 1)),

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -28,7 +28,8 @@ const defaultProps = {
   maxRequests: { type: 'number', value: 10, compare: true },
   onClick: { type: 'function', value: null, compare: true },
   transparentColor: { type: 'array', value: null, compare: true },
-  refinementStrategy: { type: 'string', value: null, compare: true }
+  refinementStrategy: { type: 'string', value: null, compare: true },
+  excludeBackground: { type: 'boolean', value: false, compare: true }
 };
 
 /**
@@ -58,6 +59,8 @@ const defaultProps = {
  * In other words, any fragment shader output equal transparentColor (before applying opacity) will have opacity 0.
  * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
+ * @param {string} props.refinementStrategy 'best-available' | 'no-overlap' | 'never' will be passed to TileLayer. A default will be chosen based on opacity.
+ * @param {boolean} props.excludeBackground Whether to exclude the background image. The background image is also excluded for opacity!=1.
  */
 
 export default class MultiscaleImageLayer extends CompositeLayer {

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -27,7 +27,8 @@ const defaultProps = {
   lensBorderRadius: { type: 'number', value: 0.02, compare: true },
   maxRequests: { type: 'number', value: 10, compare: true },
   onClick: { type: 'function', value: null, compare: true },
-  transparentColor: { type: 'array', value: null, compare: true }
+  transparentColor: { type: 'array', value: null, compare: true },
+  refinementStrategy: { type: 'string', value: null, compare: true }
 };
 
 /**

--- a/src/layers/index.js
+++ b/src/layers/index.js
@@ -3,3 +3,4 @@ export { default as ImageLayer } from './ImageLayer';
 export { default as OverviewLayer } from './OverviewLayer';
 export { default as ScaleBarLayer } from './ScaleBarLayer';
 export { default as XRLayer } from './XRLayer';
+export { default as BitmapLayer } from './BitmapLayer';

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -1,4 +1,4 @@
-import React from 'react'; // eslint-disable-line import/no-unresolved
+import React, { useState } from 'react'; // eslint-disable-line import/no-unresolved
 import VivViewer from './VivViewer';
 import {
   DetailView,
@@ -7,6 +7,35 @@ import {
   DETAIL_VIEW_ID,
   OVERVIEW_VIEW_ID
 } from '../views';
+import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
+
+function useGlobalSelection(loaderSelection) {
+  // viewportSelection is the last selection that had an onViewportLoad callback.
+  const [viewportSelection, setViewportSelection] = useState(loaderSelection);
+  let onViewportLoad;
+  let newLoaderSelection = null;
+  let oldLoaderSelection = loaderSelection;
+  if (
+    loaderSelection?.length &&
+    viewportSelection?.length &&
+    GLOBAL_SLIDER_DIMENSION_FIELDS.some(
+      f => loaderSelection[0][f] !== viewportSelection[0][f]
+    )
+  ) {
+    // onViewportLoad is a property of TileLayer that is passed through:
+    // https://deck.gl/docs/api-reference/geo-layers/tile-layer#onviewportload
+    onViewportLoad = () => {
+      // Slightly delay to avoid issues with a render in the middle of a deck.gl layer state update.
+      setTimeout(() => {
+        setViewportSelection(loaderSelection);
+      }, 0);
+    };
+    // Set newLoaderSelection to cause the creation of an extra tile layer.
+    newLoaderSelection = loaderSelection;
+    oldLoaderSelection = viewportSelection;
+  }
+  return { newLoaderSelection, oldLoaderSelection, onViewportLoad };
+}
 
 /**
  * This component provides a component for an overview-detail VivViewer of an image (i.e picture-in-picture).
@@ -63,6 +92,11 @@ const PictureInPictureViewer = props => {
     transparentColor,
     onViewStateChange
   } = props;
+  const {
+    newLoaderSelection,
+    oldLoaderSelection,
+    onViewportLoad
+  } = useGlobalSelection(loaderSelection);
   const viewState =
     initialViewState ||
     getDefaultInitialViewState(loader, { height, width }, 0.5);
@@ -77,7 +111,10 @@ const PictureInPictureViewer = props => {
     sliderValues,
     colorValues,
     channelIsOn,
-    loaderSelection,
+    loaderSelection: oldLoaderSelection,
+    newLoaderSelection,
+    onViewportLoad,
+    transitionFields: GLOBAL_SLIDER_DIMENSION_FIELDS,
     colormap,
     isLensOn,
     lensSelection,

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -40,6 +40,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
+ * @param {Array} [transitionFields] A string array indicating which fields require a transition: Default: ['time', 'z'].
  */
 
 const PictureInPictureViewer = props => {
@@ -63,13 +64,14 @@ const PictureInPictureViewer = props => {
     lensBorderRadius = 0.02,
     clickCenter = true,
     transparentColor,
-    onViewStateChange
+    onViewStateChange,
+    transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS
   } = props;
   const {
     newLoaderSelection,
     oldLoaderSelection,
     onViewportLoad
-  } = useGlobalSelection(loaderSelection);
+  } = useGlobalSelection(loaderSelection, transitionFields);
   const viewState =
     initialViewState ||
     getDefaultInitialViewState(loader, { height, width }, 0.5);
@@ -87,7 +89,7 @@ const PictureInPictureViewer = props => {
     loaderSelection: oldLoaderSelection,
     newLoaderSelection,
     onViewportLoad,
-    transitionFields: GLOBAL_SLIDER_DIMENSION_FIELDS,
+    transitionFields,
     colormap,
     isLensOn,
     lensSelection,

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'; // eslint-disable-line import/no-unresolved
+import React from 'react'; // eslint-disable-line import/no-unresolved
 import VivViewer from './VivViewer';
 import {
   DetailView,
@@ -7,35 +7,8 @@ import {
   DETAIL_VIEW_ID,
   OVERVIEW_VIEW_ID
 } from '../views';
+import useGlobalSelection from './global-selection-hook';
 import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
-
-function useGlobalSelection(loaderSelection) {
-  // viewportSelection is the last selection that had an onViewportLoad callback.
-  const [viewportSelection, setViewportSelection] = useState(loaderSelection);
-  let onViewportLoad;
-  let newLoaderSelection = null;
-  let oldLoaderSelection = loaderSelection;
-  if (
-    loaderSelection?.length &&
-    viewportSelection?.length &&
-    GLOBAL_SLIDER_DIMENSION_FIELDS.some(
-      f => loaderSelection[0][f] !== viewportSelection[0][f]
-    )
-  ) {
-    // onViewportLoad is a property of TileLayer that is passed through:
-    // https://deck.gl/docs/api-reference/geo-layers/tile-layer#onviewportload
-    onViewportLoad = () => {
-      // Slightly delay to avoid issues with a render in the middle of a deck.gl layer state update.
-      setTimeout(() => {
-        setViewportSelection(loaderSelection);
-      }, 0);
-    };
-    // Set newLoaderSelection to cause the creation of an extra tile layer.
-    newLoaderSelection = loaderSelection;
-    oldLoaderSelection = viewportSelection;
-  }
-  return { newLoaderSelection, oldLoaderSelection, onViewportLoad };
-}
 
 /**
  * This component provides a component for an overview-detail VivViewer of an image (i.e picture-in-picture).

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -28,6 +28,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
+ * @param {Array} [transitionFields] A string array indicating which fields require a transition: Default: ['time', 'z'].
  */
 const SideBySideViewer = props => {
   const {
@@ -48,13 +49,14 @@ const SideBySideViewer = props => {
     lensBorderColor = [255, 255, 255],
     lensBorderRadius = 0.02,
     transparentColor,
-    onViewStateChange
+    onViewStateChange,
+    transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS
   } = props;
   const {
     newLoaderSelection,
     oldLoaderSelection,
     onViewportLoad
-  } = useGlobalSelection(loaderSelection);
+  } = useGlobalSelection(loaderSelection, transitionFields);
   const viewState =
     initialViewState ||
     getDefaultInitialViewState(loader, { height, width }, 0.5);
@@ -83,7 +85,7 @@ const SideBySideViewer = props => {
     loaderSelection: oldLoaderSelection,
     newLoaderSelection,
     onViewportLoad,
-    transitionFields: GLOBAL_SLIDER_DIMENSION_FIELDS,
+    transitionFields,
     colormap,
     isLensOn,
     lensSelection,

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -1,6 +1,8 @@
 import React from 'react'; // eslint-disable-line import/no-unresolved
 import VivViewer from './VivViewer';
 import { SideBySideView, getDefaultInitialViewState } from '../views';
+import useGlobalSelection from './global-selection-hook';
+import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
 
 /**
  * This component provides a side-by-side VivViewer with linked zoom/pan.
@@ -48,6 +50,11 @@ const SideBySideViewer = props => {
     transparentColor,
     onViewStateChange
   } = props;
+  const {
+    newLoaderSelection,
+    oldLoaderSelection,
+    onViewportLoad
+  } = useGlobalSelection(loaderSelection);
   const viewState =
     initialViewState ||
     getDefaultInitialViewState(loader, { height, width }, 0.5);
@@ -73,7 +80,10 @@ const SideBySideViewer = props => {
     sliderValues,
     colorValues,
     channelIsOn,
-    loaderSelection,
+    loaderSelection: oldLoaderSelection,
+    newLoaderSelection,
+    onViewportLoad,
+    transitionFields: GLOBAL_SLIDER_DIMENSION_FIELDS,
     colormap,
     isLensOn,
     lensSelection,

--- a/src/viewers/global-selection-hook.js
+++ b/src/viewers/global-selection-hook.js
@@ -1,0 +1,30 @@
+import { useState } from 'react'; // eslint-disable-line import/no-unresolved
+import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
+
+export default function useGlobalSelection(loaderSelection) {
+  // viewportSelection is the last selection that had an onViewportLoad callback.
+  const [viewportSelection, setViewportSelection] = useState(loaderSelection);
+  let onViewportLoad;
+  let newLoaderSelection = null;
+  let oldLoaderSelection = loaderSelection;
+  if (
+    loaderSelection?.length &&
+    viewportSelection?.length &&
+    GLOBAL_SLIDER_DIMENSION_FIELDS.some(
+      f => loaderSelection[0][f] !== viewportSelection[0][f]
+    )
+  ) {
+    // onViewportLoad is a property of TileLayer that is passed through:
+    // https://deck.gl/docs/api-reference/geo-layers/tile-layer#onviewportload
+    onViewportLoad = () => {
+      // Slightly delay to avoid issues with a render in the middle of a deck.gl layer state update.
+      setTimeout(() => {
+        setViewportSelection(loaderSelection);
+      }, 0);
+    };
+    // Set newLoaderSelection to cause the creation of an extra tile layer.
+    newLoaderSelection = loaderSelection;
+    oldLoaderSelection = viewportSelection;
+  }
+  return { newLoaderSelection, oldLoaderSelection, onViewportLoad };
+}

--- a/src/viewers/global-selection-hook.js
+++ b/src/viewers/global-selection-hook.js
@@ -1,7 +1,6 @@
 import { useState } from 'react'; // eslint-disable-line import/no-unresolved
-import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
 
-export default function useGlobalSelection(loaderSelection) {
+export default function useGlobalSelection(loaderSelection, transitionFields) {
   // viewportSelection is the last selection that had an onViewportLoad callback.
   const [viewportSelection, setViewportSelection] = useState(loaderSelection);
   let onViewportLoad;
@@ -10,7 +9,7 @@ export default function useGlobalSelection(loaderSelection) {
   if (
     loaderSelection?.length &&
     viewportSelection?.length &&
-    GLOBAL_SLIDER_DIMENSION_FIELDS.some(
+    transitionFields.some(
       f => loaderSelection[0][f] !== viewportSelection[0][f]
     )
   ) {

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -14,7 +14,7 @@ export default class DetailView extends VivView {
     const { loader } = props;
     const { id, height, width } = this;
     const layerViewState = viewStates[id];
-    const layers = getDetailLayers(id, props);
+    const layers = getImageLayers(id, props);
 
     const { physicalSizes } = loader;
     if (physicalSizes) {

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -1,6 +1,6 @@
 import { ScaleBarLayer } from '../layers';
 import VivView from './VivView';
-import { getDetailLayers, getVivId } from './utils';
+import { getImageLayers, getVivId } from './utils';
 import { OVERVIEW_VIEW_ID } from './OverviewView';
 
 export const DETAIL_VIEW_ID = 'detail';

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -22,12 +22,15 @@ export default class DetailView extends VivView {
     const layerViewState = viewStates[id];
     const layers = [];
 
+    // Create at least one layer even without loaderSelection so that the tests pass.
     if (loader.isPyramid) {
       layers.push(
         ...[loaderSelection, newLoaderSelection]
-          .filter(s => s)
+          .filter((s, i) => i === 0 || s)
           .map((s, i) => {
-            const suffix = transitionFields.map(f => s[0][f]).join('-');
+            const suffix = s
+              ? `-${transitionFields.map(f => s[0][f]).join('-')}`
+              : '';
             const newProps =
               i !== 0
                 ? {
@@ -40,7 +43,7 @@ export default class DetailView extends VivView {
               ...props,
               ...newProps,
               loaderSelection: s,
-              id: `${loader.type}${getVivId(id)}-${suffix}`,
+              id: `${loader.type}${getVivId(id)}${suffix}`,
               viewportId: id
             });
           })

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -1,6 +1,6 @@
-import { MultiscaleImageLayer, ImageLayer, ScaleBarLayer } from '../layers';
+import { ScaleBarLayer } from '../layers';
 import VivView from './VivView';
-import { getVivId } from './utils';
+import { getDetailLayers, getVivId } from './utils';
 import { OVERVIEW_VIEW_ID } from './OverviewView';
 
 export const DETAIL_VIEW_ID = 'detail';
@@ -11,51 +11,10 @@ export const DETAIL_VIEW_ID = 'detail';
  * */
 export default class DetailView extends VivView {
   getLayers({ props, viewStates }) {
-    const {
-      loader,
-      loaderSelection,
-      newLoaderSelection,
-      onViewportLoad,
-      transitionFields
-    } = props;
+    const { loader } = props;
     const { id, height, width } = this;
     const layerViewState = viewStates[id];
-    const layers = [];
-
-    // Create at least one layer even without loaderSelection so that the tests pass.
-    if (loader.isPyramid) {
-      layers.push(
-        ...[loaderSelection, newLoaderSelection]
-          .filter((s, i) => i === 0 || s)
-          .map((s, i) => {
-            const suffix = s
-              ? `-${transitionFields.map(f => s[0][f]).join('-')}`
-              : '';
-            const newProps =
-              i !== 0
-                ? {
-                    onViewportLoad,
-                    refinementStrategy: 'never',
-                    excludeBackground: true
-                  }
-                : {};
-            return new MultiscaleImageLayer({
-              ...props,
-              ...newProps,
-              loaderSelection: s,
-              id: `${loader.type}${getVivId(id)}${suffix}`,
-              viewportId: id
-            });
-          })
-      );
-    } else {
-      layers.push(
-        new ImageLayer(props, {
-          id: `${loader.type}${getVivId(id)}`,
-          viewportId: id
-        })
-      );
-    }
+    const layers = getDetailLayers(id, props);
 
     const { physicalSizes } = loader;
     if (physicalSizes) {

--- a/src/views/SideBySideView.js
+++ b/src/views/SideBySideView.js
@@ -1,9 +1,9 @@
 import { PolygonLayer } from '@deck.gl/layers';
 import { COORDINATE_SYSTEM } from '@deck.gl/core';
 
-import { MultiscaleImageLayer, ImageLayer, ScaleBarLayer } from '../layers';
+import { ScaleBarLayer } from '../layers';
 import VivView from './VivView';
-import { getVivId, makeBoundingBox } from './utils';
+import { getDetailLayers, getVivId, makeBoundingBox } from './utils';
 /**
  * This class generates a MultiscaleImageLayer and a view for use in the SideBySideViewer.
  * It is linked with its other views as controlled by `linkedIds`, `zoomLock`, and `panLock` parameters.
@@ -104,18 +104,7 @@ export default class SideBySideView extends VivView {
     } = this;
     const layerViewState = viewStates[id];
     const boundingBox = makeBoundingBox({ ...layerViewState, height, width });
-    const layers = [];
-
-    const detailLayer = loader.isPyramid
-      ? new MultiscaleImageLayer(props, {
-          id: `${loader.type}${getVivId(id)}`,
-          viewportId: id
-        })
-      : new ImageLayer(props, {
-          id: `${loader.type}${getVivId(id)}`,
-          viewportId: id
-        });
-    layers.push(detailLayer);
+    const layers = getDetailLayers(id, props);
 
     const border = new PolygonLayer({
       id: `viewport-outline-${loader.type}${getVivId(id)}`,

--- a/src/views/SideBySideView.js
+++ b/src/views/SideBySideView.js
@@ -3,7 +3,7 @@ import { COORDINATE_SYSTEM } from '@deck.gl/core';
 
 import { ScaleBarLayer } from '../layers';
 import VivView from './VivView';
-import { getDetailLayers, getVivId, makeBoundingBox } from './utils';
+import { getImageLayers, getVivId, makeBoundingBox } from './utils';
 /**
  * This class generates a MultiscaleImageLayer and a view for use in the SideBySideViewer.
  * It is linked with its other views as controlled by `linkedIds`, `zoomLock`, and `panLock` parameters.

--- a/src/views/SideBySideView.js
+++ b/src/views/SideBySideView.js
@@ -104,7 +104,7 @@ export default class SideBySideView extends VivView {
     } = this;
     const layerViewState = viewStates[id];
     const boundingBox = makeBoundingBox({ ...layerViewState, height, width });
-    const layers = getDetailLayers(id, props);
+    const layers = getImageLayers(id, props);
 
     const border = new PolygonLayer({
       id: `viewport-outline-${loader.type}${getVivId(id)}`,

--- a/src/views/utils.js
+++ b/src/views/utils.js
@@ -56,7 +56,7 @@ export function getDefaultInitialViewState(loader, viewSize, zoomBackOff = 0) {
  * @param {Object} props The layer properties.
  * @returns {Array} An array of layers.
  */
-export function getDetailLayers(id, props) {
+export function getImageLayers(id, props) {
   const {
     loader,
     loaderSelection,

--- a/src/views/utils.js
+++ b/src/views/utils.js
@@ -1,4 +1,7 @@
 import { OrthographicView } from '@deck.gl/core';
+// Do not import from '../layers' because that causes a circular dependency.
+import MultiscaleImageLayer from '../layers/MultiscaleImageLayer';
+import ImageLayer from '../layers/ImageLayer';
 
 export function getVivId(id) {
   return `-#${id}#`;
@@ -45,4 +48,51 @@ export function getDefaultInitialViewState(loader, viewSize, zoomBackOff = 0) {
     zoom
   };
   return loaderInitialViewState;
+}
+
+/**
+ * Creates the layers for viewing an image in detail.
+ * @param {string} id The identifier of the view.
+ * @param {Object} props The layer properties.
+ * @returns {Array} An array of layers.
+ */
+export function getDetailLayers(id, props) {
+  const {
+    loader,
+    loaderSelection,
+    newLoaderSelection,
+    onViewportLoad,
+    transitionFields
+  } = props;
+  // Create at least one layer even without loaderSelection so that the tests pass.
+  if (loader.isPyramid) {
+    return [loaderSelection, newLoaderSelection]
+      .filter((s, i) => i === 0 || s)
+      .map((s, i) => {
+        const suffix = s
+          ? `-${transitionFields.map(f => s[0][f]).join('-')}`
+          : '';
+        const newProps =
+          i !== 0
+            ? {
+                onViewportLoad,
+                refinementStrategy: 'never',
+                excludeBackground: true
+              }
+            : {};
+        return new MultiscaleImageLayer({
+          ...props,
+          ...newProps,
+          loaderSelection: s,
+          id: `${loader.type}${getVivId(id)}${suffix}`,
+          viewportId: id
+        });
+      });
+  }
+  return [
+    new ImageLayer(props, {
+      id: `${loader.type}${getVivId(id)}`,
+      viewportId: id
+    })
+  ];
 }

--- a/src/views/utils.js
+++ b/src/views/utils.js
@@ -58,12 +58,13 @@ export function getDefaultInitialViewState(loader, viewSize, zoomBackOff = 0) {
  */
 export function getImageLayers(id, props) {
   const {
-    loader,
     loaderSelection,
     newLoaderSelection,
     onViewportLoad,
-    transitionFields
+    transitionFields,
+    ...layerProps
   } = props;
+  const { loader } = layerProps;
   // Create at least one layer even without loaderSelection so that the tests pass.
   if (loader.isPyramid) {
     return [loaderSelection, newLoaderSelection]
@@ -81,7 +82,7 @@ export function getImageLayers(id, props) {
               }
             : {};
         return new MultiscaleImageLayer({
-          ...props,
+          ...layerProps,
           ...newProps,
           loaderSelection: s,
           id: `${loader.type}${getVivId(id)}${suffix}`,
@@ -90,9 +91,10 @@ export function getImageLayers(id, props) {
       });
   }
   return [
-    new ImageLayer(props, {
+    new ImageLayer(layerProps, {
       id: `${loader.type}${getVivId(id)}`,
-      viewportId: id
+      viewportId: id,
+      loaderSelection
     })
   ];
 }


### PR DESCRIPTION
This implements the smooth global selection transitions discussed in #351. It maintains the last successfully loaded selection in `PictureInPictureViewer`. If the newly selected selection differs from the last loaded one, `DetailView` creates two instances of `MultiscaleImageLayer`, each with a different loader selection. The top layer for the new loader selection has a callback `onViewportLoad` that will make the new selection the successfully loaded one.

Because `GLOBAL_SLIDER_DIMENSION_FIELDS` is needed, it is duplicated from the Avivator constants. It is recommended that Avivator would get this constant from Viv in the future instead of maintaining its own copy.

This also exports `BitmapLayer`, the original request in #351.