### PR TITLE
Fix Empty Loader Selection Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix `VivViewer` and `VivView` types.
 - Fix `ImageLayer` `loader` type.
 - Refine `LayerProps` JSDoc annotations for more precise emitted types.
+- Fix `Avivator` and `getImageLyaers` utility for `loaderSelection` that is empty array.
 
 ## 0.9.4
 

--- a/avivator/src/Avivator.js
+++ b/avivator/src/Avivator.js
@@ -262,7 +262,7 @@ export default function Avivator(props) {
       // Set new image to default selection for non-global selections (0)
       // and use current global selection otherwise.
       selection[field] = GLOBAL_SLIDER_DIMENSION_FIELDS.includes(field)
-        ? selections[0][field]
+        ? globalSelections[field]
         : 0;
     });
     const { domain, slider } = await getSingleSelectionStats({

--- a/src/views/utils.js
+++ b/src/views/utils.js
@@ -74,9 +74,8 @@ export function getImageLayers(id, props) {
   return [loaderSelection, newLoaderSelection]
     .filter((s, i) => i === 0 || s)
     .map((s, i) => {
-      const suffix = s
-        ? `-${transitionFields.map(f => s[0][f]).join('-')}`
-        : '';
+      const suffix =
+        s && s[0] ? `-${transitionFields.map(f => s[0][f]).join('-')}` : '';
       const newProps =
         i !== 0
           ? {


### PR DESCRIPTION
#### Background
If you remove all channels in `Avivator`, the app crashes because the `VivView` classes in SBS and PIP don't check for empty lists.
#### Change List
- Check if `loaderSelection` has a first entry to prevent crashes due to it being an empty list but still truthy.
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
