### PR TITLE
Export default not * from pixel-sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Export `defaults` from `tiff/pixel-source.ts` and `zarr/pixel-source.ts` as `TiffPixelSource` and `ZarrPixelSource`.
 
 ## 0.9.0
 

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -2,5 +2,5 @@ export { loadOmeTiff } from './tiff';
 export { loadBioformatsZarr, loadOmeZarr } from './zarr';
 export { getChannelStats } from './utils';
 
-export * as TiffPixelSource from './tiff/pixel-source';
-export * as ZarrPixelSource from './zarr/pixel-source';
+export { default as TiffPixelSource } from './tiff/pixel-source';
+export { default as ZarrPixelSource } from './zarr/pixel-source';


### PR DESCRIPTION
I accidentally exported `*` and not `default` for each PixelSource. This corrects the exports.