### PR TITLE
Add `handleCoordinate` Hover Hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Support `Float64` (OME `double`) datatype by casting array data to `Float32`. 
+- `onHover` prop for `VivViewer`, `PictureInPictureViewer`, `SideBySideViewer` for deck.gl callback.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Support `Float64` (OME `double`) datatype by casting array data to `Float32`. 
 - `onHover` prop for `VivViewer`, `PictureInPictureViewer`, `SideBySideViewer` for deck.gl callback.
-
+- Add `handleCoordnate` `hoverHook` for PIP.
 ### Changed
 
 ## 0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Support `Float64` (OME `double`) datatype by casting array data to `Float32`. 
 - `onHover` prop for `VivViewer`, `PictureInPictureViewer`, `SideBySideViewer` for deck.gl callback.
 - Add `handleCoordnate` `hoverHook` for PIP.
+
 ### Changed
 
 ## 0.9.2

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -22,8 +22,8 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {Object} props.overview Allows you to pass settings into the OverviewView: { scale, margin, position, minimumWidth, maximumWidth,
  * boundingBoxColor, boundingBoxOutlineWidth, viewportOutlineColor, viewportOutlineWidth}.  See http://viv.gehlenborglab.org/#overviewview for defaults.
  * @param {Boolean} props.overviewOn Whether or not to show the OverviewView.
- * @param {Object} props.hoverHooks Object including the allowable hooks - right now only accepting a function with key handleValue like { handleValue: (valueArray) => {} } where valueArray
- * has the pixel values for the image under the hover location.
+ * @param {Object} props.hoverHooks Object including utility hooks - an object with key handleValue like { handleValue: (valueArray) => {}, handleCoordinate: (coordinate) => {} } where valueArray
+ * has the pixel values for the image under the hover location and coordinate is the coordinate in the image from which the values are picked.
  * @param {Array} [props.viewStates] Array of objects like [{ target: [x, y, 0], zoom: -zoom, id: DETAIL_VIEW_ID }] for setting where the viewer looks (optional - this is inferred from height/width/loader
  * internally by default using getDefaultInitialViewState).
  * @param {number} props.height Current height of the component.

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -22,7 +22,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {Object} props.overview Allows you to pass settings into the OverviewView: { scale, margin, position, minimumWidth, maximumWidth,
  * boundingBoxColor, boundingBoxOutlineWidth, viewportOutlineColor, viewportOutlineWidth}.  See http://viv.gehlenborglab.org/#overviewview for defaults.
  * @param {Boolean} props.overviewOn Whether or not to show the OverviewView.
- * @param {Object} props.hoverHooks Object including utility hooks - an object with key handleValue like { handleValue: (valueArray) => {}, handleCoordinate: (coordinate) => {} } where valueArray
+ * @param {Object} [props.hoverHooks] Object including utility hooks - an object with key handleValue like { handleValue: (valueArray) => {}, handleCoordinate: (coordinate) => {} } where valueArray
  * has the pixel values for the image under the hover location and coordinate is the coordinate in the image from which the values are picked.
  * @param {Array} [props.viewStates] Array of objects like [{ target: [x, y, 0], zoom: -zoom, id: DETAIL_VIEW_ID }] for setting where the viewer looks (optional - this is inferred from height/width/loader
  * internally by default using getDefaultInitialViewState).
