### PR TITLE
Add onHover prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Support `Float64` (OME `double`) datatype by casting array data to `Float32`. 
+- `onHover` prop for `VivViewer`, `PictureInPictureViewer`, `SideBySideViewer` for deck.gl callback.
 
 ### Changed
 

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -40,6 +40,8 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
+ * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
+ *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition: Default: ['t', 'z'].
  */
 
@@ -65,6 +67,7 @@ const PictureInPictureViewer = props => {
     clickCenter = true,
     transparentColor,
     onViewStateChange,
+    onHover,
     transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS
   } = props;
   const {
@@ -131,6 +134,7 @@ const PictureInPictureViewer = props => {
       viewStates={viewStates}
       hoverHooks={hoverHooks}
       onViewStateChange={onViewStateChange}
+      onHover={onHover}
     />
   );
 };

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -28,6 +28,8 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
+ * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
+ *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition: Default: ['t', 'z'].
  */
 const SideBySideViewer = props => {
@@ -50,6 +52,7 @@ const SideBySideViewer = props => {
     lensBorderRadius = 0.02,
     transparentColor,
     onViewStateChange,
+    onHover,
     transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS
   } = props;
   const {
@@ -117,6 +120,7 @@ const SideBySideViewer = props => {
       views={views}
       randomize
       onViewStateChange={onViewStateChange}
+      onHover={onHover}
       viewStates={viewStates}
     />
   ) : null;

--- a/src/viewers/VivViewer.js
+++ b/src/viewers/VivViewer.js
@@ -18,6 +18,12 @@ const areViewStatesEqual = (viewState, otherViewState) => {
  */
 
 /**
+ * @callback Hover
+ * @param {Object} info
+ * @param {Object} event
+ */
+
+/**
  * This component handles rendering the various views within the DeckGL contenxt.
  * @param {Object} props
  * @param {Array} props.layerProps  Props for the layers in each view.
@@ -25,7 +31,9 @@ const areViewStatesEqual = (viewState, otherViewState) => {
  * @param {VivView} props.views Various VivViews to render.
  * @param {Array} props.viewStates List of objects like [{ target: [x, y, 0], zoom: -zoom, id: 'left' }, { target: [x, y, 0], zoom: -zoom, id: 'right' }]
  * @param {ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
- * */
+ * @param {Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
+ *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
+ */
 export default class VivViewer extends PureComponent {
   constructor(props) {
     super(props);
@@ -164,7 +172,12 @@ export default class VivViewer extends PureComponent {
   }
 
   // eslint-disable-next-line consistent-return
-  onHover({ sourceLayer, coordinate, layer }) {
+  onHover(info, event) {
+    const { sourceLayer, coordinate, layer } = info;
+    const { onHover } = this.props;
+    if (onHover) {
+      onHover(info, event);
+    }
     if (!coordinate) {
       return null;
     }


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #389
<!-- For other PRs without open issue -->
#### Background
This exposes the deck.gl `onHover` callback to the viewers, enabling tooltips.
#### Change List
- `onHover` prop for `VivViewer`, `PictureInPictureViewer`, `SideBySideViewer` for deck.gl callback.
#### Checklist
 - [X] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [X] Make sure Avivator works as expected with your change.
 
I added an `onHover` callback with `console.log` to Avivator. The callback was called as expected.
