### PR TITLE
Unify handling Int8Array, Int16Array, and Int32Array TypedArrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 to support other types of images. Migrate `src/loaders` to TypeScript.
 - Add `loadBioforamtsZarr`, `loadOmeZarr`, and `loadOmeTiff` utilities.
 - Add predictive, fully typed OME-XML response from `fast-xml-parser`.
+- Unify handling of Int8Array, Int16Array, and Int32Array TypedArrays.
 
 ## 0.8.3
 

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -4,7 +4,7 @@ import GL from '@luma.gl/constants';
 
 import XRLayer from './XRLayer';
 import BitmapLayer from './BitmapLayer';
-import { to32BitFloat, onPointer } from './utils';
+import { onPointer, isIntArray, int2UintArray } from './utils';
 import { isInterleaved } from '../loaders/utils';
 
 const defaultProps = {
@@ -106,11 +106,18 @@ export default class ImageLayer extends CompositeLayer {
             raster.format = GL.RGB;
             raster.dataFormat = GL.RGB;
           }
-        } else if (!isWebGL2(this.context.gl)) {
+        } else {
           // data is for XLRLayer in non-WebGL2 evironment
-          // we need to convert data to compatible textures
-          raster.data = to32BitFloat(raster.data);
+          if (isIntArray(raster.data[0])) {
+            raster.data = raster.data.map(d => int2UintArray(d));
+          }
+
+          if (!isWebGL2(this.context.gl)) {
+            // we need to convert data to compatible textures
+            raster.data = raster.data.map(d => new Float32Array(d));
+          }
         }
+
         if (onViewportLoad) {
           onViewportLoad(raster);
         }

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -5,7 +5,7 @@ import GL from '@luma.gl/constants';
 
 import MultiscaleImageLayerBase from './MultiscaleImageLayerBase';
 import ImageLayer from '../ImageLayer';
