### PR TITLE
Allow for LINEAR/NEAREST Filtering Interpolation Choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add screenshots to README.md
+- Allow users to choose `LINEAR` or `NEAREST` interpolation filtering for `XRLayer`.
 
 ### Changed
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -85,6 +85,6 @@ export const DTYPE_VALUES = {
 export const GLOBAL_SLIDER_DIMENSION_FIELDS = ['z', 't'];
 
 export enum INTERPOLATION_MODES {
-  LINEAR = 'Linear',
-  NEAREST = 'Nearest'
+  LINEAR = GL.LINEAR,
+  NEAREST = GL.NEAREST
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,3 +83,8 @@ export const DTYPE_VALUES = {
 } as const;
 
 export const GLOBAL_SLIDER_DIMENSION_FIELDS = ['z', 't'];
+
+export enum INTERPOLATION_MODES {
+  LINEAR = 'Linear',
+  NEAREST = 'Nearest'
+}

--- a/src/index.js
+++ b/src/index.js
@@ -16,11 +16,16 @@ import {
   DETAIL_VIEW_ID,
   OVERVIEW_VIEW_ID
 } from './views';
-import { DTYPE_VALUES, MAX_SLIDERS_AND_CHANNELS } from './constants';
+import {
+  DTYPE_VALUES,
+  MAX_SLIDERS_AND_CHANNELS,
+  INTERPOLATION_MODES
+} from './constants';
 
 export {
   DTYPE_VALUES,
   MAX_SLIDERS_AND_CHANNELS,
+  INTERPOLATION_MODES,
   ScaleBarLayer,
   MultiscaleImageLayer,
   XRLayer,

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -66,7 +66,7 @@ const defaultProps = {
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @property {function=} onViewportLoad Function that gets called when the data in the viewport loads.
  * @property {String=} id Unique identifier for this layer.
- * @property {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is NEAREST
+ * @property {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is GL.NEAREST
  */
 
 /**

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -5,6 +5,7 @@ import XRLayer from './XRLayer';
 import BitmapLayer from './BitmapLayer';
 import { onPointer } from './utils';
 import { isInterleaved } from '../loaders/utils';
+import { INTERPOLATION_MODES } from '../constants';
 
 const defaultProps = {
   pickable: { type: 'boolean', value: true, compare: true },
@@ -31,7 +32,12 @@ const defaultProps = {
   lensBorderRadius: { type: 'number', value: 0.02, compare: true },
   onClick: { type: 'function', value: null, compare: true },
   transparentColor: { type: 'array', value: null, compare: true },
-  onViewportLoad: { type: 'function', value: null, compare: true }
+  onViewportLoad: { type: 'function', value: null, compare: true },
+  interpolation: {
+    type: 'string',
+    value: INTERPOLATION_MODES.NEAREST,
+    compare: true
+  }
 };
 
 /**
@@ -60,6 +66,7 @@ const defaultProps = {
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @property {function=} onViewportLoad Function that gets called when the data in the viewport loads.
  * @property {String=} id Unique identifier for this layer.
+ * @property {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is NEAREST
  */
 
 /**

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -10,6 +10,7 @@ import {
   isInterleaved,
   SIGNAL_ABORTED
 } from '../../loaders/utils';
+import { INTERPOLATION_MODES } from '../../constants';
 
 // From https://github.com/visgl/deck.gl/pull/4616/files#diff-4d6a2e500c0e79e12e562c4f1217dc80R128
 const DECK_GL_TILE_SIZE = 512;
@@ -33,7 +34,12 @@ const defaultProps = {
   onClick: { type: 'function', value: null, compare: true },
   transparentColor: { type: 'array', value: null, compare: true },
   refinementStrategy: { type: 'string', value: null, compare: true },
-  excludeBackground: { type: 'boolean', value: false, compare: true }
+  excludeBackground: { type: 'boolean', value: false, compare: true },
+  interpolation: {
+    type: 'string',
+    value: INTERPOLATION_MODES.LINEAR,
+    compare: true
+  }
 };
 
 /**
@@ -65,6 +71,7 @@ const defaultProps = {
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @property {string=} refinementStrategy 'best-available' | 'no-overlap' | 'never' will be passed to TileLayer. A default will be chosen based on opacity.
  * @property {boolean=} excludeBackground Whether to exclude the background image. The background image is also excluded for opacity!=1.
+ * @property {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is NEAREST
  */
 
 /**

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -71,7 +71,7 @@ const defaultProps = {
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @property {string=} refinementStrategy 'best-available' | 'no-overlap' | 'never' will be passed to TileLayer. A default will be chosen based on opacity.
  * @property {boolean=} excludeBackground Whether to exclude the background image. The background image is also excluded for opacity!=1.
- * @property {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is NEAREST
+ * @property {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is GL.NEAREST
  */
 
 /**

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayerBase.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayerBase.js
@@ -1,6 +1,7 @@
 import { TileLayer } from '@deck.gl/geo-layers';
 import { COORDINATE_SYSTEM } from '@deck.gl/core';
 import { renderSubLayers } from './utils';
+import { INTERPOLATION_MODES } from '../../constants';
 
 const defaultProps = {
   pickable: { type: 'boolean', value: true, compare: true },
@@ -19,7 +20,12 @@ const defaultProps = {
   lensRadius: { type: 'number', value: 100, compare: true },
   lensBorderColor: { type: 'array', value: [255, 255, 255], compare: true },
   lensBorderRadius: { type: 'number', value: 0.02, compare: true },
-  transparentColor: { type: 'array', value: null, compare: true }
+  transparentColor: { type: 'array', value: null, compare: true },
+  interpolation: {
+    type: 'string',
+    value: INTERPOLATION_MODES.NEAREST,
+    compare: true
+  }
 };
 
 /**

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -21,7 +21,6 @@ const SHADER_MODULES = [
 
 function getRenderingAttrs(dtype, gl, interpolation) {
   const isLinear = interpolation === INTERPOLATION_MODES.LINEAR;
-  const filterSetting = isLinear ? GL.LINEAR : GL.NEAREST;
   if (!isWebGL2(gl)) {
     // WebGL1
     return {
@@ -30,7 +29,7 @@ function getRenderingAttrs(dtype, gl, interpolation) {
       type: GL.FLOAT,
       sampler: 'sampler2D',
       shaderModule: SHADER_MODULES[0],
-      filter: filterSetting,
+      filter: interpolation,
       cast: data => new Float32Array(data)
     };
   }
@@ -39,7 +38,7 @@ function getRenderingAttrs(dtype, gl, interpolation) {
   return {
     ...values,
     shaderModule: SHADER_MODULES[1],
-    filter: filterSetting,
+    filter: interpolation,
     cast: isLinear ? data => new Float32Array(data) : data => data
   };
 }
@@ -91,7 +90,7 @@ const defaultProps = {
  * In other words, any fragment shader output equal transparentColor (before applying opacity) will have opacity 0.
  * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
- * @property {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is NEAREST
+ * @property {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is GL.NEAREST
  */
 /**
  * @type {{ new (...props: import('../../types').Viv<LayerProps>[]) }}

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -21,7 +21,7 @@ const SHADER_MODULES = [
 
 function getRenderingAttrs(dtype, gl, interpolation) {
   const isLinear = interpolation === INTERPOLATION_MODES.LINEAR;
-  const interpolationSetting = isLinear ? GL.LINEAR : GL.NEAREST;
+  const filterSetting = isLinear ? GL.LINEAR : GL.NEAREST;
   if (!isWebGL2(gl)) {
     // WebGL1
     return {
@@ -30,7 +30,7 @@ function getRenderingAttrs(dtype, gl, interpolation) {
       type: GL.FLOAT,
       sampler: 'sampler2D',
       shaderModule: SHADER_MODULES[0],
-      filter: interpolationSetting,
+      filter: filterSetting,
       cast: data => new Float32Array(data)
     };
   }
@@ -39,7 +39,7 @@ function getRenderingAttrs(dtype, gl, interpolation) {
   return {
     ...values,
     shaderModule: SHADER_MODULES[1],
-    filter: interpolationSetting,
+    filter: filterSetting,
     cast: isLinear ? data => new Float32Array(data) : data => data
   };
 }

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -12,13 +12,16 @@ import vs1 from './xr-layer-vertex.webgl1.glsl';
 import vs2 from './xr-layer-vertex.webgl2.glsl';
 import { lens, channels } from './shader-modules';
 import { padColorsAndSliders, getDtypeValues } from '../utils';
+import { INTERPOLATION_MODES } from '../../constants';
 
 const SHADER_MODULES = [
   { fs: fs1, fscmap: fsColormap1, vs: vs1 },
   { fs: fs2, fscmap: fsColormap2, vs: vs2 }
 ];
 
-function getRenderingAttrs(dtype, gl) {
+function getRenderingAttrs(dtype, gl, interpolation) {
+  const isLinear = interpolation === INTERPOLATION_MODES.LINEAR;
+  const interpolationSetting = isLinear ? GL.LINEAR : GL.NEAREST;
   if (!isWebGL2(gl)) {
     // WebGL1
     return {
@@ -27,11 +30,18 @@ function getRenderingAttrs(dtype, gl) {
       type: GL.FLOAT,
       sampler: 'sampler2D',
       shaderModule: SHADER_MODULES[0],
+      filter: interpolationSetting,
       cast: data => new Float32Array(data)
     };
   }
-  const values = getDtypeValues(dtype);
-  return { ...values, shaderModule: SHADER_MODULES[1] };
+  // Linear filtering only works when the data type is cast to Float32.
+  const values = getDtypeValues(isLinear ? 'Float32' : dtype);
+  return {
+    ...values,
+    shaderModule: SHADER_MODULES[1],
+    filter: interpolationSetting,
+    cast: isLinear ? data => new Float32Array(data) : data => data
+  };
 }
 
 const defaultProps = {
@@ -50,7 +60,12 @@ const defaultProps = {
   lensBorderColor: { type: 'array', value: [255, 255, 255], compare: true },
   lensBorderRadius: { type: 'number', value: 0.02, compare: true },
   unprojectLensBounds: { type: 'array', value: [0, 0, 0, 0], compare: true },
-  transparentColor: { type: 'array', value: null, compare: true }
+  transparentColor: { type: 'array', value: null, compare: true },
+  interpolation: {
+    type: 'string',
+    value: INTERPOLATION_MODES.NEAREST,
+    compare: true
+  }
 };
 
 /**
@@ -76,6 +91,7 @@ const defaultProps = {
  * In other words, any fragment shader output equal transparentColor (before applying opacity) will have opacity 0.
  * This parameter only needs to be a truthy value when using colormaps because each colormap has its own transparent color that is calculated on the shader.
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
+ * @property {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is NEAREST
  */
 /**
  * @type {{ new (...props: import('../../types').Viv<LayerProps>[]) }}
@@ -87,8 +103,12 @@ const XRLayer = class extends Layer {
    * replaces `usampler` with `sampler` if the data is not an unsigned integer
    */
   getShaders() {
-    const { colormap, dtype } = this.props;
-    const { shaderModule, sampler } = getRenderingAttrs(dtype, this.context.gl);
+    const { colormap, dtype, interpolation } = this.props;
+    const { shaderModule, sampler } = getRenderingAttrs(
+      dtype,
+      this.context.gl,
+      interpolation
+    );
     return super.getShaders({
       fs: colormap ? shaderModule.fscmap : shaderModule.fs,
       vs: shaderModule.vs,
@@ -144,7 +164,11 @@ const XRLayer = class extends Layer {
    */
   updateState({ props, oldProps, changeFlags }) {
     // setup model first
-    if (changeFlags.extensionsChanged || props.colormap !== oldProps.colormap) {
+    if (
+      changeFlags.extensionsChanged ||
+      props.colormap !== oldProps.colormap ||
+      props.interpolation !== oldProps.interpolation
+    ) {
       const { gl } = this.context;
       if (this.state.model) {
         this.state.model.delete();
@@ -154,8 +178,9 @@ const XRLayer = class extends Layer {
       this.getAttributeManager().invalidateAll();
     }
     if (
-      props.channelData !== oldProps.channelData &&
-      props.channelData?.data !== oldProps.channelData?.data
+      (props.channelData !== oldProps.channelData &&
+        props.channelData?.data !== oldProps.channelData?.data) ||
+      props.interpolation !== oldProps.interpolation
     ) {
       this.loadChannelTextures(props.channelData);
     }
@@ -331,18 +356,22 @@ const XRLayer = class extends Layer {
    * This function creates textures from the data
    */
   dataToTexture(data, width, height) {
-    const attrs = getRenderingAttrs(this.props.dtype, this.context.gl);
+    const { interpolation } = this.props;
+    const attrs = getRenderingAttrs(
+      this.props.dtype,
+      this.context.gl,
+      interpolation
+    );
     return new Texture2D(this.context.gl, {
       width,
       height,
-      // data is cast in WebGL1 environment
       data: attrs.cast?.(data) ?? data,
       // we don't want or need mimaps
       mipmaps: false,
       parameters: {
         // NEAREST for integer data
-        [GL.TEXTURE_MIN_FILTER]: GL.NEAREST,
-        [GL.TEXTURE_MAG_FILTER]: GL.NEAREST,
+        [GL.TEXTURE_MIN_FILTER]: attrs.filter,
+        [GL.TEXTURE_MAG_FILTER]: attrs.filter,
         // CLAMP_TO_EDGE to remove tile artifacts
         [GL.TEXTURE_WRAP_S]: GL.CLAMP_TO_EDGE,
         [GL.TEXTURE_WRAP_T]: GL.CLAMP_TO_EDGE

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -45,7 +45,7 @@ import {
  * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition when making a new selection: Default: ['t', 'z'].
- * @param {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is NEAREST
+ * @param {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is GL.NEAREST
  */
 
 const PictureInPictureViewer = props => {

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -8,7 +8,10 @@ import {
   OVERVIEW_VIEW_ID
 } from '../views';
 import useGlobalSelection from './global-selection-hook';
-import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
+import {
+  GLOBAL_SLIDER_DIMENSION_FIELDS,
+  INTERPOLATION_MODES
+} from '../constants';
 
 /**
  * This component provides a component for an overview-detail VivViewer of an image (i.e picture-in-picture).
@@ -42,6 +45,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition when making a new selection: Default: ['t', 'z'].
+ * @param {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is NEAREST
  */
 
 const PictureInPictureViewer = props => {
@@ -67,7 +71,8 @@ const PictureInPictureViewer = props => {
     transparentColor,
     onViewStateChange,
     onHover,
-    transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS
+    transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS,
+    interpolation = INTERPOLATION_MODES.NEAREST
   } = props;
   const {
     newLoaderSelection,
@@ -103,7 +108,8 @@ const PictureInPictureViewer = props => {
     lensRadius,
     lensBorderColor,
     lensBorderRadius,
-    transparentColor
+    transparentColor,
+    interpolation
   };
   const views = [detailView];
   const layerProps = [layerConfig];

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -2,7 +2,10 @@ import React, { useMemo } from 'react'; // eslint-disable-line import/no-unresol
 import VivViewer from './VivViewer';
 import { SideBySideView, getDefaultInitialViewState } from '../views';
 import useGlobalSelection from './global-selection-hook';
-import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
+import {
+  GLOBAL_SLIDER_DIMENSION_FIELDS,
+  INTERPOLATION_MODES
+} from '../constants';
 
 /**
  * This component provides a side-by-side VivViewer with linked zoom/pan.
@@ -32,6 +35,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition: Default: ['t', 'z'].
+ * @param {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is NEAREST
  */
 const SideBySideViewer = props => {
   const {
@@ -54,7 +58,8 @@ const SideBySideViewer = props => {
     transparentColor,
     onViewStateChange,
     onHover,
-    transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS
+    transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS,
+    interpolation = INTERPOLATION_MODES.NEAREST
   } = props;
   const {
     newLoaderSelection,
@@ -111,7 +116,8 @@ const SideBySideViewer = props => {
     lensRadius,
     lensBorderColor,
     lensBorderRadius,
-    transparentColor
+    transparentColor,
+    interpolation
   };
   const views = [detailViewRight, detailViewLeft];
   const layerProps = [layerConfig, layerConfig];

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -35,7 +35,7 @@ import {
  * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition: Default: ['t', 'z'].
- * @param {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is NEAREST
+ * @param {String=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is GL.NEAREST
  */
 const SideBySideViewer = props => {
   const {


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #298.

I will add the choice to Avivator with the 3D stuff since Avivator is changing so much there.

<!-- For all the PRs -->
#### Change List
- Add `interpolation` prop to all of the layers/components to allow for LINEAR vs. NEAREST filtering (called "interpolation")

#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
