### PR TITLE
Make sure loading message reappears if the resolution changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Make sure loading message reappears if the resolution changes.
+
 ## 0.10.2
 
 ### Added

--- a/src/layers/VolumeLayer/VolumeLayer.js
+++ b/src/layers/VolumeLayer/VolumeLayer.js
@@ -69,6 +69,19 @@ const defaultProps = {
  * @ignore
  */
 const VolumeLayer = class extends CompositeLayer {
+  clearState() {
+    this.setState({
+      height: null,
+      width: null,
+      depth: null,
+      data: null,
+      physicalSizeScalingMatrix: null,
+      resolutionMatrix: null,
+      progress: 0,
+      abortController: null
+    });
+  }
+
   finalizeState() {
     this.state.abortController.abort();
   }
@@ -85,7 +98,7 @@ const VolumeLayer = class extends CompositeLayer {
     // Only fetch new data to render if loader has changed
     if (resolutionChanged) {
       // Clear last volume.
-      this.setState({});
+      this.clearState();
     }
     if (loaderChanged || loaderSelectionChanged || resolutionChanged) {
       const {

--- a/src/layers/VolumeLayer/VolumeLayer.js
+++ b/src/layers/VolumeLayer/VolumeLayer.js
@@ -83,6 +83,10 @@ const VolumeLayer = class extends CompositeLayer {
     const loaderSelectionChanged =
       props.loaderSelection !== oldProps.loaderSelection;
     // Only fetch new data to render if loader has changed
+    if (resolutionChanged) {
+      // Clear last volume.
+      this.setState({});
+    }
     if (loaderChanged || loaderSelectionChanged || resolutionChanged) {
       const {
         loader,


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
From the vitessce meeting.  This PR ensures the loading message re-appears after the resolution changes.

#### Change List
- Reset `VolumeLayer` state if resolution changes.

#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