-import { to32BitFloat, onPointer } from '../utils';
+import { onPointer, int2UintArray, isIntArray } from '../utils';
 import {
   getImageSize,
   isInterleaved,
@@ -166,8 +166,15 @@ export default class MultiscaleImageLayer extends CompositeLayer {
           return tile;
         }
 
+        // Viv's shaders don't work for signed arrays, need to cast to Uint
+        if (isIntArray(tile.data[0])) {
+          tile.data = tile.data.map(d => int2UintArray(d));
+        }
+
+        // Need to cast data regardless of dtype f32 if not WebGL
+        // TODO: skip if already float32? This copies the data...
         if (noWebGl2) {
-          tile.data = to32BitFloat(tile.data);
+          tile.data = tile.data.map(d => new Float32Array(d));
         }
 
         return tile;

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -11,8 +11,7 @@ import fs2 from './xr-layer-fragment.webgl2.glsl';
 import vs1 from './xr-layer-vertex.webgl1.glsl';
 import vs2 from './xr-layer-vertex.webgl2.glsl';
 import { lens, channels } from './shader-modules';
-import { DTYPE_VALUES } from '../../constants';
-import { padColorsAndSliders } from '../utils';
+import { padColorsAndSliders, getDtypeAttrs } from '../utils';
 
 const SHADER_MODULES = [
   { fs: fs1, fscmap: fsColormap1, vs: vs1 },
@@ -302,8 +301,7 @@ export default class XRLayer extends Layer {
   dataToTexture(data, width, height) {
     const { gl } = this.context;
     const noWebGL2 = !isWebGL2(gl);
-    const { dtype } = this.props;
-    const { format, dataFormat, type } = DTYPE_VALUES[dtype];
+    const { format, dataFormat, type } = getDtypeAttrs(this.props.dtype);
     const texture = new Texture2D(this.context.gl, {
       width,
       height,

--- a/src/layers/utils.js
+++ b/src/layers/utils.js
@@ -31,7 +31,7 @@ export function padColorsAndSliders({
   const colors = colorValues.map((color, i) =>
     channelIsOn[i] ? color.map(c => c / MAX_COLOR_INTENSITY) : DEFAULT_COLOR_OFF
   );
-  const maxSliderValue = (domain && domain[1]) || DTYPE_VALUES[dtype].max;
+  const maxSliderValue = (domain && domain[1]) || getDtypeAttrs(dtype).max;
   const sliders = sliderValues.map((slider, i) =>
     channelIsOn[i] ? slider : [maxSliderValue, maxSliderValue]
   );
@@ -61,11 +61,38 @@ export function padColorsAndSliders({
   return paddedColorsAndSliders;
 }
 
-export function to32BitFloat(data) {
-  const data32bit = data.map(arr => {
-    return new Float32Array(arr);
-  });
-  return data32bit;
+/**
+ *
+ * @param {import('../types').SupportedTypedArray} data
+ */
+export function isIntArray(data) {
+  return data.constructor.name.startsWith('Int');
+}
+
+/**
+ * Get same constants properties for Int as Uint.
+ * @param {import('../types').SupportedDtype} dtype
+ */
+export function getDtypeAttrs(dtype) {
+  // We cast all IntArray buffers to Uint, so any dtype
+  // that is a Int array we want to get the constant 
+  // values for the Uint counterpart.
+  if (dtype.startsWith('Int')) {
+    dtype = `Ui${dtype.slice(1)}`;
+  }
+  return DTYPE_VALUES[dtype];
+}
+
+/**
+ *
+ * @param {Int8Array | Int16Array | Int32Array} data
+ * @returns {Uint8Array | Uint16Array | Uint32Array}
+ */
+export function int2UintArray(data) {
+  const suffix = data.constructor.name.slice(1); // nt8Array | nt16ARray | nt32Array
+  const name = `Ui${suffix}`;
+  const ctr = globalThis[name];
+  return new ctr(data);
 }
 
 export function onPointer(layer) {

--- a/src/loaders/tiff/lib/utils.ts
+++ b/src/loaders/tiff/lib/utils.ts
@@ -6,10 +6,9 @@ const DTYPE_LOOKUP = {
   uint16: 'Uint16',
   uint32: 'Uint32',
   float: 'Float32',
-  // TODO: we currently need to cast these dtypes to their uint counterparts.
-  int8: 'Uint8',
-  int16: 'Uint16',
-  int32: 'Uint32'
+  int8: 'Int8',
+  int16: 'Int16',
+  int32: 'Int32'
 } as const;
 
 export function getOmePixelSourceMeta({ Pixels }: OMEXML[0]) {

--- a/src/loaders/tiff/pixel-source.ts
+++ b/src/loaders/tiff/pixel-source.ts
@@ -65,16 +65,6 @@ class TiffPixelSource<S extends string[]> implements PixelSource<S> {
       data = new Float32Array(data.buffer);
     }
 
-    // geotiff.js returns the correct TypedArray but need to cast to Uint for viv.
-    if (data?.constructor.name.startsWith('Int')) {
-      const suffix = data.constructor.name.slice(1); // nt8Array | nt16Array | nt32Array
-      const name = `Ui${suffix}` as
-        | 'Uint8Array'
-        | 'Uint16Array'
-        | 'Uint32Array';
-      data = new globalThis[name](data);
-    }
-
     return {
       data: data,
       width: raster.width,

--- a/src/loaders/zarr/pixel-source.ts
+++ b/src/loaders/zarr/pixel-source.ts
@@ -20,7 +20,10 @@ const DTYPE_LOOKUP = {
   u1: 'Uint8',
   u2: 'Uint16',
   u4: 'Uint32',
-  f4: 'Float32'
+  f4: 'Float32',
+  i1: 'Int8',
+  i2: 'Int16',
+  i4: 'Int32'
 } as const;
 
 type ZarrIndexer<S extends string[]> = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,11 @@
-export type SupportedDtype = 'Uint8' | 'Uint16' | 'Uint32' | 'Float32';
+export type SupportedDtype =
+  | 'Uint8'
+  | 'Uint16'
+  | 'Uint32'
+  | 'Int8'
+  | 'Int16'
+  | 'Int32'
+  | 'Float32';
 export type SupportedTypedArray = InstanceType<
   typeof globalThis[`${SupportedDtype}Array`]
 >;

--- a/tests/loaders/bioformats-zarr.spec.js
+++ b/tests/loaders/bioformats-zarr.spec.js
@@ -30,7 +30,7 @@ test('Creates correct ZarrPixelSource.', async t => {
 });
 
 test('Get raster data.', async t => {
-  t.plan(10);
+  t.plan(13);
   try {
     const { data } = await load(store, await meta);
     const [base] = data;
@@ -41,6 +41,7 @@ test('Get raster data.', async t => {
       t.equal(pixelData.width, 439);
       t.equal(pixelData.height, 167);
       t.equal(pixelData.data.length, 439 * 167);
+      t.equal(pixelData.data.constructor.name, 'Int8Array');
     }
 
     try {

--- a/tests/loaders/ome-tiff.spec.js
+++ b/tests/loaders/ome-tiff.spec.js
@@ -4,7 +4,7 @@ import { fromFile } from 'geotiff';
 import { load } from '../../src/loaders/tiff/ome-tiff';
 
 test('Creates correct TiffPixelSource for OME-TIFF.', async t => {
-  t.plan(6);
+  t.plan(5);
   try {
     const tiff = await fromFile('tests/loaders/fixtures/multi-channel.ome.tif');
     const { data } = await load(tiff);
@@ -26,7 +26,6 @@ test('Creates correct TiffPixelSource for OME-TIFF.', async t => {
       'Photometric interpretation is 1.'
     );
     t.equal(base.meta.physicalSizes, undefined, 'No physical sizes.');
-    t.equal(base.dtype, 'Uint8', 'Data should be cast from int8 to uint8');
   } catch (e) {
     t.fail(e);
   }
@@ -45,7 +44,7 @@ test('Get raster data.', async t => {
       t.equal(pixelData.width, 439);
       t.equal(pixelData.height, 167);
       t.equal(pixelData.data.length, 439 * 167);
-      t.equal(pixelData.data.constructor.name, 'Uint8Array');
+      t.equal(pixelData.data.constructor.name, 'Int8Array');
     }
 
     try {


### PR DESCRIPTION
Fixes #370 

Rather than making the PixelSource convert the data, we should do the conversion as close to making the texture as possible. This way, this pixel sources reflect the actual dtype of the data and internally we do what we need to render pixels.

Two screenshots of test data (from `test/loaders/fixtures`): OME-TIFF and Bioformats-zarr

<img width="886" alt="image" src="https://user-images.githubusercontent.com/24403730/107096251-4b5e4c00-67d8-11eb-862a-ab9f8d6f7fb8.png">
