### PR TITLE
Allow `trimPyramid` to Return More Levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Allow `trimPyramid` to return zarr `ZarrPixelSource`s that can be rendered properly but have different `tileSize` than base resolution.
+
 ## 0.9.1
 
 ### Added

--- a/src/loaders/utils.ts
+++ b/src/loaders/utils.ts
@@ -162,4 +162,10 @@ export function getImageSize<T extends string[]>(source: PixelSource<T>) {
   return { height, width };
 }
 
+export function getChunkSize<T extends string[]>(source: PixelSource<T>) {
+  const interleaved = isInterleaved(source.shape);
+  const [height, width] = source.chunks.slice(interleaved ? -3 : -2);
+  return { height, width };
+}
+
 export const SIGNAL_ABORTED = '__vivSignalAborted';

--- a/src/loaders/zarr/pixel-source.ts
+++ b/src/loaders/zarr/pixel-source.ts
@@ -52,6 +52,10 @@ class ZarrPixelSource<S extends string[]> implements PixelSource<S> {
     return this._data.shape;
   }
 
+  get chunks() {
+    return this._data.chunks;
+  }
+
   get dtype() {
     const suffix = this._data.dtype.slice(1) as keyof typeof DTYPE_LOOKUP;
     if (!(suffix in DTYPE_LOOKUP)) {


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- For other PRs without open issue -->
Right now, `trimPyramid` only checks `tileSize` but the `MultiscaleImageLayer` should be robust to different tile sizes at lower resolution levels, provided that the returned data from `getTile` matches the expected downsample-by-two data model that the layer uses internally.
#### Background
<!-- For all the PRs -->
#358 introduced the very sleek `trimPyramid` function but I think by weakening a bit, we could give more access to different levels.  This is necessary for 3D so that we can render downsampled resolutions. The goal of this PR is to strike a medium between allowing access to downsampled levels of `ZarrPixelSource` and not breaking our current rendering.
#### Change List
- Check the `chunks` sizes and the overall `shape` of the current level of the pyramid in the loop `trimPyramid` to see if it matches the expected downsampled-by-two size that can be rendered by our `MultiscaleImageLayer`.
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
