### PR TITLE
getChannelStats snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `getChannelStats` in snippet to show how to use it.
+
 ### Changed
 
 ## 0.9.3

--- a/docs/SAMPLES.md
+++ b/docs/SAMPLES.md
@@ -58,6 +58,8 @@ function App() {
     load(url).then(setLoader);
   }, []);
 
+  // Viv exposes the getChannelStats to produce nice initial settings
+  // so that users can have an "in focus" image immediately.
   const autoProps = useMemo(() => {
     if(!loader) {
       return props

--- a/docs/SAMPLES.md
+++ b/docs/SAMPLES.md
@@ -71,6 +71,9 @@ function App() {
     // These are calculated bounds for the sliders
     // that could be used for display purposes.
     // domains = stats.map(stat => stat.domain);
+
+    // These are precalculated settings for the sliders that
+    // should render a good, "in focus" image initially.
     sliders = stats.map(stat => stat.autoSliders);
     const newProps = { ...props, sliders };
   }, [loader])

--- a/docs/SAMPLES.md
+++ b/docs/SAMPLES.md
@@ -10,11 +10,11 @@ recognizes,
 - `http://localhost:8000/LuCa-7color_Scan1.ome.tif` (OME-TIFF)
 - `http://localhost:8000/LuCa-7color_Scan1/` (Bioformats-generated Zarr)
 
-
 ```javascript
 import React, { useState, useEffect, useMemo } from 'react';
 
 import {
+  getChannelStats,
   loadOmeTiff,
   loadBioformatsZarr,
   PictureInPictureViewer,

--- a/docs/SAMPLES.md
+++ b/docs/SAMPLES.md
@@ -12,7 +12,7 @@ recognizes,
 
 
 ```javascript
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 
 import {
   loadOmeTiff,

--- a/docs/SAMPLES.md
+++ b/docs/SAMPLES.md
@@ -58,14 +58,31 @@ function App() {
     load(url).then(setLoader);
   }, []);
 
+  const autoProps = useMemo(() => {
+    if(!loader) {
+      return props
+    }
+    // Use lowest level of the image pyramid for calculating stats.
+    const source = loader.data[loader.length - 1];
+    const stats = await Promise.all(props.selections.map(async selection => {
+      const raster = await source.getRaster({ selection });
+      return getChannelStats(raster.data);
+    }));
+    // These are calculated bounds for the sliders
+    // that could be used for display purposes.
+    // domains = stats.map(stat => stat.domain);
+    sliders = stats.map(stat => stat.autoSliders);
+    const newProps = { ...props, sliders };
+  }, [loader])
+
   if (!loader) return null;
   return (
     <PictureInPictureViewer
       loader={loader.data}
-      sliderValues={props.sliders}
-      colorValues={props.colors}
-      channelIsOn={props.isOn}
-      loaderSelection={props.selections}
+      sliderValues={autoProps.sliders}
+      colorValues={autoProps.colors}
+      channelIsOn={autoProps.isOn}
+      loaderSelection={autoProps.selections}
       height={1080}
       width={1920}
     />


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
The current documentation for `getChannelStats` just states that it takes in a TypedArray but I'm not sure people will really know what to do that immediately.  We could add a snippet like this to the documentation for the method instead of doing this, but I figured this is a good place for it since the snippet is a couple of lines and anyone who uses our components will also probably (want to) use this.  I found myself re-writing this line of code frequently in Vitessce when upgrading so it seemed like a good thing to document here.

<!-- For all the PRs -->
#### Change List
- Add a `getChannelStats` part to the snippet.

#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
