### PR TITLE
Set View State from Props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Adjust the zoom level for tile layer if scaled.
 - Update `getDefaultInitialViewState` to return floating point zoom that fills the screen by default.
 - Upgrade geotiff to fix out-of-range requests issue.
+- Changed `initialViewState` to `viewState` in `PictureInPictureViewer` and to `viewStates` in the other viewers. The new properties control the deck.gl view state at any time and not just when the components are created.
 - Fix `maxZoom` bug.
 - Smooth transitions for global selection changes.
 - GH actions allow for running on PR as well as push (so that forked repos run tests).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9018,6 +9018,11 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6240,8 +6240,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -9017,11 +9016,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.ismatch": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@luma.gl/shadertools": "^8.3.1",
     "fast-xml-parser": "^3.16.0",
     "geotiff": "ilan-gold/geotiff.js#ilan-gold/viv_083",
+    "lodash.isequal": "^4.5.0",
     "math.gl": "^3.3.0",
     "quickselect": "^2.0.0",
     "zarr": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
     "@luma.gl/constants": "^8.3.1",
     "@luma.gl/core": "^8.3.1",
     "@luma.gl/shadertools": "^8.3.1",
+    "fast-deep-equal": "^3.1.3",
     "fast-xml-parser": "^3.16.0",
     "geotiff": "ilan-gold/geotiff.js#ilan-gold/viv_083",
