### PR TITLE
Fix for 3D Blending.

### DIFF
--- a/src/layers/VolumeLayer/VolumeLayer.js
+++ b/src/layers/VolumeLayer/VolumeLayer.js
@@ -1,4 +1,5 @@
 import { CompositeLayer, COORDINATE_SYSTEM } from '@deck.gl/core';
+import GL from '@luma.gl/constants';
 import { TextLayer } from '@deck.gl/layers';
 import { Matrix4 } from 'math.gl';
 import XR3DLayer from '../XR3DLayer';
@@ -168,6 +169,13 @@ const VolumeLayer = class extends CompositeLayer {
       channelData: { data, width, height, depth },
       id: `XR3DLayer-${0}-${height}-${width}-${0}-${resolution}-${id}`,
       physicalSizeScalingMatrix,
+      parameters: {
+        [GL.CULL_FACE]: true,
+        [GL.CULL_FACE_MODE]: GL.FRONT,
+        [GL.DEPTH_TEST]: false,
+        blendFunc: [GL.SRC_ALPHA, GL.ONE],
+        blend: true
+      },
       resolutionMatrix,
       dtype
     });

--- a/src/layers/XR3DLayer/XR3DLayer.js
+++ b/src/layers/XR3DLayer/XR3DLayer.js
@@ -135,11 +135,6 @@ const XR3DLayer = class extends Layer {
     this.setState({
       model: this._getModel(gl)
     });
-    // Needed to only render the back polygons.
-    setParameters(gl, {
-      [GL.CULL_FACE]: true,
-      [GL.CULL_FACE_MODE]: GL.FRONT
-    });
     // This tells WebGL how to read row data from the texture.  For example, the default here is 4 (i.e for RGBA, one byte per channel) so
     // each row of data is expected to be a multiple of 4.  This setting (i.e 1) allows us to have non-multiple-of-4 row sizes.  For example, for 2 byte (16 bit data),
     // we could use 2 as the value and it would still work, but 1 also works fine (and is more flexible for 8 bit - 1 byte - textures as well).


### PR DESCRIPTION
#### Background
To test this out add another `VolumeLayer` to the `VolumeView`:
Previously our blending didn't work because we were not using the right WebGL settings.  It should work pretty well now.
```javascript
  getLayers({ props }) {
    const { loader } = props;
    const { id } = this;

    const layers = [
      new VolumeLayer(props, {
        id: `${loader.type}${getVivId(id)}`
      }),
      new VolumeLayer(props, {
        id: `${loader.type}${getVivId(id)}-2`,
        modelMatrix: new Matrix4().rotateZ(.5).translate([250, 250, 0])
      })
    ];

    return layers;
  }
```

There are other things that we can do like depth testing and so forth to get different blending types but those would require a change along the lines of [this](https://github.com/hms-dbmi/viv/compare/ilan-gold/use_3d_tab_avivator...ilan-gold/viv_3d_polygon_fix?expand=1) - in short, we would need to render each channel individually and then combine them as well as track the depth at which each channel renders.  The downside of this approach is that the additive rendering mode does not look as nice and it would mean that we could not use global colormaps (i.e one colormap for many channels).  This is more broadly related to #304 and if we do go that route, I think we should do it for our 2D layers as well.
<!-- For all the PRs -->
#### Change List
- Add correct blending parameters to the `VolumeLayer`

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
