### PR TITLE
Float64 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Support OME `double` (and in general, double-precision floating point) datatype
+- Support `Float64` (OME `double`) datatype by casting array data to `Float32`. 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Support OME `double` (i.e `Float64`) datatype
+- Support OME `double` (and in general, double-precision floating point) datatype
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Support OME `double` (i.e `Float64`) datatype
+
 ### Changed
 
 ## 0.9.2

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import GL from '@luma.gl/constants';
+import type { TypedArray } from 'zarr';
 
 export const MAX_COLOR_INTENSITY = 255;
 
@@ -77,7 +78,7 @@ export const DTYPE_VALUES = {
     // https://en.wikipedia.org/wiki/Single-precision_floating-point_format.
     max: 3.4 * 10 ** 38,
     sampler: 'sampler2D',
-    cast: data => new Float32Array(data)
+    cast: (data: TypedArray) => new Float32Array(data)
   }
 } as const;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -67,6 +67,17 @@ export const DTYPE_VALUES = {
     type: GL.INT,
     max: 2 ** (32 - 1) - 1,
     sampler: 'isampler2D'
+  },
+  // Cast Float64 as 32 bit float point so it can be rendered.
+  Float64: {
+    format: GL.R32F,
+    dataFormat: GL.RED,
+    type: GL.FLOAT,
+    // Not sure what to do about this one - a good use case for channel stats, I suppose:
+    // https://en.wikipedia.org/wiki/Single-precision_floating-point_format.
+    max: 3.4 * 10 ** 38,
+    sampler: 'sampler2D',
+    cast: data => new Float32Array(data)
   }
 } as const;
 

--- a/src/loaders/tiff/lib/utils.ts
+++ b/src/loaders/tiff/lib/utils.ts
@@ -6,6 +6,7 @@ const DTYPE_LOOKUP = {
   uint16: 'Uint16',
   uint32: 'Uint32',
   float: 'Float32',
+  double: 'Float64',
   int8: 'Int8',
   int16: 'Int16',
   int32: 'Int32'

--- a/src/loaders/tiff/pixel-source.ts
+++ b/src/loaders/tiff/pixel-source.ts
@@ -54,19 +54,9 @@ class TiffPixelSource<S extends string[]> implements PixelSource<S> {
      * geotiff.js returns objects with different structure
      * depending on `interleave`. It's weird, but this seems to work.
      */
-    let data = (interleave ? raster : raster[0]) as TypedArray;
-
-    /*
-     * GeoTiff.js returns Uint32Array when the tiff has 32 significant bits,
-     * even if the image is Float32. The underlying ArrayBuffer is correct, but
-     * we need to take a different TypeArray view of the buffer.
-     */
-    if (this.dtype === 'Float32') {
-      data = new Float32Array(data.buffer);
-    }
-
+    const data = (interleave ? raster : raster[0]) as TypedArray;
     return {
-      data: data,
+      data,
       width: raster.width,
       height: raster.height
     } as PixelData;

--- a/src/loaders/zarr/pixel-source.ts
+++ b/src/loaders/zarr/pixel-source.ts
@@ -19,6 +19,7 @@ const DTYPE_LOOKUP = {
   u2: 'Uint16',
   u4: 'Uint32',
   f4: 'Float32',
+  f8: 'Float64',
   i1: 'Int8',
   i2: 'Int16',
   i4: 'Int32'


### PR DESCRIPTION
<!-- For other PRs without open issue -->
This PR adds support for double-precision floating point data.
#### Background
Right now we don't support double-precision floating point data but we could by casting to a Float32.  We have IMC data coming in from HuBMAP that is in this format so that is the motivation for doing this.  I think this solution requires the least amount of code while also preserving "double/Float64" as the datatype whenever someone were to `console.log` it.
#### Change List
- support `double` type from OME as `Float64` in Viv
- Add `Float64` support in Viv by casting to `Float32` and using the shader settings for 32 bit floats.
- Remove extraneous cast to `Float32Array` for tiff (it was a fix for a misidentified bug which was not a bug) 
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
