### PR TITLE
Fix Bugs in `getChannelStats`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Changed
 
+- Fix bug in `getChannelStats` where we only considered values over 1 for the sliders
+- Fix bug in `getChannelStats` where array of zeros passed in causes undefined slider settings
+
 ## 0.9.5
 
 ### Added

--- a/src/loaders/utils.ts
+++ b/src/loaders/utils.ts
@@ -58,7 +58,7 @@ export function getChannelStats(arr: TypedArray) {
   // Used for "auto" settings.  This is the best parameter I've found experimentally.
   // I don't think there is a right answer and this feature is common in Fiji.
   // Also it's best to use a non-zero array for this.
-  const cutoffArr = arr.filter((i: number) => i >= 0.00000000001);
+  const cutoffArr = arr.filter((i: number) => i > 0);
   const cutoffPercentile = 0.0005;
   const topCutoffLocation = Math.floor(
     cutoffArr.length * (1 - cutoffPercentile)

--- a/src/loaders/utils.ts
+++ b/src/loaders/utils.ts
@@ -58,7 +58,7 @@ export function getChannelStats(arr: TypedArray) {
   // Used for "auto" settings.  This is the best parameter I've found experimentally.
   // I don't think there is a right answer and this feature is common in Fiji.
   // Also it's best to use a non-zero array for this.
-  const cutoffArr = arr.filter((i: number) => i >= 1);
+  const cutoffArr = arr.filter((i: number) => i >= 0.00000000001);
   const cutoffPercentile = 0.0005;
   const topCutoffLocation = Math.floor(
     cutoffArr.length * (1 - cutoffPercentile)
@@ -67,8 +67,8 @@ export function getChannelStats(arr: TypedArray) {
   quickselect(cutoffArr, topCutoffLocation);
   quickselect(cutoffArr, bottomCutoffLocation, 0, topCutoffLocation);
   const autoSliders = [
-    cutoffArr[bottomCutoffLocation],
-    cutoffArr[topCutoffLocation]
+    cutoffArr[bottomCutoffLocation] || 0,
+    cutoffArr[topCutoffLocation] || 0
   ];
   return {
     mean,

--- a/tests/loaders/utils.spec.js
+++ b/tests/loaders/utils.spec.js
@@ -6,6 +6,44 @@ import {
   isInterleaved
 } from '../../src/loaders/utils';
 
+test('getChannelStats: All zeros', t => {
+  t.plan(7);
+  try {
+    const data = [
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0]
+    ];
+    const channelStats = data.map(arr => getChannelStats(arr));
+    const means = channelStats.map(stat => stat.mean);
+    const domains = channelStats.map(stat => stat.domain);
+    const standardDeviations = channelStats.map(stat => stat.sd);
+    const thirdQuartiles = channelStats.map(stat => stat.q3);
+    const firstQuartiles = channelStats.map(stat => stat.q1);
+    const medians = channelStats.map(stat => stat.median);
+    const sliders = channelStats.map(stat => stat.autoSliders);
+
+    t.deepEqual(means, [0, 0, 0]);
+    t.deepEqual(domains, [
+      [0, 0],
+      [0, 0],
+      [0, 0]
+    ]);
+    t.deepEqual(sliders, [
+      [0, 0],
+      [0, 0],
+      [0, 0]
+    ]);
+    t.deepEqual(standardDeviations, [0, 0, 0]);
+    t.deepEqual(firstQuartiles, [0, 0, 0]);
+    t.deepEqual(thirdQuartiles, [0, 0, 0]);
+    t.deepEqual(medians, [0, 0, 0]);
+    t.end();
+  } catch (e) {
+    t.fail(e);
+  }
+});
+
 test('getChannelStats: Small', t => {
   t.plan(6);
   try {


### PR DESCRIPTION
<!-- For other PRs without open issue -->
If you passed in an array of all zeros previously, the `autoSliders` value would be undefined because we filter the array to non-zero values.  
#### Background
Additionally, using 1 is too high for `Float32` data so the slider settings were often too low.  Now the [Luca7 32 bit](http://avivator.gehlenborglab.org/?image_url=https://viv-demo.storage.googleapis.com/LuCa-7color_3x3component_data.ome.tif) example works much better.

<!-- For all the PRs -->
#### Change List
- Always return numeric value for `autoSliders` from `getChannelStats`
- Fix data filtering for `Float32` values.
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
