### PR TITLE
Slicing Reversion + New Demo Datasets

### DIFF
--- a/avivator/src/components/Controller/components/Slicer.js
+++ b/avivator/src/components/Controller/components/Slicer.js
@@ -37,7 +37,7 @@ const Slicer = () => {
         alignItems="center"
         key={label}
       >
-        <Grid item xs={1}>
+        <Grid item xs={1} style={{ marginBottom: 8 }}>
           {label}:
         </Grid>
         <Grid item xs={11}>

--- a/avivator/src/components/Controller/components/Slicer.js
+++ b/avivator/src/components/Controller/components/Slicer.js
@@ -1,47 +1,34 @@
 import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import Slider from '@material-ui/core/Slider';
-import Button from '@material-ui/core/Button';
-import { useImageSettingsStore } from '../../../state';
-import { truncateDecimalNumber } from '../../../utils';
-import { EPSILON } from '../../../constants';
-
-function formatter(label) {
-  const isRadius = label === 'r'; // useful variable name
-  return v => {
-    const val = truncateDecimalNumber(isRadius ? v : v / Math.PI, 4);
-    const radians = label === 'r' ? '' : 'π';
-    return `${val}${radians}`;
-  };
-}
+import { useImageSettingsStore, useChannelSettings } from '../../../state';
+import { getBoundingCube, truncateDecimalNumber } from '../../../utils';
 
 const Slicer = () => {
-  const {
-    setClippingPlaneSettings,
-    sphericals: [spherical]
-  } = useImageSettingsStore();
+  const { setImageSetting, xSlice, ySlice, zSlice } = useImageSettingsStore();
+  const { loader } = useChannelSettings();
+  const [xSliceInit, ySliceInit, zSliceInit] = getBoundingCube(loader);
   const sliceValuesAndSetSliceFunctions = [
     [
-      spherical.phi,
-      phi => setClippingPlaneSettings(0, { phi }),
-      'ϕ',
-      [0, Math.PI * 2]
+      xSlice,
+      xSliceNew => setImageSetting({ xSlice: xSliceNew }),
+      'x',
+      xSliceInit
     ],
     [
-      spherical.theta,
-      theta => setClippingPlaneSettings(0, { theta }),
-      'ϴ',
-      [-Math.PI / 2, Math.PI / 2]
+      ySlice,
+      ySliceNew => setImageSetting({ ySlice: ySliceNew }),
+      'y',
+      ySliceInit
     ],
     [
-      spherical.radius,
-      radius => setClippingPlaneSettings(0, { radius }),
-      'r',
-      // Since the box has diagonal length (1 + 1)^{\frac{1}{2}}
-      [EPSILON, Math.sqrt(2)]
+      zSlice,
+      zSliceNew => setImageSetting({ zSlice: zSliceNew }),
+      'z',
+      zSliceInit
     ]
   ];
-  const slicers = sliceValuesAndSetSliceFunctions.map(
+  return sliceValuesAndSetSliceFunctions.map(
     ([val, setVal, label, [min, max]]) => (
       <Grid
         container
@@ -58,7 +45,7 @@ const Slicer = () => {
             value={val}
             onChange={(e, v) => setVal(v)}
             valueLabelDisplay="auto"
-            valueLabelFormat={formatter(label)}
+            valueLabelFormat={v => truncateDecimalNumber(v, 5)}
             getAriaLabel={() => `${label} slider`}
             min={min}
             max={max}
@@ -68,35 +55,6 @@ const Slicer = () => {
         </Grid>
       </Grid>
     )
-  );
-  const presets = [
-    ['X', [EPSILON, 0.5 * Math.PI, 0.5 * Math.PI]],
-    ['Y', [EPSILON, -0.5 * Math.PI, 0]],
-    ['Z', [EPSILON, 0, 0]]
-  ].map(([label, [radius, theta, phi]]) => (
-    <Grid item xs="auto" key={label}>
-      <Button
-        onClick={() => {
-          setClippingPlaneSettings(0, { radius, phi, theta });
-        }}
-        style={{ padding: 0, paddingTop: 4 }}
-      >
-        {label} Slice
-      </Button>
-    </Grid>
-  ));
-  return (
-    <>
-      <Grid
-        container
-        direction="row"
-        justify="space-between"
-        alignItems="center"
-      >
-        {presets}
-      </Grid>
-      {slicers}
-    </>
   );
 };
 

--- a/avivator/src/components/Controller/components/VolumeButton.js
+++ b/avivator/src/components/Controller/components/VolumeButton.js
@@ -15,7 +15,12 @@ import {
   useViewerStore,
   useChannelSetters
 } from '../../../state';
-import { range, guessRgb, getMultiSelectionStats } from '../../../utils';
+import {
+  range,
+  guessRgb,
+  getMultiSelectionStats,
+  getBoundingCube
+} from '../../../utils';
 
 function formatBytes(bytes, decimals = 2) {
   if (bytes === 0) return '0 Bytes';
@@ -139,7 +144,15 @@ function VolumeButton() {
                             setViewerState({
                               isChannelLoading: selections.map(_ => true)
                             });
-                            setImageSetting({ resolution });
+                            const [xSlice, ySlice, zSlice] = getBoundingCube(
+                              loader
+                            );
+                            setImageSetting({
+                              resolution,
+                              xSlice,
+                              ySlice,
+                              zSlice
+                            });
                             toggle();
                             getMultiSelectionStats({
                               loader,

--- a/avivator/src/components/Viewer.js
+++ b/avivator/src/components/Viewer.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
-import { Plane } from '@math.gl/culling';
-import { Matrix4 } from '@math.gl/core';
 import debounce from 'lodash/debounce';
 import {
   SideBySideViewer,
@@ -14,7 +12,7 @@ import {
   useViewerStore,
   useChannelSettings
 } from '../state';
-import { useWindowSize, getPhysicalSizeScalingMatrix } from '../utils';
+import { useWindowSize } from '../utils';
 import { DEFAULT_OVERVIEW } from '../constants';
 
 const Viewer = () => {
@@ -25,7 +23,9 @@ const Viewer = () => {
     lensSelection,
     colormap,
     renderingMode,
-    sphericals,
+    xSlice,
+    ySlice,
+    zSlice,
     resolution,
     isLensOn,
     zoomLock,
@@ -34,21 +34,6 @@ const Viewer = () => {
     onViewportLoad,
     useFixedAxis
   } = useImageSettingsStore();
-  const source = loader[0];
-  const physicalSizeScalingMatrix = getPhysicalSizeScalingMatrix(source);
-  const pixelScalingMatrix = new Matrix4().scale(
-    ['x', 'y', 'z'].map(d => source.shape[source.labels.indexOf(d)])
-  );
-  const clippingPlanes = sphericals.map(v =>
-    new Plane().fromPointNormal(
-      pixelScalingMatrix.transformPoint(
-        physicalSizeScalingMatrix.transformPoint(v.toVector3())
-      ),
-      pixelScalingMatrix.transformPoint(
-        physicalSizeScalingMatrix.transformPoint(v.toVector3())
-      )
-    )
-  );
   return use3d ? (
     <VolumeViewer
       loader={loader}
@@ -57,7 +42,9 @@ const Viewer = () => {
       channelIsOn={isOn}
       loaderSelection={selections}
       colormap={colormap.length > 0 && colormap}
-      clippingPlanes={clippingPlanes}
+      xSlice={xSlice}
+      ySlice={ySlice}
+      zSlice={zSlice}
       resolution={resolution}
       renderingMode={renderingMode}
       height={viewSize.height}

--- a/avivator/src/constants.js
+++ b/avivator/src/constants.js
@@ -29,4 +29,3 @@ export const COLOR_PALLETE = [
 export const GLOBAL_SLIDER_DIMENSION_FIELDS = ['z', 't'];
 export const INITIAL_SLIDER_VALUE = [1500, 20000];
 export const FILL_PIXEL_VALUE = '----';
-export const EPSILON = 0.000000000001;

--- a/avivator/src/source-info.js
+++ b/avivator/src/source-info.js
@@ -22,8 +22,18 @@ const sources = [
   },
   {
     // Generated using bioformats2raw and raw2ometiff.
-    path: 'HandEuncompressed_Scan1.ome.tif',
-    description: 'Perkin Elmer H&E Stain HandEuncompressed_Scan1.qptiff'
+    path: '2018-12-18_ASY_H2B_bud_05_3D_8_angles.ome.tif',
+    description: 'idr0077'
+  },
+  {
+    // Generated using bioformats2raw and raw2ometiff.
+    path: 'brain.pyramid.ome.tif',
+    description: 'idr0085'
+  },
+  {
+    // Generated using bioformats2raw and raw2ometiff.
+    path: 'idr0106.pyramid.ome.tif',
+    description: 'idr0106'
   }
 ];
 

--- a/avivator/src/state.js
+++ b/avivator/src/state.js
@@ -8,8 +8,6 @@ import { _SphericalCoordinates as SphericalCoordinates } from '@math.gl/core';
 // eslint-disable-next-line import/no-unresolved
 import { RENDERING_MODES } from '@hms-dbmi/viv';
 
-import { EPSILON } from './constants';
-
 const captialize = string => string.charAt(0).toUpperCase() + string.slice(1);
 
 const generateToggles = (defaults, set) => {
@@ -124,13 +122,15 @@ const DEFAULT_IMAGE_STATE = {
   lensSelection: 0,
   colormap: '',
   renderingMode: RENDERING_MODES.MAX_INTENSITY_PROJECTION,
-  sphericals: [new SphericalCoordinates({ radius: EPSILON, phi: 0, theta: 0 })],
   resolution: 0,
   isLensOn: false,
   zoomLock: true,
   panLock: true,
   isOverviewOn: false,
   useFixedAxis: true,
+  xSlice: null,
+  ySlice: null,
+  zSlice: null,
   onViewportLoad: () => {}
 };
 
@@ -141,16 +141,7 @@ export const useImageSettingsStore = create(set => ({
     set(state => ({
       ...state,
       ...newState
-    })),
-  setClippingPlaneSettings: (index, props) =>
-    set(state => {
-      const newState = {};
-      newState.sphericals = [...state.sphericals];
-      Object.entries(props).forEach(([prop, val]) => {
-        newState.sphericals[index][prop] = val;
-      });
-      return { ...state, ...newState };
-    })
+    }))
 }));
 
 const DEFAULT_VIEWER_STATE = {

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -320,3 +320,16 @@ export function getPhysicalSizeScalingMatrix(loader) {
   }
   return new Matrix4().identity();
 }
+
+export function getBoundingCube(loader) {
+  const source = Array.isArray(loader) ? loader[0] : loader;
+  const { shape, labels } = source;
+  const physicalSizeScalingMatrix = getPhysicalSizeScalingMatrix(source);
+  const xSlice = [0, physicalSizeScalingMatrix[0] * shape[labels.indexOf('x')]];
+  const ySlice = [0, physicalSizeScalingMatrix[5] * shape[labels.indexOf('y')]];
+  const zSlice = [
+    0,
+    physicalSizeScalingMatrix[10] * shape[labels.indexOf('z')]
+  ];
+  return [xSlice, ySlice, zSlice];
+}


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
This should be the final PR - it reverts the slicing mechanism back to what it was previously with orthogonal slicing.  I also added my three favorite idr datasets for our demo and removed the H&E stain (was nice at first to show we can recognize it, but don't think it really adds anything).
<!-- For all the PRs -->
#### Change List
- Update demo list with idr datasets and remove H&E example
- Revert slicing to only orthogonal clipping plane slicing.
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
