### PR TITLE
Upgrade zarr@0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 to support other types of images. Migrate `src/loaders` to TypeScript.
 - Add `loadBioforamtsZarr`, `loadOmeZarr`, and `loadOmeTiff` utilities.
 - Add predictive, fully typed OME-XML response from `fast-xml-parser`.
+- Upgrade Zarr.js to v0.4.
 
 ## 0.8.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14026,7 +14026,8 @@
     "ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.9.0",
@@ -15104,13 +15105,12 @@
       "dev": true
     },
     "zarr": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.3.1.tgz",
-      "integrity": "sha512-M0/Qv3IYb0zgxrL6EWQgnS/CNnSggBaybEfi9Bc8eWakJa6Hr+JN/NDGJZIqyd8NgqoW2to3S6VGcIwuMIgTQQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.4.0.tgz",
+      "integrity": "sha512-zvxdX3aRWxjy6H3OtA7R05NNZvRKxn/7bkNJhUsVKKbNoJ3DBqYERQfzI4WfAV1OTcclqvlYwkQ7DWsGJA5QEw==",
       "requires": {
         "numcodecs": "^0.1.0",
-        "p-queue": "6.2.0",
-        "ts-interface-checker": "^0.1.10"
+        "p-queue": "6.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "geotiff": "ilan-gold/geotiff.js#ilan-gold/viv_083",
     "math.gl": "^3.3.0",
     "quickselect": "^2.0.0",
-    "zarr": "^0.3.0"
+    "zarr": "^0.4.0"
   },
   "prettier": {
     "singleQuote": true,

--- a/src/loaders/zarr/index.ts
+++ b/src/loaders/zarr/index.ts
@@ -1,4 +1,5 @@
-import { HTTPStore, FileStore } from './lib/storage';
+import { FileStore } from './lib/storage';
+import { HTTPStore } from 'zarr';
 import { getRootPrefix } from './lib/utils';
 
 import { load as loadBioformats } from './bioformats-zarr';
@@ -20,15 +21,13 @@ export async function loadBioformatsZarr(
   source: string | (File & { path: string })[],
   options: ZarrOptions = {}
 ) {
-  const { fetchOptions } = options;
-
   const METADATA = 'METADATA.ome.xml';
   const ZARR_DIR = 'data.zarr';
 
   if (typeof source === 'string') {
     const url = source.endsWith('/') ? source.slice(0, -1) : source;
-    const store = new HTTPStore(url + '/' + ZARR_DIR, fetchOptions);
-    const xmlSource = await fetch(url + '/' + METADATA, fetchOptions);
+    const store = new HTTPStore(url + '/' + ZARR_DIR, options);
+    const xmlSource = await fetch(url + '/' + METADATA, options.fetchOptions);
     return loadBioformats(store, xmlSource);
   }
 
@@ -70,7 +69,7 @@ export async function loadOmeZarr(
   source: string,
   options: ZarrOptions & { type?: 'multiscales' }
 ) {
-  const store = new HTTPStore(source, options.fetchOptions);
+  const store = new HTTPStore(source, options);
 
   if (options?.type !== 'multiscales') {
     throw Error('Only multiscale OME-Zarr is supported.');

--- a/src/loaders/zarr/pixel-source.ts
+++ b/src/loaders/zarr/pixel-source.ts
@@ -2,10 +2,8 @@ import { BoundsCheckError } from 'zarr';
 import { isInterleaved } from '../utils';
 import { getIndexer } from './lib/indexer';
 
-import type { HTTPStore } from './lib/storage';
 import type { ZarrArray } from 'zarr';
-import type { RawArray } from 'zarr/dist/types/rawArray';
-import type { AsyncStore } from 'zarr/dist/types/storage/types';
+import type { RawArray } from 'zarr/types/rawArray';
 
 import type {
   PixelSource,
@@ -86,19 +84,9 @@ class ZarrPixelSource<S extends string[]> implements PixelSource<S> {
     const { x, y, selection, signal } = props;
     const sel = this._chunkIndex(selection, x, y);
 
-    const store = this._data.store as HTTPStore | AsyncStore<ArrayBuffer>;
-
-    // Injects `signal` prior to zarr.js calling `store.getItem`
-    if (signal && '__vivAddSignal' in store) {
-      store.__vivAddSignal(signal);
-    }
-
-    const { data, shape } = (await this._data.getRawChunk(sel)) as RawArray;
-
-    // Clear signal from HTTPStore
-    if ('__vivClearSignal' in store) {
-      store.__vivClearSignal();
-    }
+    const { data, shape } = (await this._data.getRawChunk(sel, {
+      storeOptions: { signal }
+    })) as RawArray;
 
     const [height, width] = shape;
     return { data, width, height } as PixelData;


### PR DESCRIPTION
Upgrades zarr.js to v0.4. 

- Removes our custom `HTTPStore` since `zarr.HTTPStore` supports passing `RequestInit` (including signal) in `getRawChunk`. 

- Replaces our hierarchy traversal (concatonating url paths + `getJson` for metdata) with zarr's built-in hierarchy traversal (`openGroup`, `grp.getItem(arrayPath)`).

- Uses `Attributes` object to read `.zattrs`. 

- _Finally_ removes those annoying 404s for `.zgroup` when trying to open an array.
