### PR TITLE
Fix Scale Bar in Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 - Export `defaults` from `tiff/pixel-source.ts` and `zarr/pixel-source.ts` as `TiffPixelSource` and `ZarrPixelSource`.
 - Copy array-like selection for `ZarrPixelSource` rather than mutating.
+- Fix scale bar bug in `View` to match new loaders.
 
 ## 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+
 - Export `defaults` from `tiff/pixel-source.ts` and `zarr/pixel-source.ts` as `TiffPixelSource` and `ZarrPixelSource`.
 - Copy array-like selection for `ZarrPixelSource` rather than mutating.
 - Fix scale bar bug in `View` to match new loaders.
@@ -20,7 +21,7 @@
 - Fix z-slider broken by transition fields.
 - Upgrade deck.gl to 8.4.0-beta.1 to handle aborting tiles after selection better.
 - Rewrite data loaders as `PixelSource` | `PixelSource[]`. Introduce `ZarrPixelSource` and `TiffPixelSource`
-to support other types of images. Migrate `src/loaders` to TypeScript.
+  to support other types of images. Migrate `src/loaders` to TypeScript.
 - Add `loadBioforamtsZarr`, `loadOmeZarr`, and `loadOmeTiff` utilities.
 - Add predictive, fully typed OME-XML response from `fast-xml-parser`.
 - Upgrade Zarr.js to v0.4.

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -17,16 +17,14 @@ export default class DetailView extends VivView {
     const layers = getImageLayers(id, props);
 
     // Inspect the first pixel source for physical sizes
-    const {
-      meta: { physicalSizes }
-    } = loader[0];
-    if (physicalSizes?.x) {
+    if (loader[0]?.meta?.physicalSizes?.x) {
+      const { size, unit } = loader[0].meta.physicalSizes.x;
       layers.push(
         new ScaleBarLayer({
           id: getVivId(id),
           loader,
-          unit: physicalSizes.x.unit,
-          size: physicalSizes.x.size,
+          unit,
+          size,
           viewState: { ...layerViewState, height, width }
         })
       );

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -17,14 +17,14 @@ export default class DetailView extends VivView {
     const layers = getImageLayers(id, props);
 
     // Inspect the first pixel source for physical sizes
-    const { physicalSizes } = loader[0];
+    const { meta: { physicalSizes } } = loader[0];
     if (physicalSizes?.x) {
       layers.push(
         new ScaleBarLayer({
           id: getVivId(id),
           loader,
           unit: physicalSizes.x.unit,
-          size: physicalSizes.x.value,
+          size: physicalSizes.x.size,
           viewState: { ...layerViewState, height, width }
         })
       );

--- a/src/views/DetailView.js
+++ b/src/views/DetailView.js
@@ -17,7 +17,9 @@ export default class DetailView extends VivView {
     const layers = getImageLayers(id, props);
 
     // Inspect the first pixel source for physical sizes
-    const { meta: { physicalSizes } } = loader[0];
+    const {
+      meta: { physicalSizes }
+    } = loader[0];
     if (physicalSizes?.x) {
       layers.push(
         new ScaleBarLayer({

--- a/src/views/SideBySideView.js
+++ b/src/views/SideBySideView.js
@@ -118,16 +118,14 @@ export default class SideBySideView extends VivView {
     });
     layers.push(border);
 
-    const {
-      meta: { physicalSizes }
-    } = loader[0];
-    if (physicalSizes?.x) {
+    if (loader[0]?.meta?.physicalSizes?.x) {
+      const { size, unit } = loader[0].meta.physicalSizes.x;
       layers.push(
         new ScaleBarLayer({
           id: getVivId(id),
           loader,
-          unit: physicalSizes.x.unit,
-          size: physicalSizes.x.size,
+          unit,
+          size,
           viewState: { ...layerViewState, height, width }
         })
       );

--- a/src/views/SideBySideView.js
+++ b/src/views/SideBySideView.js
@@ -118,7 +118,9 @@ export default class SideBySideView extends VivView {
     });
     layers.push(border);
 
-    const { meta: { physicalSizes } } = loader[0];
+    const {
+      meta: { physicalSizes }
+    } = loader[0];
     if (physicalSizes?.x) {
       layers.push(
         new ScaleBarLayer({

--- a/src/views/SideBySideView.js
+++ b/src/views/SideBySideView.js
@@ -118,14 +118,14 @@ export default class SideBySideView extends VivView {
     });
     layers.push(border);
 
-    const { physicalSizes } = loader[0];
+    const { meta: { physicalSizes } } = loader[0];
     if (physicalSizes?.x) {
       layers.push(
         new ScaleBarLayer({
           id: getVivId(id),
           loader,
           unit: physicalSizes.x.unit,
-          size: physicalSizes.x.value,
+          size: physicalSizes.x.size,
           viewState: { ...layerViewState, height, width }
         })
       );

--- a/tests/layers_views/views/DetailView.spec.js
+++ b/tests/layers_views/views/DetailView.spec.js
@@ -45,7 +45,7 @@ test(`DetailView layer type and props check`, t => {
   t.end();
 });
 
-test(`DetailView layer type and props check`, t => {
+test(`DetailView does not render scale bar without physical size`, t => {
   const view = new DetailView(detailViewArguments);
   const loader = { type: 'loads' };
   const layers = view.getLayers({

--- a/tests/layers_views/views/DetailView.spec.js
+++ b/tests/layers_views/views/DetailView.spec.js
@@ -17,9 +17,9 @@ test(`DetailView layer type and props check`, t => {
   const layers = view.getLayers({
     props: {
       loader: [
-        { ...loader, physicalSizes: { x: { value: 1, unit: 'cm' } }},
-        { ...loader, physicalSizes: { x: { value: 1, unit: 'cm' } }},
-        { ...loader, physicalSizes: { x: { value: 1, unit: 'cm' } }},
+        { ...loader, meta: { physicalSizes: { x: { value: 1, unit: 'cm' } } } },
+        { ...loader, meta: { physicalSizes: { x: { value: 1, unit: 'cm' } } } },
+        { ...loader, meta: { physicalSizes: { x: { value: 1, unit: 'cm' } } } }
       ]
     },
     viewStates: {
@@ -41,6 +41,31 @@ test(`DetailView layer type and props check`, t => {
     layers[0].props.viewportId,
     view.id,
     'DetailView id should be passed down to layer as ViewportId.'
+  );
+  t.end();
+});
+
+test(`DetailView layer type and props check`, t => {
+  const view = new DetailView(detailViewArguments);
+  const loader = { type: 'loads' };
+  const layers = view.getLayers({
+    props: {
+      loader: [loader, loader]
+    },
+    viewStates: {
+      detail: {
+        target: [0, 0, 0],
+        zoom: 0
+      }
+    }
+  });
+  t.ok(
+    layers[0] instanceof MultiscaleImageLayer,
+    'DetailView layer should be MultiscaleImageLayer.'
+  );
+  t.ok(
+    layers.length === 1,
+    'DetailView layer should not display ScaleBarLayer in without physical size.'
   );
   t.end();
 });

--- a/tests/layers_views/views/SideBySideView.spec.js
+++ b/tests/layers_views/views/SideBySideView.spec.js
@@ -4,7 +4,11 @@ import { PolygonLayer } from '@deck.gl/layers';
 
 import { SideBySideView } from '../../../src/views';
 import { generateViewTests, defaultArguments } from './VivView.spec';
-import { MultiscaleImageLayer, ImageLayer, ScaleBarLayer } from '../../../src/layers';
+import {
+  MultiscaleImageLayer,
+  ImageLayer,
+  ScaleBarLayer
+} from '../../../src/layers';
 
 generateViewTests(SideBySideView, defaultArguments);
 
@@ -13,8 +17,9 @@ test(`SideBySideView layer type and props check`, t => {
   const loader = { type: 'loads' };
   const layers = view.getLayers({
     props: {
-      loader: 
-        [{ ...loader, physicalSizes: { x: { value: 1, unit: 'cm' } } }],
+      loader: [
+        { ...loader, meta: { physicalSizes: { x: { value: 1, unit: 'cm' } } } }
+      ]
     },
     viewStates: {
       foo: {
@@ -43,16 +48,15 @@ test(`SideBySideView layer type and props check`, t => {
   t.end();
 });
 
-
 test(`SideBySideView layer with multiscale`, t => {
   const view = new SideBySideView(defaultArguments);
   const loader = { type: 'loads' };
   const layers = view.getLayers({
     props: {
       loader: [
-        { ...loader, physicalSizes: { x: { value: 1, unit: 'cm' } } },
-        { ...loader, physicalSizes: { x: { value: 1, unit: 'cm' } } }
-      ],
+        { ...loader, meta: { physicalSizes: { x: { value: 1, unit: 'cm' } } } },
+        { ...loader, meta: { physicalSizes: { x: { value: 1, unit: 'cm' } } } }
+      ]
     },
     viewStates: {
       foo: {
@@ -77,6 +81,35 @@ test(`SideBySideView layer with multiscale`, t => {
     layers[0].props.viewportId,
     view.id,
     'SideBySideView id should be passed down to layer as ViewportId.'
+  );
+  t.end();
+});
+
+test(`SideBySideView layer without physical size scale bar`, t => {
+  const view = new SideBySideView(defaultArguments);
+  const loader = { type: 'loads' };
+  const layers = view.getLayers({
+    props: {
+      loader: [loader, loader]
+    },
+    viewStates: {
+      foo: {
+        target: [0, 0, 0],
+        zoom: 0
+      }
+    }
+  });
+  t.ok(
+    layers[0] instanceof MultiscaleImageLayer,
+    'SideBySideView layer should be MultiscaleImageLayer.'
+  );
+  t.ok(
+    layers[1] instanceof PolygonLayer,
+    'SideBySideView layer should be PolygonLayer.'
+  );
+  t.ok(
+    layers.length === 2,
+    'SideBySideView should not have more than PolygonLayer and MultiscaleImageLayer'
   );
   t.end();
 });

--- a/tests/layers_views/views/SideBySideView.spec.js
+++ b/tests/layers_views/views/SideBySideView.spec.js
@@ -85,7 +85,7 @@ test(`SideBySideView layer with multiscale`, t => {
   t.end();
 });
 
-test(`SideBySideView layer without physical size scale bar`, t => {
+test(`SideBySideView layer does not render scale bar without physical size`, t => {
   const view = new SideBySideView(defaultArguments);
   const loader = { type: 'loads' };
   const layers = view.getLayers({


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #376
<!-- For all the PRs -->
#### Change List
- `physicalSizes` moved to the `meta` attribute and off of the loader itself - we did not update the `DetailView` or `SideBySideView` to reflect this.
- `value` -> `size` in the loaders so this needs to be used as such in the views as well
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
