### PR TITLE
Improve emitted TS types for layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fix `VivViewer` and `VivView` types.
 - Fix `ImageLayer` `loader` type.
+- Refine `LayerProps` JSDoc annotations for more precise emitted types.
 
 ## 0.9.4
 

--- a/src/layers/BitmapLayer.js
+++ b/src/layers/BitmapLayer.js
@@ -127,7 +127,8 @@ class BitmapLayerWrapper extends BaseBitmapLayer {
  * @property {String=} id Unique identifier for this layer.
  */
 /**
- * @type {{ new(...props: LayerProps[]) }}
+ * @type {{ new (...props: import('../types').Viv<LayerProps>[]) }}
+ * @ignore
  */
 const BitmapLayer = class extends CompositeLayer {
   initializeState(args) {

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -39,7 +39,7 @@ const defaultProps = {
  * @type {Object}
  * @property {Array.<Array.<number>>} sliderValues List of [begin, end] values to control each channel's ramp function.
  * @property {Array.<Array.<number>>} colorValues List of [r, g, b] values for each channel.
- * @property {Array.<Array.<boolean>>} channelIsOn List of boolean values for each channel for whether or not it is visible.
+ * @property {Array.<boolean>} channelIsOn List of boolean values for each channel for whether or not it is visible.
  * @property {Object} loader PixelSource. Represents an N-dimensional image.
  * @property {Array} loaderSelection Selection to be used for fetching data.
  * @property {number=} opacity Opacity of the layer.
@@ -63,7 +63,8 @@ const defaultProps = {
  */
 
 /**
- * @type {{ new(...props: LayerProps[]) }}
+ * @type {{ new <S extends string[]>(...props: import('../types').Viv<LayerProps, S>[]) }}
+ * @ignore
  */
 const ImageLayer = class extends CompositeLayer {
   initializeState() {

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -41,7 +41,7 @@ const defaultProps = {
  * @type {object}
  * @property {Array.<Array.<number>>} sliderValues List of [begin, end] values to control each channel's ramp function.
  * @property {Array.<Array.<number>>} colorValues List of [r, g, b] values for each channel.
- * @property {Array.<Array.<boolean>>} channelIsOn List of boolean values for each channel for whether or not it is visible.
+ * @property {Array.<boolean>} channelIsOn List of boolean values for each channel for whether or not it is visible.
  * @property {Array} loader Image pyramid. PixelSource[], where each PixelSource is decreasing in shape.
  * @property {Array} loaderSelection Selection to be used for fetching data.
  * @property {number=} opacity Opacity of the layer.
@@ -68,7 +68,8 @@ const defaultProps = {
  */
 
 /**
- * @type {{ new(...props: LayerProps[]) }}
+ * @type {{ new <S extends string[]>(...props: import('../../types').Viv<LayerProps, S>[]) }}
+ * @ignore
  */
 const MultiscaleImageLayer = class extends CompositeLayer {
   initializeState() {

--- a/src/layers/OverviewLayer.js
+++ b/src/layers/OverviewLayer.js
@@ -40,7 +40,7 @@ const defaultProps = {
  * @type {Object}
  * @property {Array.<Array.<number>>} sliderValues List of [begin, end] values to control each channel's ramp function.
  * @property {Array.<Array.<number>>} colorValues List of [r, g, b] values for each channel.
- * @property {Array.<Array.<boolean>>} channelIsOn List of boolean values for each channel for whether or not it is visible.
+ * @property {Array.<boolean>} channelIsOn List of boolean values for each channel for whether or not it is visible.
  * @property {Array} loader PixelSource[]. Assumes multiscale if loader.length > 1.
  * @property {Array} loaderSelection Selection to be used for fetching data.
  * @property {number=} opacity Opacity of the layer.
@@ -54,7 +54,8 @@ const defaultProps = {
  */
 
 /**
- * @type {{ new(...props: LayerProps[]) }}
+ * @type {{ new <S extends string[]>(...props: import('../types').Viv<LayerProps, S>[]) }}
+ * @ignore
  */
 const OverviewLayer = class extends CompositeLayer {
   renderLayers() {

--- a/src/layers/ScaleBarLayer.js
+++ b/src/layers/ScaleBarLayer.js
@@ -61,6 +61,7 @@ const defaultProps = {
 
 /**
  * @type {{ new(...props: LayerProps[]) }}
+ * @ignore
  */
 const ScaleBarLayer = class extends CompositeLayer {
   renderLayers() {

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -78,7 +78,7 @@ const defaultProps = {
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  */
 /**
- * @type {{ new(...props: import('../types').Viv<LayerProps>[]) }}
+ * @type {{ new (...props: import('../../types').Viv<LayerProps>[]) }}
  * @ignore
  */
 const XRLayer = class extends Layer {

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -58,7 +58,7 @@ const defaultProps = {
  * @type {object}
  * @property {Array.<Array.<number>>} sliderValues List of [begin, end] values to control each channel's ramp function.
  * @property {Array.<Array.<number>>} colorValues List of [r, g, b] values for each channel.
- * @property {Array.<Array.<boolean>>} channelIsOn List of boolean values for each channel for whether or not it is visible.
+ * @property {Array.<boolean>} channelIsOn List of boolean values for each channel for whether or not it is visible.
  * @property {string} dtype Dtype for the layer.
  * @property {number=} opacity Opacity of the layer.
  * @property {string=} colormap String indicating a colormap (default: '').  The full list of options is here: https://github.com/glslify/glsl-colormap#glsl-colormap
@@ -78,7 +78,8 @@ const defaultProps = {
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  */
 /**
- * @type {{ new(...props: LayerProps[]) }}
+ * @type {{ new(...props: import('../types').Viv<LayerProps>[]) }}
+ * @ignore
  */
 const XRLayer = class extends Layer {
   /**

--- a/src/loaders/zarr/index.ts
+++ b/src/loaders/zarr/index.ts
@@ -1,12 +1,12 @@
-import { FileStore } from './lib/storage';
 import { HTTPStore } from 'zarr';
+import { FileStore } from './lib/storage';
 import { getRootPrefix } from './lib/utils';
 
 import { load as loadBioformats } from './bioformats-zarr';
 import { load as loadOme } from './ome-zarr';
 
 interface ZarrOptions {
-  fetchOptions?: RequestInit;
+  fetchOptions: RequestInit;
 }
 
 /**
@@ -19,7 +19,7 @@ interface ZarrOptions {
  */
 export async function loadBioformatsZarr(
   source: string | (File & { path: string })[],
-  options: ZarrOptions = {}
+  options: Partial<ZarrOptions> = {}
 ) {
   const METADATA = 'METADATA.ome.xml';
   const ZARR_DIR = 'data.zarr';
@@ -67,7 +67,7 @@ export async function loadBioformatsZarr(
  */
 export async function loadOmeZarr(
   source: string,
-  options: ZarrOptions & { type?: 'multiscales' }
+  options: Partial<ZarrOptions & { type: 'multiscales' }> = {}
 ) {
   const store = new HTTPStore(source, options);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface PixelSource<S extends string[]> {
   meta?: PixelSourceMeta;
 }
 
+// Not an exported type. Used below with `Viv` utility type.
 interface VivProps<S extends string[]> {
   sliderValues: [begin: number, end: number][];
   colorValues: [r: number, g: number, b: number][];
@@ -83,4 +84,4 @@ export type Viv<LayerProps, S extends string[] = string[]> =
             ? PixelSource<S>[]
             : PixelSource<S>;
         }
-      : {});
+      : never);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { DTYPE_VALUES } from './constants';
+import type { Matrix4 } from 'math.gl';
 
 export type SupportedDtype = keyof typeof DTYPE_VALUES;
 export type SupportedTypedArray = InstanceType<
@@ -50,3 +51,37 @@ export interface PixelSource<S extends string[]> {
   tileSize: number;
   meta?: PixelSourceMeta;
 }
+
+interface VivProps<S extends string[]> {
+  sliderValues: [begin: number, end: number][];
+  colorValues: [r: number, g: number, b: number][];
+  loaderSelection: PixelSourceSelection<S>[];
+  domain?: [min: number, max: number][];
+  modelMatrix?: Matrix4;
+}
+
+/**
+ * DocumentationJS does not understand TS syntax in JSDoc annotations,
+ * which means our generated types from `LayerProps` aren't very precise.
+ *
+ * This utility type overrides keys from `LayerProps` with
+ * more precise types if they exist in `VivProps`. We import this type in
+ * each Layer constructor, ignored by DocumentationJS, meaning our documentation
+ * stays the same (with less precise types) but code completion / type-checking
+ * is much more strict and useful.
+ */
+export type Viv<LayerProps, S extends string[] = string[]> = Omit<
+  LayerProps,
+  keyof VivProps<S> | 'loader'
+> &
+  {
+    [K in keyof VivProps<S>]: K extends keyof LayerProps
+      ? VivProps<S>[K]
+      : never;
+  } & {
+    loader: 'loader' extends keyof LayerProps
+      ? LayerProps['loader'] extends any[]
+        ? PixelSource<S>[]
+        : PixelSource<S>
+      : never;
+  };

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,8 +56,9 @@ interface VivProps<S extends string[]> {
   sliderValues: [begin: number, end: number][];
   colorValues: [r: number, g: number, b: number][];
   loaderSelection: PixelSourceSelection<S>[];
+  dtype: keyof typeof DTYPE_VALUES;
   domain?: [min: number, max: number][];
-  modelMatrix?: Matrix4;
+  modelMatrix?: Matrix4 | undefined;
 }
 
 /**
@@ -74,15 +75,12 @@ export type Viv<LayerProps, S extends string[] = string[]> =
   // Remove all shared properties from VivProps from LayerProps
   Omit<LayerProps, keyof VivProps<S> | 'loader'> &
     // If a property from VivProps exists on LayerProps, replace it
-    {
-      [K in keyof VivProps<S>]: K extends keyof LayerProps
-        ? VivProps<S>[K]
-        : never;
-    } & {
-      // Loader type is special and depends on what is provided (Array or Object)
-      loader: 'loader' extends keyof LayerProps
-        ? LayerProps['loader'] extends Array<unknown>
-          ? PixelSource<S>[]
-          : PixelSource<S>
-        : never;
-    };
+    Pick<VivProps<S>, keyof LayerProps & keyof VivProps<S>> &
+    // Loader type is special and depends on what is provided (Array or Object)
+    ('loader' extends keyof LayerProps
+      ? {
+          loader: LayerProps['loader'] extends Array<unknown>
+            ? PixelSource<S>[]
+            : PixelSource<S>;
+        }
+      : {});

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,18 +70,19 @@ interface VivProps<S extends string[]> {
  * stays the same (with less precise types) but code completion / type-checking
  * is much more strict and useful.
  */
-export type Viv<LayerProps, S extends string[] = string[]> = Omit<
-  LayerProps,
-  keyof VivProps<S> | 'loader'
-> &
-  {
-    [K in keyof VivProps<S>]: K extends keyof LayerProps
-      ? VivProps<S>[K]
-      : never;
-  } & {
-    loader: 'loader' extends keyof LayerProps
-      ? LayerProps['loader'] extends any[]
-        ? PixelSource<S>[]
-        : PixelSource<S>
-      : never;
-  };
+export type Viv<LayerProps, S extends string[] = string[]> =
+  // Remove all shared properties from VivProps from LayerProps
+  Omit<LayerProps, keyof VivProps<S> | 'loader'> &
+    // If a property from VivProps exists on LayerProps, replace it
+    {
+      [K in keyof VivProps<S>]: K extends keyof LayerProps
+        ? VivProps<S>[K]
+        : never;
+    } & {
+      // Loader type is special and depends on what is provided (Array or Object)
+      loader: 'loader' extends keyof LayerProps
+        ? LayerProps['loader'] extends Array<unknown>
+          ? PixelSource<S>[]
+          : PixelSource<S>
+        : never;
+    };


### PR DESCRIPTION
_TL;DR: Our choice of JSDoc syntax for types is good for our documentation generator, but the actual generated TS types suffer as a result. This PR gives us the best of both worlds: the same documentation and better TS types._

### Motivation

We currently use JSDoc syntax to define the properties for our layers. This is good for our documentation, because `documentationJS` understands JSDoc syntax and not TS, but the choice to use JSDoc syntax means that our emitted TypeScript declarations aren't very precise or helpful. 

Essentially, current annotations denote optional/required fields and "rough" shapes, but that's about it. For example, the following is currently valid:

```javascript
import {ImageLayer} from "@hms-dbmi/viv";
const layer = new ImageLayer({
    loader: {}, // just an empty object, _should_ be a PixelSource!
    loaderSelection: [{ someRandomKey: 0, foo: 0, }], // not linked to the loader at all
    channelIsOn: [true],
    domain: [[0]], // [min, max] not enforced
    colorValues: [[255, 255, 255, 1000]],  // [r, g, b] not enforced
    sliderValues: [[0, 1, 0]], // [min, max] not enforced
    modelMatrix: {} // Matrix4 not checked
  });
```

### Approach

This PR adds a utility type `Viv<LayerProps, S extends string[]>` that is used to _refine_ the constructor signatures to more precise types. The current constructor signatures `/** @type {{ new (...props: LayerProps[]) }} */` are _not_ used by JSDoc, so we can apply this utility type without disrupting our documentation.

The `Viv` utility type is pretty complicated, but essentially it creates a new type that _replaces_ fields on `LayerProps` with more precise types defined in `VivProps`:

```typescript
interface VivProps<S extends string[]> {
  sliderValues: [begin: number, end: number][];
  colorValues: [r: number, g: number, b: number][];
  loaderSelection: PixelSourceSelection<S>[];
  domain?: [min: number, max: number][];
  modelMatrix?: Matrix4;
}
```

it is used like the following:

```javascript
/**
 * @type {{ new <S extends string[]>(...props: import('../types').Viv<LayerProps, S>[]) }}
 * @ignore
 */
const ImageLayer = class extends CompositeLayer {
```

The cool thing is that the generic parameter `S` is inferred from the pixel source, so we can restrict the loader selection to be valid. Here are some examples of how this approach provides better type safety.

![image](https://user-images.githubusercontent.com/24403730/113948325-94cc1700-97da-11eb-9f02-c7a5554975ab.png)


This approach lets us continue to write our documentation like we have previously, but then inject better types for use in TypeScript and VSCode. 