### PR TITLE
Small Features/Fixes for Viv Src

### DIFF
--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -127,7 +127,11 @@ const ImageLayer = class extends CompositeLayer {
           }
           this.setState({ ...raster });
         })
-        .catch(e => (e === SIGNAL_ABORTED ? null : e));
+        .catch(e => {
+          if (e !== SIGNAL_ABORTED)  {
+            throw e; // re-throws error if not our signal
+          }
+         });
     }
   }
 

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -4,7 +4,7 @@ import GL from '@luma.gl/constants';
 import XRLayer from './XRLayer';
 import BitmapLayer from './BitmapLayer';
 import { onPointer } from './utils';
-import { isInterleaved } from '../loaders/utils';
+import { isInterleaved, SIGNAL_ABORTED } from '../loaders/utils';
 
 const defaultProps = {
   pickable: { type: 'boolean', value: true, compare: true },
@@ -83,6 +83,10 @@ const ImageLayer = class extends CompositeLayer {
     }
   }
 
+  finalizeState() {
+    this.state.abortController.abort();
+  }
+
   updateState({ changeFlags, props, oldProps }) {
     const { propsChanged } = changeFlags;
     const loaderChanged =
@@ -93,32 +97,37 @@ const ImageLayer = class extends CompositeLayer {
     if (loaderChanged || loaderSelectionChanged) {
       // Only fetch new data to render if loader has changed
       const { loader, loaderSelection = [], onViewportLoad } = this.props;
-      const getRaster = selection => loader.getRaster({ selection });
+      const abortController = new AbortController();
+      this.setState({ abortController });
+      const { signal } = abortController;
+      const getRaster = selection => loader.getRaster({ selection, signal });
       const dataPromises = loaderSelection.map(getRaster);
 
-      Promise.all(dataPromises).then(rasters => {
-        const raster = {
-          data: rasters.map(d => d.data),
-          width: rasters[0].width,
-          height: rasters[0].height
-        };
+      Promise.all(dataPromises)
+        .then(rasters => {
+          const raster = {
+            data: rasters.map(d => d.data),
+            width: rasters[0].width,
+            height: rasters[0].height
+          };
 
-        if (isInterleaved(loader.shape)) {
-          // data is for BitmapLayer and needs to be of form { data: Uint8Array, width, height };
-          // eslint-disable-next-line prefer-destructuring
-          raster.data = raster.data[0];
-          if (raster.data.length === raster.width * raster.height * 3) {
-            // data is RGB (not RGBA) and need to update texture formats
-            raster.format = GL.RGB;
-            raster.dataFormat = GL.RGB;
+          if (isInterleaved(loader.shape)) {
+            // data is for BitmapLayer and needs to be of form { data: Uint8Array, width, height };
+            // eslint-disable-next-line prefer-destructuring
+            raster.data = raster.data[0];
+            if (raster.data.length === raster.width * raster.height * 3) {
+              // data is RGB (not RGBA) and need to update texture formats
+              raster.format = GL.RGB;
+              raster.dataFormat = GL.RGB;
+            }
           }
-        }
 
-        if (onViewportLoad) {
-          onViewportLoad(raster);
-        }
-        this.setState({ ...raster });
-      });
+          if (onViewportLoad) {
+            onViewportLoad(raster);
+          }
+          this.setState({ ...raster });
+        })
+        .catch(e => (e === SIGNAL_ABORTED ? null : e));
     }
   }
 

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -128,10 +128,10 @@ const ImageLayer = class extends CompositeLayer {
           this.setState({ ...raster });
         })
         .catch(e => {
-          if (e !== SIGNAL_ABORTED)  {
+          if (e !== SIGNAL_ABORTED) {
             throw e; // re-throws error if not our signal
           }
-         });
+        });
     }
   }
 