-    "lodash.isequal": "^4.5.0",
     "math.gl": "^3.3.0",
     "quickselect": "^2.0.0",
     "zarr": "^0.3.0"

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,9 @@ import {
   OverviewView,
   DetailView,
   SideBySideView,
-  getDefaultInitialViewState
+  getDefaultInitialViewState,
+  DETAIL_VIEW_ID,
+  OVERVIEW_VIEW_ID
 } from './views';
 import {
   createZarrLoader,
@@ -39,6 +41,8 @@ export {
   PictureInPictureViewer,
   getDefaultInitialViewState,
   SideBySideView,
+  DETAIL_VIEW_ID,
+  OVERVIEW_VIEW_ID,
   getChannelStats,
   SideBySideViewer,
   DetailView,

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -24,7 +24,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {Boolean} props.overviewOn Whether or not to show the OverviewView.
  * @param {Object} props.hoverHooks Object including the allowable hooks - right now only accepting a function with key handleValue like { handleValue: (valueArray) => {} } where valueArray
  * has the pixel values for the image under the hover location.
- * @param {number} props.initialViewState Object like { target: [x, y, 0], zoom: -zoom } for initializing where the viewer looks (optional - this is inferred from height/width/loader
+ * @param {Object} [props.viewState] Object like { target: [x, y, 0], zoom: -zoom } for setting where the viewer looks (optional - this is inferred from height/width/loader
  * internally by default using getDefaultInitialViewState).
  * @param {number} props.height Current height of the component.
  * @param {number} props.width Current width of the component.
@@ -49,7 +49,7 @@ const PictureInPictureViewer = props => {
     sliderValues,
     colorValues,
     channelIsOn,
-    initialViewState,
+    viewState,
     colormap,
     overview,
     overviewOn,
@@ -72,12 +72,10 @@ const PictureInPictureViewer = props => {
     oldLoaderSelection,
     onViewportLoad
   } = useGlobalSelection(loaderSelection, transitionFields);
-  const viewState =
-    initialViewState ||
-    getDefaultInitialViewState(loader, { height, width }, 0.5);
-  const detailViewState = { ...viewState, id: DETAIL_VIEW_ID };
+  const baseViewState =
+    viewState || getDefaultInitialViewState(loader, { height, width }, 0.5);
   const detailView = new DetailView({
-    initialViewState: detailViewState,
+    id: DETAIL_VIEW_ID,
     height,
     width
   });
@@ -100,10 +98,11 @@ const PictureInPictureViewer = props => {
   };
   const views = [detailView];
   const layerProps = [layerConfig];
+  const viewStates = [{ ...baseViewState, id: DETAIL_VIEW_ID }];
   if (overviewOn && loader) {
-    const overviewViewState = { ...viewState, id: OVERVIEW_VIEW_ID };
+    const overviewViewState = { ...baseViewState, id: OVERVIEW_VIEW_ID };
     const overviewView = new OverviewView({
-      initialViewState: overviewViewState,
+      id: OVERVIEW_VIEW_ID,
       loader,
       detailHeight: height,
       detailWidth: width,
@@ -112,12 +111,14 @@ const PictureInPictureViewer = props => {
     });
     views.push(overviewView);
     layerProps.push(layerConfig);
+    viewStates.push(overviewViewState);
   }
   if (!loader) return null;
   return (
     <VivViewer
       layerProps={layerProps}
       views={views}
+      viewStates={viewStates}
       hoverHooks={hoverHooks}
       onViewStateChange={onViewStateChange}
     />

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -24,7 +24,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {Boolean} props.overviewOn Whether or not to show the OverviewView.
  * @param {Object} props.hoverHooks Object including the allowable hooks - right now only accepting a function with key handleValue like { handleValue: (valueArray) => {} } where valueArray
  * has the pixel values for the image under the hover location.
- * @param {Array} [props.viewStates] Array of objects like [{ target: [x, y, 0], zoom: -zoom, id: 'detail' }] for setting where the viewer looks (optional - this is inferred from height/width/loader
+ * @param {Array} [props.viewStates] Array of objects like [{ target: [x, y, 0], zoom: -zoom, id: DETAIL_VIEW_ID }] for setting where the viewer looks (optional - this is inferred from height/width/loader
  * internally by default using getDefaultInitialViewState).
  * @param {number} props.height Current height of the component.
  * @param {number} props.width Current width of the component.
@@ -73,7 +73,7 @@ const PictureInPictureViewer = props => {
     onViewportLoad
   } = useGlobalSelection(loaderSelection, transitionFields);
   const baseViewState =
-    viewStatesProp.find(v => v.id === DETAIL_VIEW_ID) ||
+    viewStatesProp?.find(v => v.id === DETAIL_VIEW_ID) ||
     getDefaultInitialViewState(loader, { height, width }, 0.5);
   const detailView = new DetailView({
     id: DETAIL_VIEW_ID,
@@ -102,7 +102,7 @@ const PictureInPictureViewer = props => {
   const viewStates = [{ ...baseViewState, id: DETAIL_VIEW_ID }];
   if (overviewOn && loader) {
     // It's unclear why this is needed because OverviewView.filterViewState sets "zoom" and "target".
-    const overviewViewState = viewStatesProp.find(
+    const overviewViewState = viewStatesProp?.find(
       v => v.id === OVERVIEW_VIEW_ID
     ) || { ...baseViewState, id: OVERVIEW_VIEW_ID };
     const overviewView = new OverviewView({

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -24,7 +24,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {Boolean} props.overviewOn Whether or not to show the OverviewView.
  * @param {Object} props.hoverHooks Object including the allowable hooks - right now only accepting a function with key handleValue like { handleValue: (valueArray) => {} } where valueArray
  * has the pixel values for the image under the hover location.
- * @param {Object} [props.viewState] Object like { target: [x, y, 0], zoom: -zoom } for setting where the viewer looks (optional - this is inferred from height/width/loader
+ * @param {Array} [props.viewStates] Array of objects like [{ target: [x, y, 0], zoom: -zoom, id: 'detail' }] for setting where the viewer looks (optional - this is inferred from height/width/loader
  * internally by default using getDefaultInitialViewState).
  * @param {number} props.height Current height of the component.
  * @param {number} props.width Current width of the component.
@@ -49,7 +49,7 @@ const PictureInPictureViewer = props => {
     sliderValues,
     colorValues,
     channelIsOn,
-    viewState,
+    viewStates: viewStatesProp,
     colormap,
     overview,
     overviewOn,
@@ -73,7 +73,8 @@ const PictureInPictureViewer = props => {
     onViewportLoad
   } = useGlobalSelection(loaderSelection, transitionFields);
   const baseViewState =
-    viewState || getDefaultInitialViewState(loader, { height, width }, 0.5);
+    viewStatesProp.find(v => v.id === DETAIL_VIEW_ID) ||
+    getDefaultInitialViewState(loader, { height, width }, 0.5);
   const detailView = new DetailView({
     id: DETAIL_VIEW_ID,
     height,
@@ -100,7 +101,10 @@ const PictureInPictureViewer = props => {
   const layerProps = [layerConfig];
   const viewStates = [{ ...baseViewState, id: DETAIL_VIEW_ID }];
   if (overviewOn && loader) {
-    const overviewViewState = { ...baseViewState, id: OVERVIEW_VIEW_ID };
+    // It's unclear why this is needed because OverviewView.filterViewState sets "zoom" and "target".
+    const overviewViewState = viewStatesProp.find(
+      v => v.id === OVERVIEW_VIEW_ID
+    ) || { ...baseViewState, id: OVERVIEW_VIEW_ID };
     const overviewView = new OverviewView({
       id: OVERVIEW_VIEW_ID,
       loader,

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -72,13 +72,14 @@ const PictureInPictureViewer = props => {
     oldLoaderSelection,
     onViewportLoad
   } = useGlobalSelection(loaderSelection, transitionFields);
+  const detailViewState = viewStatesProp?.find(v => v.id === DETAIL_VIEW_ID);
   const baseViewState = useMemo(() => {
     return (
-      viewStatesProp?.find(v => v.id === DETAIL_VIEW_ID) ||
+      detailViewState ||
       getDefaultInitialViewState(loader, { height, width }, 0.5)
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loader, viewStatesProp]);
+  }, [loader, detailViewState]);
 
   const detailView = new DetailView({
     id: DETAIL_VIEW_ID,

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -57,8 +57,10 @@ const SideBySideViewer = props => {
     oldLoaderSelection,
     onViewportLoad
   } = useGlobalSelection(loaderSelection, transitionFields);
+  const leftViewState = viewStatesProp?.find(v => v.id === 'left');
+  const rightViewState = viewStatesProp?.find(v => v.id === 'right');
   const viewStates = useMemo(() => {
-    if (viewStatesProp) {
+    if (leftViewState && rightViewState) {
       return viewStatesProp;
     }
     const defaultViewState = getDefaultInitialViewState(
@@ -67,11 +69,11 @@ const SideBySideViewer = props => {
       0.5
     );
     return [
-      { ...defaultViewState, id: 'left' },
-      { ...defaultViewState, id: 'right' }
+      leftViewState || { ...defaultViewState, id: 'left' },
+      rightViewState || { ...defaultViewState, id: 'right' }
     ];
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loader, viewStatesProp]);
+  }, [loader, leftViewState, rightViewState]);
 
   const detailViewLeft = new SideBySideView({
     id: 'left',

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -15,7 +15,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {Array} props.loaderSelection Selection to be used for fetching data.
  * @param {Boolean} props.zoomLock Whether or not lock the zooms of the two views.
  * @param {Boolean} props.panLock Whether or not lock the pans of the two views.
- * @param {Object} props.viewStates List of objects like [{ target: [x, y, 0], zoom: -zoom, id: 'left' }, { target: [x, y, 0], zoom: -zoom, id: 'right' }] for initializing where the viewer looks (optional - this is inferred from height/width/loader
+ * @param {Array} props.viewStates List of objects like [{ target: [x, y, 0], zoom: -zoom, id: 'left' }, { target: [x, y, 0], zoom: -zoom, id: 'right' }] for initializing where the viewer looks (optional - this is inferred from height/width/loader
  * internally by default using getDefaultInitialViewState).
  * @param {number} props.height Current height of the component.
  * @param {number} props.width Current width of the component.

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -15,7 +15,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {Array} props.loaderSelection Selection to be used for fetching data.
  * @param {Boolean} props.zoomLock Whether or not lock the zooms of the two views.
  * @param {Boolean} props.panLock Whether or not lock the pans of the two views.
- * @param {Array} props.viewStates List of objects like [{ target: [x, y, 0], zoom: -zoom, id: 'left' }, { target: [x, y, 0], zoom: -zoom, id: 'right' }] for initializing where the viewer looks (optional - this is inferred from height/width/loader
+ * @param {Array} [props.viewStates] List of objects like [{ target: [x, y, 0], zoom: -zoom, id: 'left' }, { target: [x, y, 0], zoom: -zoom, id: 'right' }] for initializing where the viewer looks (optional - this is inferred from height/width/loader
  * internally by default using getDefaultInitialViewState).
  * @param {number} props.height Current height of the component.
  * @param {number} props.width Current width of the component.

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -15,7 +15,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {Array} props.loaderSelection Selection to be used for fetching data.
  * @param {Boolean} props.zoomLock Whether or not lock the zooms of the two views.
  * @param {Boolean} props.panLock Whether or not lock the pans of the two views.
- * @param {number} props.initialViewState Object like { target: [x, y, 0], zoom: -zoom } for initializing where the viewer looks (optional - this is inferred from height/width/loader
+ * @param {Object} props.viewStates List of objects like [{ target: [x, y, 0], zoom: -zoom, id: 'left' }, { target: [x, y, 0], zoom: -zoom, id: 'right' }] for initializing where the viewer looks (optional - this is inferred from height/width/loader
  * internally by default using getDefaultInitialViewState).
  * @param {number} props.height Current height of the component.
  * @param {number} props.width Current width of the component.
@@ -36,7 +36,7 @@ const SideBySideViewer = props => {
     sliderValues,
     colorValues,
     channelIsOn,
-    initialViewState,
+    viewStates: viewStatesProp,
     colormap,
     panLock,
     loaderSelection,
@@ -57,11 +57,22 @@ const SideBySideViewer = props => {
     oldLoaderSelection,
     onViewportLoad
   } = useGlobalSelection(loaderSelection, transitionFields);
-  const viewState =
-    initialViewState ||
-    getDefaultInitialViewState(loader, { height, width }, 0.5);
+  let viewStates;
+  if (viewStatesProp) {
+    viewStates = viewStatesProp;
+  } else {
+    const defaultViewState = getDefaultInitialViewState(
+      loader,
+      { height, width },
+      0.5
+    );
+    viewStates = [
+      { ...defaultViewState, id: 'left' },
+      { ...defaultViewState, id: 'right' }
+    ];
+  }
   const detailViewLeft = new SideBySideView({
-    initialViewState: { ...viewState, id: 'left' },
+    id: 'left',
     linkedIds: ['right'],
     panLock,
     zoomLock,
@@ -69,7 +80,7 @@ const SideBySideViewer = props => {
     width: width / 2
   });
   const detailViewRight = new SideBySideView({
-    initialViewState: { ...viewState, id: 'right' },
+    id: 'right',
     x: width / 2,
     linkedIds: ['left'],
     panLock,
@@ -102,6 +113,7 @@ const SideBySideViewer = props => {
       views={views}
       randomize
       onViewStateChange={onViewStateChange}
+      viewStates={viewStates}
     />
   ) : null;
 };

--- a/src/viewers/VivViewer.js
+++ b/src/viewers/VivViewer.js
@@ -103,8 +103,7 @@ export default class VivViewer extends PureComponent {
           viewState => viewState.id === view.id
         );
         return (
-          currViewState &&
-          (!prevViewState || !areViewStatesEqual(currViewState, prevViewState))
+          currViewState && !areViewStatesEqual(currViewState, prevViewState)
         );
       })
       .map(view => view.id);

--- a/src/views/OverviewView.js
+++ b/src/views/OverviewView.js
@@ -37,7 +37,7 @@ class OverviewController extends Controller {
  * From the base class VivView, only the initialViewState argument is used.  This class uses private methods to position its x and y from the
  * additional arguments:
  * @param {Object} args
- * @param {Object} args.initialViewState ViewState object: { target: [x, y, 0], zoom: -zoom }.
+ * @param {string} args.id id for this VivView.
  * @param {Object} args.loader Loader to be used for inferring zoom level and fetching data.  It must have the properies `dtype`, `numLevels`, and `tileSize` and implement `getTile` and `getRaster`.
  * @param {number} args.detailHeight Height of the detail view.
  * @param {number} args.detailWidth Width of the detail view.
@@ -52,7 +52,7 @@ class OverviewController extends Controller {
  * */
 export default class OverviewView extends VivView {
   constructor({
-    initialViewState,
+    id,
     loader,
     detailHeight,
     detailWidth,
@@ -65,7 +65,7 @@ export default class OverviewView extends VivView {
     maximumHeight = 350,
     clickCenter = true
   }) {
-    super({ initialViewState });
+    super({ id });
     this.margin = margin;
     this.loader = loader;
     this.position = position;

--- a/src/views/SideBySideView.js
+++ b/src/views/SideBySideView.js
@@ -17,7 +17,7 @@ import { getImageLayers, getVivId, makeBoundingBox } from './utils';
  * */
 export default class SideBySideView extends VivView {
   constructor({
-    initialViewState,
+    id,
     x,
     y,
     height,
@@ -28,7 +28,7 @@ export default class SideBySideView extends VivView {
     viewportOutlineColor = [255, 255, 255],
     viewportOutlineWidth = 10
   }) {
-    super({ initialViewState, x, y, height, width });
+    super({ id, x, y, height, width });
     this.linkedIds = linkedIds;
     this.panLock = panLock;
     this.zoomLock = zoomLock;

--- a/src/views/VivView.js
+++ b/src/views/VivView.js
@@ -4,7 +4,7 @@ import { OrthographicView } from '@deck.gl/core';
 /**
  * This class generates a layer and a view for use in the VivViewer
  * @param {Object} args
- * @param {Object} args.initialViewState ViewState object: { target: [x, y, 0], zoom: -zoom }.
+ * @param {string} args.id id for this VivView.
  * @param {Object} args.height Width of the view.
  * @param {Object} args.width Height of the view.
  * @param {string} args.id Id for the current view
@@ -12,11 +12,9 @@ import { OrthographicView } from '@deck.gl/core';
  * @param {number} args.y Y (top-left) location on the screen for the current view
  */
 export default class VivView {
-  constructor({ initialViewState, x = 0, y = 0, height, width }) {
-    const { id } = initialViewState;
+  constructor({ id, x = 0, y = 0, height, width }) {
     this.width = width;
     this.height = height;
-    this.initialViewState = initialViewState;
     this.id = id;
     this.x = x;
     this.y = y;

--- a/tests/layers_views/views/OverviewView.spec.js
+++ b/tests/layers_views/views/OverviewView.spec.js
@@ -1,7 +1,15 @@
 /* eslint-disable import/no-extraneous-dependencies, no-unused-expressions */
 import test from 'tape-catch';
-import { OverviewView, DETAIL_VIEW_ID, OVERVIEW_VIEW_ID } from '../../../src/views';
-import { generateViewTests, defaultArguments } from './VivView.spec';
+import {
+  OverviewView,
+  DETAIL_VIEW_ID,
+  OVERVIEW_VIEW_ID
+} from '../../../src/views';
+import {
+  generateViewTests,
+  defaultArguments,
+  defaultViewState
+} from './VivView.spec';
 import { OverviewLayer } from '../../../src/layers';
 
 const id = OVERVIEW_VIEW_ID;
@@ -14,14 +22,14 @@ const loader = {
 };
 const overviewViewArguments = {
   ...defaultArguments,
+  id,
   loader,
   detailHeight: 1000,
   detailWidth: 500
 };
-overviewViewArguments.initialViewState = {
-  ...defaultArguments.initialViewState
+const overviewViewState = {
+  ...defaultViewState
 };
-overviewViewArguments.initialViewState.id = OVERVIEW_VIEW_ID;
 
 const linkedViewIds = [DETAIL_VIEW_ID];
 
@@ -32,8 +40,8 @@ test(`OverviewView layer type check.`, t => {
   const layers = view.getLayers({
     props: { loader },
     viewStates: {
-      [id]: overviewViewArguments.initialViewState,
-      detail: overviewViewArguments.initialViewState
+      [id]: overviewViewState,
+      [DETAIL_VIEW_ID]: overviewViewState
     }
   });
   t.ok(

--- a/tests/layers_views/views/VivView.spec.js
+++ b/tests/layers_views/views/VivView.spec.js
@@ -5,28 +5,25 @@ import { VivView } from '../../../src/views';
 import { getVivId } from '../../../src/views/utils';
 
 export const defaultArguments = {
-  initialViewState: {
-    target: [5000, 5000, 0],
-    zoom: -4,
-    id: 'foo'
-  },
+  id: 'foo',
   x: 100,
   y: 50,
   height: 500,
   width: 1000
 };
 
+export const defaultViewState = {
+  target: [5000, 5000, 0],
+  zoom: -4
+};
+
 export function generateViewTests(ViewType, args, linkedViewIds = []) {
   test(`${ViewType.name} constructor test`, t => {
     const view = new ViewType(args);
-    const { height, width, x, y } = view;
-    t.equal(
-      view.id,
-      args.initialViewState.id,
-      `${ViewType.name} constructor should destructure initialViewState for id.`
-    );
+    const { id, height, width, x, y } = view;
+    t.ok(id, `${ViewType.name} should have its id.`);
     t.ok(height, `${ViewType.name} should have its height.`);
-    t.ok(width, `${ViewType.name} should  haveits width.`);
+    t.ok(width, `${ViewType.name} should  have its width.`);
     t.ok(x, `${ViewType.name} should have its x position.`);
     t.ok(y, `${ViewType.name} should have its y position.`);
     t.end();
@@ -61,10 +58,10 @@ export function generateViewTests(ViewType, args, linkedViewIds = []) {
 
   test(`${ViewType.name} layer test`, t => {
     const view = new ViewType(args);
-    const viewStates = { [view.id]: defaultArguments.initialViewState };
+    const viewStates = { [view.id]: defaultViewState };
     linkedViewIds.forEach(id => {
       // endow linked views with some properties
-      viewStates[id] = defaultArguments.initialViewState;
+      viewStates[id] = defaultViewState;
     });
     const layers = view.getLayers({
       props: { loader: { type: 'loads', isPyramid: true } },


### PR DESCRIPTION
This addresses #353. Contrary to what I wrote before, @ilan-gold's implementation already worked for `SideBySideViewer`. One only had to set `viewStates` instead of `viewState` in Avivator. I tested it extensively with different view states for the left and right views.

I implemented the state update that I proposed in #353. I made some tweaks to the comparisons to make it possible to add view state for a view that didn't initially have that prop. I replaced `lodash.isequal` with `fast-deep-equal` because it is seven times as fast in a benchmark reported in their repo. Also, you already had it as an indirect dev dependency.

I updated all failing tests to the new props.