@@ -56,7 +56,7 @@ const PictureInPictureViewer = props => {
     overview,
     overviewOn,
     loaderSelection,
-    hoverHooks,
+    hoverHooks = {},
     height,
     width,
     isLensOn = false,

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -40,6 +40,8 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
+ * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
+ *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition: Default: ['t', 'z'].
  */
 
@@ -65,6 +67,7 @@ const PictureInPictureViewer = props => {
     clickCenter = true,
     transparentColor,
     onViewStateChange,
+    onHover,
     transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS
   } = props;
   const {
@@ -131,6 +134,7 @@ const PictureInPictureViewer = props => {
       viewStates={viewStates}
       hoverHooks={hoverHooks}
       onViewStateChange={onViewStateChange}
+      onHover={onHover}
     />
   );
 };

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -28,6 +28,8 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @param {import('./VivViewer').ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
+ * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
+ *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition: Default: ['t', 'z'].
  */
 const SideBySideViewer = props => {
@@ -50,6 +52,7 @@ const SideBySideViewer = props => {
     lensBorderRadius = 0.02,
     transparentColor,
     onViewStateChange,
+    onHover,
     transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS
   } = props;
   const {
@@ -117,6 +120,7 @@ const SideBySideViewer = props => {
       views={views}
       randomize
       onViewStateChange={onViewStateChange}
+      onHover={onHover}
       viewStates={viewStates}
     />
   ) : null;

--- a/src/viewers/VivViewer.js
+++ b/src/viewers/VivViewer.js
@@ -175,7 +175,7 @@ export default class VivViewer extends PureComponent {
   onHover(info, event) {
     const { sourceLayer, coordinate, layer } = info;
     const { onHover, hoverHooks } = this.props;
-    const { handleValue = () => {}, hanldeCoordnate = console.log } = hoverHooks;
+    const { handleValue = () => {}, hanldeCoordnate = () => {} } = hoverHooks;
     if (onHover) {
       onHover(info, event);
     }

--- a/src/viewers/VivViewer.js
+++ b/src/viewers/VivViewer.js
@@ -18,6 +18,12 @@ const areViewStatesEqual = (viewState, otherViewState) => {
  */
 
 /**
+ * @callback Hover
+ * @param {Object} info
+ * @param {Object} event
+ */
+
+/**
  * This component handles rendering the various views within the DeckGL contenxt.
  * @param {Object} props
  * @param {Array} props.layerProps  Props for the layers in each view.
@@ -25,7 +31,9 @@ const areViewStatesEqual = (viewState, otherViewState) => {
  * @param {VivView} props.views Various VivViews to render.
  * @param {Array} props.viewStates List of objects like [{ target: [x, y, 0], zoom: -zoom, id: 'left' }, { target: [x, y, 0], zoom: -zoom, id: 'right' }]
  * @param {ViewStateChange} [props.onViewStateChange] Callback that returns the deck.gl view state (https://deck.gl/docs/api-reference/core/deck#onviewstatechange).
- * */
+ * @param {Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
+ *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
+ */
 export default class VivViewer extends PureComponent {
   constructor(props) {
     super(props);
@@ -164,7 +172,12 @@ export default class VivViewer extends PureComponent {
   }
 
   // eslint-disable-next-line consistent-return
-  onHover({ sourceLayer, coordinate, layer }) {
+  onHover(info, event) {
+    const { sourceLayer, coordinate, layer } = info;
+    const { onHover } = this.props;
+    if (onHover) {
+      onHover(info, event);
+    }
     if (!coordinate) {
       return null;
     }

--- a/src/viewers/VivViewer.js
+++ b/src/viewers/VivViewer.js
@@ -175,14 +175,13 @@ export default class VivViewer extends PureComponent {
   onHover(info, event) {
     const { sourceLayer, coordinate, layer } = info;
     const { onHover, hoverHooks } = this.props;
-    const { handleValue = () => {}, handleCoordnate = () => {} } = hoverHooks;
     if (onHover) {
       onHover(info, event);
     }
-    if (!coordinate) {
+    if (!hoverHooks) {
       return null;
     }
-    if (!hoverHooks) {
+    if (!coordinate) {
       return null;
     }
     const { channelData, bounds } = sourceLayer.props;
@@ -193,7 +192,7 @@ export default class VivViewer extends PureComponent {
     if (!data) {
       return null;
     }
-
+    const { handleValue = () => {}, handleCoordnate = () => {} } = hoverHooks;
     let dataCoords;
     // Tiled layer needs a custom layerZoomScale.
     if (sourceLayer.id.includes('Tiled')) {

--- a/src/viewers/VivViewer.js
+++ b/src/viewers/VivViewer.js
@@ -175,7 +175,7 @@ export default class VivViewer extends PureComponent {
   onHover(info, event) {
     const { sourceLayer, coordinate, layer } = info;
     const { onHover, hoverHooks } = this.props;
-    const { handleValue = () => {}, hanldeCoordnate = () => {} } = hoverHooks;
+    const { handleValue = () => {}, handleCoordnate = () => {} } = hoverHooks;
     if (onHover) {
       onHover(info, event);
     }
@@ -221,7 +221,7 @@ export default class VivViewer extends PureComponent {
     const coords = dataCoords[1] * width + dataCoords[0];
     const hoverData = data.map(d => d[coords]);
     handleValue(hoverData);
-    hanldeCoordnate(coordinate);
+    handleCoordnate(coordinate);
   }
 
   /**

--- a/src/viewers/VivViewer.js
+++ b/src/viewers/VivViewer.js
@@ -174,19 +174,15 @@ export default class VivViewer extends PureComponent {
   // eslint-disable-next-line consistent-return
   onHover(info, event) {
     const { sourceLayer, coordinate, layer } = info;
-    const { onHover } = this.props;
+    const { onHover, hoverHooks } = this.props;
+    const { handleValue = () => {}, hanldeCoordnate = console.log } = hoverHooks;
     if (onHover) {
       onHover(info, event);
     }
     if (!coordinate) {
       return null;
     }
-    const { hoverHooks } = this.props;
     if (!hoverHooks) {
-      return null;
-    }
-    const { handleValue } = hoverHooks;
-    if (!handleValue) {
       return null;
     }
     const { channelData, bounds } = sourceLayer.props;
@@ -225,6 +221,7 @@ export default class VivViewer extends PureComponent {
     const coords = dataCoords[1] * width + dataCoords[0];
     const hoverData = data.map(d => d[coords]);
     handleValue(hoverData);
+    hanldeCoordnate(coordinate);
   }
 
   /**


### PR DESCRIPTION
I think this is a natural extension of the `hoverHooks` API.  I have the `handleValue` hoverHook because the calculation to get the value is non-trivial and tied to knowing how the deck.gl `TileLayer` works with different tile sizes.  This extends that to just return the coordinate.  I think the `onHover` addition still has value so I'd like both to coexist.  To be merged post #390.