--- a/src/layers/VolumeLayer/utils.js
+++ b/src/layers/VolumeLayer/utils.js
@@ -20,7 +20,8 @@ export async function getVolume({
   source,
   selection,
   onUpdate = () => {},
-  downsampleDepth = 1
+  downsampleDepth = 1,
+  signal
 }) {
   const { shape, labels, dtype } = source;
   const { height, width } = getImageSize(source);
@@ -37,7 +38,8 @@ export async function getVolume({
         z: z * downsampleDepth
       };
       const { data: rasterData } = await source.getRaster({
-        selection: depthSelection
+        selection: depthSelection,
+        signal
       });
       let r = 0;
       onUpdate();

--- a/src/layers/XR3DLayer/xr-layer-fragment.glsl
+++ b/src/layers/XR3DLayer/xr-layer-fragment.glsl
@@ -129,7 +129,7 @@ void main(void) {
 		// Check if this point is on the "positive" side or "negative" side of the plane - only show positive.
 		float canShow = 1.;
 		for (int i = 0; i < _NUM_PLANES; i += 1) {
-			canShow *= max(0., sign(dot(normals[i], p - (distances[i] * normals[i]))));
+			canShow *= max(0., sign(dot(normals[i], p) + distances[i]));
 		}
 		// Do not show coordinates outside 0-1 box.
 		// Something about the undefined behavior outside the box causes the additive blender to 

--- a/src/layers/XR3DLayer/xr-layer-vertex.glsl
+++ b/src/layers/XR3DLayer/xr-layer-vertex.glsl
@@ -15,6 +15,7 @@ uniform mat4 view;
 // A matrix for scaling in the model space before any transformations.
 // This projects the unit cube up to match the "pixel size" multiplied by the physical size ratio, if provided.
 uniform mat4 scale;
+uniform mat4 resolution;
 
 
 out vec3 vray_dir;
@@ -23,7 +24,7 @@ flat out vec3 transformed_eye;
 void main() {
 
   // Step 1: Standard MVP transformation (+ the scale matrix) to place the positions on your 2D screen ready for rasterization + fragment processing.
-  gl_Position = proj * view * model * scale * vec4(positions, 1.0);
+  gl_Position = proj * view * model * scale * resolution * vec4(positions, 1.0);
 
   // Step 2: Invert the eye back from world space to the normalized 0-1 cube world space because ray casting on the fragment shader runs in 0-1 space.
   // Geometrically, the transformed_eye is a position relative to the 0-1 normalized vertices, which themselves are the inverse of the model + scale trasnformation.
@@ -63,7 +64,7 @@ void main() {
   /
  #
   */
-  transformed_eye = (inverse(scale) * inverse(model) * (vec4(eye_pos, 1.0))).xyz;
+  transformed_eye = (inverse(resolution) * inverse(scale) * inverse(model) * (vec4(eye_pos, 1.0))).xyz;
 
   // Step 3: Rays are from eye to vertices so that they get interpolated over the fragments.
   vray_dir = positions - transformed_eye;

--- a/src/loaders/omexml.ts
+++ b/src/loaders/omexml.ts
@@ -108,7 +108,7 @@ type PixelType =
   | 'complex'
   | 'double-complex';
 
-type UnitsLength =
+export type UnitsLength =
   | 'Ym'
   | 'Zm'
   | 'Em'

--- a/src/loaders/tiff/lib/utils.ts
+++ b/src/loaders/tiff/lib/utils.ts
@@ -1,5 +1,5 @@
 import { getDims, getLabels } from '../../utils';
-import type { OMEXML } from '../../omexml';
+import type { OMEXML, UnitsLength } from '../../omexml';
 
 const DTYPE_LOOKUP = {
   uint8: 'Uint8',
@@ -44,9 +44,10 @@ export function getOmePixelSourceMeta({ Pixels }: OMEXML[0]) {
   }
 
   const dtype = DTYPE_LOOKUP[Pixels.Type as keyof typeof DTYPE_LOOKUP];
-
-  if (Pixels.PhysicalSizeX && Pixels.PhysicalSizeY && Pixels.PhysicalSizeZ) {
-    const physicalSizes = {
+  if (Pixels.PhysicalSizeX && Pixels.PhysicalSizeY) {
+    const physicalSizes: {
+      [k: string]: { size: number; unit: UnitsLength };
+    } = {
       x: {
         size: Pixels.PhysicalSizeX,
         unit: Pixels.PhysicalSizeXUnit
@@ -54,12 +55,14 @@ export function getOmePixelSourceMeta({ Pixels }: OMEXML[0]) {
       y: {
         size: Pixels.PhysicalSizeY,
         unit: Pixels.PhysicalSizeYUnit
-      },
-      z: {
-        size: Pixels.PhysicalSizeZ,
-        unit: Pixels.PhysicalSizeZUnit
       }
     };
+    if (Pixels.PhysicalSizeZ) {
+      physicalSizes.z = {
+        size: Pixels.PhysicalSizeZ,
+        unit: Pixels.PhysicalSizeZUnit
+      };
+    }
     return { labels, getShape, physicalSizes, dtype };
   }
 

--- a/src/loaders/tiff/pixel-source.ts
+++ b/src/loaders/tiff/pixel-source.ts
@@ -27,9 +27,9 @@ class TiffPixelSource<S extends string[]> implements PixelSource<S> {
     this._indexer = indexer;
   }
 
-  async getRaster({ selection }: RasterSelection<S>) {
+  async getRaster({ selection, signal }: RasterSelection<S>) {
     const image = await this._indexer(selection);
-    return this._readRasters(image);
+    return this._readRasters(image, { signal });
   }
 
   async getTile({ x, y, selection, signal }: TileSelection<S>) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type PixelSourceSelection<S extends string[]> = {
 
 export interface RasterSelection<S extends string[]> {
   selection: PixelSourceSelection<S>;
+  signal?: AbortSignal;
 }
 
 export interface TileSelection<S extends string[]> {

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -42,6 +42,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition when making a new selection: Default: ['t', 'z'].
+ * @param {function} [props.onViewportLoad] Function that gets called when the data in the viewport loads.
  */
 
 const PictureInPictureViewer = props => {
@@ -67,12 +68,13 @@ const PictureInPictureViewer = props => {
     transparentColor,
     onViewStateChange,
     onHover,
-    transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS
+    transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS,
+    onViewportLoad
   } = props;
   const {
     newLoaderSelection,
     oldLoaderSelection,
-    onViewportLoad
+    onViewportLoad: transitionOnViewportLoad
   } = useGlobalSelection(loaderSelection, transitionFields);
   const detailViewState = viewStatesProp?.find(v => v.id === DETAIL_VIEW_ID);
   const baseViewState = useMemo(() => {
@@ -96,6 +98,7 @@ const PictureInPictureViewer = props => {
     loaderSelection: oldLoaderSelection,
     newLoaderSelection,
     onViewportLoad,
+    transitionOnViewportLoad,
     transitionFields,
     colormap,
     isLensOn,

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -32,6 +32,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition: Default: ['t', 'z'].
+ * @param {function} [props.onViewportLoad] Function that gets called when the data in the viewport loads.
  */
 const SideBySideViewer = props => {
   const {
@@ -54,12 +55,13 @@ const SideBySideViewer = props => {
     transparentColor,
     onViewStateChange,
     onHover,
-    transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS
+    transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS,
+    onViewportLoad
   } = props;
   const {
     newLoaderSelection,
     oldLoaderSelection,
-    onViewportLoad
+    onViewportLoad: transitionOnViewportLoad
   } = useGlobalSelection(loaderSelection, transitionFields);
   const leftViewState = viewStatesProp?.find(v => v.id === 'left');
   const rightViewState = viewStatesProp?.find(v => v.id === 'right');
@@ -104,6 +106,7 @@ const SideBySideViewer = props => {
     loaderSelection: oldLoaderSelection,
     newLoaderSelection,
     onViewportLoad,
+    transitionOnViewportLoad,
     transitionFields,
     colormap,
     isLensOn,

--- a/src/viewers/VivViewer.js
+++ b/src/viewers/VivViewer.js
@@ -8,6 +8,8 @@ const areViewStatesEqual = (viewState, otherViewState) => {
   return (
     otherViewState === viewState ||
     (viewState?.zoom === otherViewState?.zoom &&
+      viewState?.rotationX === otherViewState?.rotationX &&
+      viewState?.rotationOrbit === otherViewState?.rotationOrbit &&
       equal(viewState?.target, otherViewState?.target))
   );
 };

--- a/src/viewers/global-selection-hook.js
+++ b/src/viewers/global-selection-hook.js
@@ -15,12 +15,7 @@ export default function useGlobalSelection(loaderSelection, transitionFields) {
   ) {
     // onViewportLoad is a property of TileLayer that is passed through:
     // https://deck.gl/docs/api-reference/geo-layers/tile-layer#onviewportload
-    onViewportLoad = () => {
-      // Slightly delay to avoid issues with a render in the middle of a deck.gl layer state update.
-      setTimeout(() => {
-        setViewportSelection(loaderSelection);
-      }, 0);
-    };
+    onViewportLoad = () => setViewportSelection(loaderSelection);
     // Set newLoaderSelection to cause the creation of an extra tile layer.
     newLoaderSelection = loaderSelection;
     oldLoaderSelection = viewportSelection;

--- a/src/views/VolumeView.js
+++ b/src/views/VolumeView.js
@@ -5,11 +5,15 @@ import VivView from './VivView';
 
 /**
  * This class generates a VolumeLayer and a view for use in the VivViewer as volumetric rendering.
+ * @param {Object} args
+ * @param {Array<number>} args.target Centered target for the camera (used if useFixedAxis is true)
+ * @param {Boolean} args.useFixedAxis Whether or not to fix the axis of the camera.
  * */
 export default class VolumeView extends VivView {
-  constructor({ target, ...args }) {
+  constructor({ target, useFixedAxis, ...args }) {
     super(args);
     this.target = target;
+    this.useFixedAxis = useFixedAxis;
   }
 
   getDeckGlView() {
@@ -26,12 +30,12 @@ export default class VolumeView extends VivView {
   }
 
   filterViewState({ viewState }) {
-    const { id, target } = this;
+    const { id, target, useFixedAxis } = this;
     return viewState.id === id
       ? {
           ...viewState,
-          // fix the center of the camera
-          target
+          // fix the center of the camera if desired
+          target: useFixedAxis ? target : viewState.target
         }
       : null;
   }

--- a/src/views/utils.js
+++ b/src/views/utils.js
@@ -1,9 +1,11 @@
 import { OrthographicView } from '@deck.gl/core';
+import { Matrix4 } from 'math.gl';
 import { getImageSize } from '../loaders/utils';
 
 // Do not import from '../layers' because that causes a circular dependency.
 import MultiscaleImageLayer from '../layers/MultiscaleImageLayer';
 import ImageLayer from '../layers/ImageLayer';
+import { getPhysicalSizeScalingMatrix } from '../layers/utils';
 
 export function getVivId(id) {
   return `-#${id}#`;
@@ -33,20 +35,35 @@ export function makeBoundingBox(viewState) {
  * Create an initial view state that centers the image in the viewport at the zoom level that fills the dimensions in `viewSize`.
  * @param {Object} loader (PixelSource[] | PixelSource)
  * @param {Object} viewSize { height, width } object giving dimensions of the viewport for deducing the right zoom level to center the image.
- * @param {Object} zoomBackOff A positive number which controls how far zoomed out the view state is from filling the entire viewport (default is 0 so the image fully fills the view).
+ * @param {Object=} zoomBackOff A positive number which controls how far zoomed out the view state is from filling the entire viewport (default is 0 so the image fully fills the view).
  * SideBySideViewer and PictureInPictureViewer use .5 when setting viewState automatically in their default behavior, so the viewport is slightly zoomed out from the image
  * filling the whole screen.  1 unit of zoomBackOff (so a passed-in value of 1) corresponds to a 2x zooming out.
- * @returns {ViewState} A default initial view state that centers the image within the view: { target: [x, y, 0], zoom: -zoom }.
+ * @param {Boolean=} use3d Whether or not to return a view state that can be used with the 3d viewer
+ * @param {Boolean=} modelMatrix If using a transformation matrix, passing it in here will allow this function to properly center the volume.
+ * @returns {Object} A default initial view state that centers the image within the view: { target: [x, y, 0], zoom: -zoom }.
  */
-export function getDefaultInitialViewState(loader, viewSize, zoomBackOff = 0) {
-  const { width, height } = getImageSize(
-    Array.isArray(loader) ? loader[0] : loader
-  );
+export function getDefaultInitialViewState(
+  loader,
+  viewSize,
+  zoomBackOff = 0,
+  use3d = false,
+  modelMatrix
+) {
+  const source = Array.isArray(loader) ? loader[0] : loader;
+  const { width, height } = getImageSize(source);
+  const depth = source.shape[source.labels.indexOf('z')];
   const zoom =
     Math.log2(Math.min(viewSize.width / width, viewSize.height / height)) -
     zoomBackOff;
+  const physicalSizeScalingMatrix = getPhysicalSizeScalingMatrix(source);
   const loaderInitialViewState = {
-    target: [width / 2, height / 2, 0],
+    target: (modelMatrix || new Matrix4()).transformPoint(
+      (use3d ? physicalSizeScalingMatrix : new Matrix4()).transformPoint([
+        width / 2,
+        height / 2,
+        use3d ? depth / 2 : 0
+      ])
+    ),
     zoom
   };
   return loaderInitialViewState;
@@ -62,8 +79,9 @@ export function getImageLayers(id, props) {
   const {
     loaderSelection,
     newLoaderSelection,
-    onViewportLoad,
     transitionFields,
+    transitionOnViewportLoad,
+    onViewportLoad,
     ...layerProps
   } = props;
   const { loader } = layerProps;
@@ -73,7 +91,7 @@ export function getImageLayers(id, props) {
   // Create at least one layer even without loaderSelection so that the tests pass.
   const Layer = loader.length > 1 ? MultiscaleImageLayer : ImageLayer;
   const layerLoader = loader.length > 1 ? loader : loader[0];
-  return [loaderSelection, newLoaderSelection]
+  const layers = [loaderSelection, newLoaderSelection]
     .filter((s, i) => i === 0 || s)
     .map((s, i) => {
       const suffix =
@@ -81,9 +99,15 @@ export function getImageLayers(id, props) {
       const newProps =
         i !== 0
           ? {
-              onViewportLoad
+              onViewportLoad: args => {
+                // Slightly delay to avoid issues with a render in the middle of a deck.gl layer state update.
+                setTimeout(() => {
+                  onViewportLoad(args);
+                  transitionOnViewportLoad(args);
+                }, 0);
+              }
             }
-          : {};
+          : { onViewportLoad };
       if (loader.length > 1 && i !== 0) {
         newProps.refinementStrategy = 'never';
         newProps.excludeBackground = true;
@@ -97,4 +121,5 @@ export function getImageLayers(id, props) {
         loader: layerLoader
       });
     });
+  return layers;
 }


### PR DESCRIPTION
#### Background
This contains new features for the Viv core needed for #421
#### Change List
- Rescale the downsampled coordiante system to match the full resolution (and update `xSlice`, clipping planes etc. accordingly to use the new coordinate system)
- Handle onViewportLoad callbacks in the Viewers better (using `setTimeout` to make sure updates are propagated)
- Add an abort option for the `VolumeLayer` and `ImageLayer` so that `onViewportLoad` may be used to optimal effect
- Fix a bug in the loaders where the z size used to be necessary
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
