### PR TITLE
Don't mutate Zarr chunk selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 - Export `defaults` from `tiff/pixel-source.ts` and `zarr/pixel-source.ts` as `TiffPixelSource` and `ZarrPixelSource`.
-- Copy arry-like selection for `ZarrPixelSource` rather than mutating.
+- Copy array-like selection for `ZarrPixelSource` rather than mutating.
 
 ## 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Export `defaults` from `tiff/pixel-source.ts` and `zarr/pixel-source.ts` as `TiffPixelSource` and `ZarrPixelSource`.
+- Copy arry-like selection for `ZarrPixelSource` rather than mutating.
 
 ## 0.9.0
 

--- a/src/loaders/zarr/lib/indexer.ts
+++ b/src/loaders/zarr/lib/indexer.ts
@@ -15,7 +15,7 @@ export function getIndexer<T extends string>(labels: T[]) {
   const dims = getDims(labels);
   return (sel: { [K in T]: number } | number[]) => {
     if (Array.isArray(sel)) {
-      return sel;
+      return [...sel];
     }
     const selection: number[] = Array(size).fill(0);
     for (const [key, value] of Object.entries(sel)) {


### PR DESCRIPTION
Indexing a `ZarrPixelSource` with an `number[]` selection would mutate the original selection (not good!). This PR changes the zarr indexer to create a copy of the selection that is safe to mutate.