### PR TITLE
Remove pyramid trimming for ZarrPixelSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Remove `trimPyramid` and require declaration of `tileSize` in `ZarrPixelSource`.
+
 ## 0.9.1
 
 ### Added

--- a/src/loaders/zarr/bioformats-zarr.ts
+++ b/src/loaders/zarr/bioformats-zarr.ts
@@ -4,7 +4,7 @@ import { fromString } from '../omexml';
 import {
   guessBioformatsLabels,
   loadMultiscales,
-  trimPyramid
+  guessTileSize
 } from './lib/utils';
 import ZarrPixelSource from './pixel-source';
 
@@ -22,10 +22,11 @@ export async function load(
   const { data } = await loadMultiscales(root, '0');
 
   const labels = guessBioformatsLabels(data[0], imgMeta);
-  const pyramid = data.map(arr => new ZarrPixelSource(arr, labels));
+  const tileSize = guessTileSize(data[0]);
+  const pyramid = data.map(arr => new ZarrPixelSource(arr, labels, tileSize));
 
   return {
-    data: trimPyramid(pyramid),
+    data: pyramid,
     metadata: imgMeta
   };
 }

--- a/src/loaders/zarr/lib/utils.ts
+++ b/src/loaders/zarr/lib/utils.ts
@@ -1,10 +1,9 @@
 import { openGroup } from 'zarr';
 import type { ZarrArray } from 'zarr';
 import type { OMEXML } from '../../omexml';
-import { getLabels } from '../../utils';
+import { getLabels, isInterleaved } from '../../utils';
 
 import type { RootAttrs } from '../ome-zarr';
-import type { PixelSource } from '../../../types';
 
 /*
  * Returns true if data shape is that expected for OME-Zarr.
@@ -87,13 +86,8 @@ export async function loadMultiscales(store: ZarrArray['store'], path = '') {
   };
 }
 
-/*
- * Downsampled resolutions in zarr-based image pyramids might have different
- * chunk sizes which aren't supported by our image layers.
- *
- * This function trims the pyramid to just levels with the same tilesize.
- *
- */
-export function trimPyramid<S extends string[]>(pyramid: PixelSource<S>[]) {
-  return pyramid.filter(level => pyramid[0].tileSize === level.tileSize);
+export function guessTileSize(arr: ZarrArray) {
+  const interleaved = isInterleaved(arr.shape);
+  const [yChunk, xChunk] = arr.chunks.slice(interleaved ? -3 : -2);
+  return Math.min(yChunk, xChunk);
 }

--- a/src/loaders/zarr/lib/utils.ts
+++ b/src/loaders/zarr/lib/utils.ts
@@ -94,5 +94,6 @@ export function guessTileSize(arr: ZarrArray) {
   const interleaved = isInterleaved(arr.shape);
   const [yChunk, xChunk] = arr.chunks.slice(interleaved ? -3 : -2);
   const size = Math.min(yChunk, xChunk);
+  // deck.gl requirement for power-of-two tile size.
   return prevPowerOf2(size);
 }

--- a/src/loaders/zarr/lib/utils.ts
+++ b/src/loaders/zarr/lib/utils.ts
@@ -86,8 +86,13 @@ export async function loadMultiscales(store: ZarrArray['store'], path = '') {
   };
 }
 
+function prevPowerOf2(x: number) {
+  return 2 ** Math.floor(Math.log2(x));
+}
+
 export function guessTileSize(arr: ZarrArray) {
   const interleaved = isInterleaved(arr.shape);
   const [yChunk, xChunk] = arr.chunks.slice(interleaved ? -3 : -2);
-  return Math.min(yChunk, xChunk);
+  const size = Math.min(yChunk, xChunk);
+  return prevPowerOf2(size);
 }

--- a/src/loaders/zarr/ome-zarr.ts
+++ b/src/loaders/zarr/ome-zarr.ts
@@ -1,5 +1,5 @@
 import type { ZarrArray } from 'zarr';
-import { loadMultiscales, trimPyramid } from './lib/utils';
+import { loadMultiscales, guessTileSize } from './lib/utils';
 import ZarrPixelSource from './pixel-source';
 import type { Labels } from '../../types';
 
@@ -38,9 +38,10 @@ export interface RootAttrs {
 export async function load(store: ZarrArray['store']) {
   const { data, rootAttrs } = await loadMultiscales(store);
   const labels = ['t', 'c', 'z', 'y', 'x'] as Labels<['t', 'c', 'z']>;
-  const pyramid = data.map(arr => new ZarrPixelSource(arr, labels));
+  const tileSize = guessTileSize(data[0]);
+  const pyramid = data.map(arr => new ZarrPixelSource(arr, labels, tileSize));
   return {
-    data: trimPyramid(pyramid),
+    data: pyramid,
     metadata: rootAttrs
   };
 }

--- a/tests/loaders/bioformats-zarr.spec.js
+++ b/tests/loaders/bioformats-zarr.spec.js
@@ -11,7 +11,7 @@ test('Creates correct ZarrPixelSource.', async t => {
   t.plan(4);
   try {
     const { data } = await load(store, await meta);
-    t.equal(data.length, 1, 'Image should not be pyramidal.');
+    t.equal(data.length, 2, 'Image should have two levels.');
     const [base] = data;
     t.deepEqual(
       base.labels,


### PR DESCRIPTION
Fixes #381
Fixes #382

Rather than inferring `tileSize` from the underlying array chunks, a _desired_ `tileSize` is now specified fro the `ZarrPixelSource`, similar to the `TiffPixelSource`. This allows us to use the _entire_ image pyramid, even when chunks are shaped differently. This change means that we can (hopefully) ensure that deck.gl gets consistently size tiles for a zarr-based pyramid.
 
