### PR TITLE
Remove Auto Interpolation Prop (where possible)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -136,8 +136,3 @@ export enum RENDERING_MODES {
 }
 
 export const GLOBAL_SLIDER_DIMENSION_FIELDS = ['z', 't'] as const;
-
-export enum INTERPOLATION_MODES {
-  LINEAR = GL.LINEAR,
-  NEAREST = GL.NEAREST
-}

--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,7 @@ import {
   DTYPE_VALUES,
   MAX_SLIDERS_AND_CHANNELS,
   COLORMAPS,
-  RENDERING_MODES,
-  INTERPOLATION_MODES
+  RENDERING_MODES
 } from './constants';
 
 export {
@@ -37,7 +36,6 @@ export {
   COLORMAPS,
   MAX_SLIDERS_AND_CHANNELS,
   RENDERING_MODES,
-  INTERPOLATION_MODES,
   ScaleBarLayer,
   VolumeLayer,
   MultiscaleImageLayer,

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -5,7 +5,6 @@ import XRLayer from './XRLayer';
 import BitmapLayer from './BitmapLayer';
 import { onPointer } from './utils';
 import { isInterleaved, SIGNAL_ABORTED } from '../loaders/utils';
-import { INTERPOLATION_MODES } from '../constants';
 
 const defaultProps = {
   pickable: { type: 'boolean', value: true, compare: true },
@@ -35,7 +34,7 @@ const defaultProps = {
   onViewportLoad: { type: 'function', value: null, compare: true },
   interpolation: {
     type: 'number',
-    value: INTERPOLATION_MODES.NEAREST,
+    value: GL.NEAREST,
     compare: true
   }
 };
@@ -66,7 +65,6 @@ const defaultProps = {
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @property {function=} onViewportLoad Function that gets called when the data in the viewport loads.
  * @property {String=} id Unique identifier for this layer.
- * @property {number=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is GL.NEAREST
  */
 
 /**

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -10,7 +10,6 @@ import {
   isInterleaved,
   SIGNAL_ABORTED
 } from '../../loaders/utils';
-import { INTERPOLATION_MODES } from '../../constants';
 
 // From https://github.com/visgl/deck.gl/pull/4616/files#diff-4d6a2e500c0e79e12e562c4f1217dc80R128
 const DECK_GL_TILE_SIZE = 512;
@@ -34,8 +33,7 @@ const defaultProps = {
   onClick: { type: 'function', value: null, compare: true },
   transparentColor: { type: 'array', value: null, compare: true },
   refinementStrategy: { type: 'string', value: null, compare: true },
-  excludeBackground: { type: 'boolean', value: false, compare: true },
-  interpolation: { type: 'number', value: null, compare: true }
+  excludeBackground: { type: 'boolean', value: false, compare: true }
 };
 
 /**
@@ -67,8 +65,6 @@ const defaultProps = {
  * Thus setting this to a truthy value (with a colormap set) indicates that the shader should make that color transparent.
  * @property {string=} refinementStrategy 'best-available' | 'no-overlap' | 'never' will be passed to TileLayer. A default will be chosen based on opacity.
  * @property {boolean=} excludeBackground Whether to exclude the background image. The background image is also excluded for opacity!=1.
- * @property {number=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter).
- * Default is null which indicates an "auto" setting where the highest reoslution is NEREAST and all else is LINEAR.
  */
 
 /**
@@ -102,8 +98,7 @@ const MultiscaleImageLayer = class extends CompositeLayer {
       modelMatrix,
       transparentColor,
       excludeBackground,
-      refinementStrategy,
-      interpolation
+      refinementStrategy
     } = this.props;
 
     // Get properties from highest resolution
@@ -235,7 +230,7 @@ const MultiscaleImageLayer = class extends CompositeLayer {
         onHover,
         onClick,
         // Background image is nicest when LINEAR in my opinion.
-        interpolation: interpolation || INTERPOLATION_MODES.LINEAR
+        interpolation: GL.LINEAR
       });
     const layers = [baseLayer, tiledLayer];
     return layers;

--- a/src/layers/MultiscaleImageLayer/utils.js
+++ b/src/layers/MultiscaleImageLayer/utils.js
@@ -1,7 +1,7 @@
+import GL from '@luma.gl/constants';
 import XRLayer from '../XRLayer';
 import BitmapLayer from '../BitmapLayer';
 import { getImageSize, isInterleaved } from '../../loaders/utils';
-import { INTERPOLATION_MODES } from '../../constants';
 
 export function range(len) {
   return [...Array(len).keys()];
@@ -49,10 +49,7 @@ export function renderSubLayers(props) {
     bounds,
     id: `tile-sub-layer-${bounds}-${id}`,
     tileId: { x, y, z },
-    // If no option is passed in, the auto setting is NEAREST at the highest resolution but LINEAR otherwise.
-    interpolation:
-      props.interpolation || z === maxZoom
-        ? INTERPOLATION_MODES.NEAREST
-        : INTERPOLATION_MODES.LINEAR
+    // The auto setting is NEAREST at the highest resolution but LINEAR otherwise.
+    interpolation: z === maxZoom ? GL.NEAREST : GL.LINEAR
   });
 }

--- a/src/layers/VolumeLayer/VolumeLayer.js
+++ b/src/layers/VolumeLayer/VolumeLayer.js
@@ -4,7 +4,7 @@ import { TextLayer } from '@deck.gl/layers';
 import { Matrix4 } from 'math.gl';
 import XR3DLayer from '../XR3DLayer';
 import { getPhysicalSizeScalingMatrix } from '../utils';
-import { RENDERING_MODES, INTERPOLATION_MODES } from '../../constants';
+import { RENDERING_MODES } from '../../constants';
 import { getVolume } from './utils';
 
 const defaultProps = {
@@ -38,11 +38,6 @@ const defaultProps = {
     value: RENDERING_MODES.MAX_INTENSITY_PROJECTION,
     compare: true
   },
-  interpolation: {
-    type: 'number',
-    value: INTERPOLATION_MODES.LINEAR,
-    compare: true
-  },
   onUpdate: { type: 'function', value: () => {}, compare: true },
   useProgressIndicator: { type: 'boolean', value: true, compare: true }
 };
@@ -65,7 +60,6 @@ const defaultProps = {
  * @property {Array.<number>=} zSlice 0-depth (physical coordinates) interval on which to slice the volume.
  * @property {function=} onViewportLoad Function that gets called when the data in the viewport loads.
  * @property {Array.<Object>=} clippingPlanes List of math.gl [Plane](https://math.gl/modules/culling/docs/api-reference/plane) objects.
- * @property {number=} interpolation The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is GL.LINEAR
  * @property {boolean=} useProgressIndicator Whether or not to use the default progress text + indicator (default is true)
  * @property {function=} onUpdate A callback to be used for getting updates of the progress, ({ progress }) => {}
  */

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -12,7 +12,6 @@ import vs1 from './xr-layer-vertex.webgl1.glsl';
 import vs2 from './xr-layer-vertex.webgl2.glsl';
 import { lens, channels } from './shader-modules';
 import { padColorsAndSliders, getDtypeValues } from '../utils';
-import { INTERPOLATION_MODES } from '../../constants';
 
 const SHADER_MODULES = [
   { fs: fs1, fscmap: fsColormap1, vs: vs1 },
@@ -20,7 +19,7 @@ const SHADER_MODULES = [
 ];
 
 function getRenderingAttrs(dtype, gl, interpolation) {
-  const isLinear = interpolation === INTERPOLATION_MODES.LINEAR;
+  const isLinear = interpolation === GL.LINEAR;
   if (!isWebGL2(gl)) {
     // WebGL1
     return {
@@ -62,7 +61,7 @@ const defaultProps = {
   transparentColor: { type: 'array', value: null, compare: true },
   interpolation: {
     type: 'number',
-    value: INTERPOLATION_MODES.NEAREST,
+    value: GL.NEAREST,
     compare: true
   }
 };

--- a/src/viewers/PictureInPictureViewer.js
+++ b/src/viewers/PictureInPictureViewer.js
@@ -8,10 +8,7 @@ import {
   OVERVIEW_VIEW_ID
 } from '../views';
 import useGlobalSelection from './global-selection-hook';
-import {
-  GLOBAL_SLIDER_DIMENSION_FIELDS,
-  INTERPOLATION_MODES
-} from '../constants';
+import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
 
 /**
  * This component provides a component for an overview-detail VivViewer of an image (i.e picture-in-picture).
@@ -45,8 +42,6 @@ import {
  * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition when making a new selection: Default: ['t', 'z'].
- * @param {Number} [props.interpolation] The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter).
- * Default is null which indicates an "auto" setting where the highest reoslution is NEREAST and all else is LINEAR.  Otherwise, for non-multiscale, the setting is NEAREST.
  * @param {function} [props.onViewportLoad] Function that gets called when the data in the viewport loads.
  */
 
@@ -74,8 +69,6 @@ const PictureInPictureViewer = props => {
     onViewStateChange,
     onHover,
     transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS,
-    // For ImageLayer, we want NEAREST
-    interpolation = loader?.length > 1 ? null : INTERPOLATION_MODES.NEAREST,
     onViewportLoad
   } = props;
   const {
@@ -113,8 +106,7 @@ const PictureInPictureViewer = props => {
     lensRadius,
     lensBorderColor,
     lensBorderRadius,
-    transparentColor,
-    interpolation
+    transparentColor
   };
   const views = [detailView];
   const layerProps = [layerConfig];

--- a/src/viewers/SideBySideViewer.js
+++ b/src/viewers/SideBySideViewer.js
@@ -2,10 +2,7 @@ import React, { useMemo } from 'react'; // eslint-disable-line import/no-unresol
 import VivViewer from './VivViewer';
 import { SideBySideView, getDefaultInitialViewState } from '../views';
 import useGlobalSelection from './global-selection-hook';
-import {
-  GLOBAL_SLIDER_DIMENSION_FIELDS,
-  INTERPOLATION_MODES
-} from '../constants';
+import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
 
 /**
  * This component provides a side-by-side VivViewer with linked zoom/pan.
@@ -35,8 +32,6 @@ import {
  * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition: Default: ['t', 'z'].
- * @param {Number} [props.interpolation] The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter).
- * Default is null which indicates an "auto" setting where the highest reoslution is NEREAST and all else is LINEAR.  Otherwise, for non-multiscale, the setting is NEAREST.
  */
 const SideBySideViewer = props => {
   const {
@@ -60,8 +55,6 @@ const SideBySideViewer = props => {
     onViewStateChange,
     onHover,
     transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS,
-    // For ImageLayer, we want NEAREST
-    interpolation = loader?.length > 1 ? null : INTERPOLATION_MODES.NEAREST,
     onViewportLoad
   } = props;
   const {
@@ -120,8 +113,7 @@ const SideBySideViewer = props => {
     lensRadius,
     lensBorderColor,
     lensBorderRadius,
-    transparentColor,
-    interpolation
+    transparentColor
   };
   const views = [detailViewRight, detailViewLeft];
   const layerProps = [layerConfig, layerConfig];

--- a/src/viewers/VolumeViewer.js
+++ b/src/viewers/VolumeViewer.js
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'; // eslint-disable-line import/no-unresol
 
 import VivViewer from './VivViewer';
 import { VolumeView, getDefaultInitialViewState } from '../views';
-import { RENDERING_MODES, INTERPOLATION_MODES } from '../constants';
+import { RENDERING_MODES } from '../constants';
 
 /**
  * This component provides a volumetric viewer that provides provides volume-ray-casting.
@@ -27,7 +27,6 @@ import { RENDERING_MODES, INTERPOLATION_MODES } from '../constants';
  * @param {number} props.width Current width of the component.
  * @param {Array.<Object>=} clippingPlanes List of math.gl [Plane](https://math.gl/modules/culling/docs/api-reference/plane) objects.
  * @param {Boolean} [useFixedAxis] Whether or not to fix the axis of the camera (default is true).
- * @param {Number} [props.interpolation] The TEXTURE_MIN_FILTER and TEXTURE_MAG_FILTER for WebGL rendering (see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter) - default is GL.LINEAR
  */
 
 const VolumeViewer = props => {
@@ -50,8 +49,7 @@ const VolumeViewer = props => {
     width: screenWidth,
     viewStates: viewStatesProp,
     clippingPlanes = [],
-    useFixedAxis = true,
-    interpolation = INTERPOLATION_MODES.LINEAR
+    useFixedAxis = true
   } = props;
   const volumeViewState = viewStatesProp?.find(state => state?.id === '3d');
   const initialViewState = useMemo(() => {
@@ -93,8 +91,7 @@ const VolumeViewer = props => {
     modelMatrix,
     // Slightly delay to avoid issues with a render in the middle of a deck.gl layer state update.
     onViewportLoad: () => setTimeout(onViewportLoad, 0),
-    clippingPlanes,
-    interpolation
+    clippingPlanes
   };
   const views = [volumeView];
   const layerProps = [layerConfig];


### PR DESCRIPTION
Following up on #448 and #447 this removes the `interpolation` prop from publicly documented API's and only leaves it in the deck.gl props where necessary for the `MultiscaleImageLayer`.  I can just merge this if you'd rather see the full comaprison.