### PR TITLE
Add in-layer warning about WebGL1 to `VolumeLayer`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Add in-layer warning about WebGL1 to `VolumeLayer`.
+
 ### Changed
 
 ## 0.10.2

--- a/src/layers/VolumeLayer/VolumeLayer.js
+++ b/src/layers/VolumeLayer/VolumeLayer.js
@@ -1,12 +1,11 @@
 import { CompositeLayer, COORDINATE_SYSTEM } from '@deck.gl/core';
 import GL from '@luma.gl/constants';
 import { isWebGL2 } from '@luma.gl/core';
-import { TextLayer } from '@deck.gl/layers';
 import { Matrix4 } from 'math.gl';
 import XR3DLayer from '../XR3DLayer';
 import { getPhysicalSizeScalingMatrix } from '../utils';
 import { RENDERING_MODES } from '../../constants';
-import { getVolume } from './utils';
+import { getVolume, getTextLayer } from './utils';
 
 const defaultProps = {
   pickable: false,
@@ -163,47 +162,24 @@ const VolumeLayer = class extends CompositeLayer {
     const { gl } = this.context;
     if (!isWebGL2(gl) && useWebGL1Warning) {
       const { viewport } = this.context;
-      return new TextLayer({
-        id: `loading-text-layer-${id}`,
-        coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
-        data: [
-          {
-            text: [
-              'Volume rendering is only available on browsers that support WebGL2. If you',
-              'are using Safari, you can turn on WebGL2 by navigating in the top menubar',
-              'to check Develop > Experimental Features > WebGL 2.0 and then refreshing',
-              'the page.'
-            ].join('\n'),
-            position: viewport.position
-          }
-        ],
-        getColor: [220, 220, 220, 255],
-        getSize: 25,
-        sizeUnits: 'meters',
-        sizeScale: 2 ** -viewport.zoom,
-        fontFamily: 'Helvetica'
-      });
+      return getTextLayer(
+        [
+          'Volume rendering is only available on browsers that support WebGL2. If you',
+          'are using Safari, you can turn on WebGL2 by navigating in the top menubar',
+          'to check Develop > Experimental Features > WebGL 2.0 and then refreshing',
+          'the page.'
+        ].join('\n'),
+        viewport,
+        id
+      );
     }
     if (!(width && height) && useProgressIndicator) {
       const { viewport } = this.context;
-      return new TextLayer({
-        id: `loading-text-layer-${id}`,
-        coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
-        data: [
-          {
-            text: `Loading Volume ${String((progress || 0) * 100).slice(
-              0,
-              5
-            )}%...`,
-            position: viewport.position
-          }
-        ],
-        getColor: [220, 220, 220, 255],
-        getSize: 25,
-        sizeUnits: 'meters',
-        sizeScale: 2 ** -viewport.zoom,
-        fontFamily: 'Helvetica'
-      });
+      return getTextLayer(
+        `Loading Volume ${String((progress || 0) * 100).slice(0, 5)}%...`,
+        viewport,
+        id
+      );
     }
     return new XR3DLayer(this.props, {
       channelData: { data, width, height, depth },

--- a/src/layers/VolumeLayer/utils.js
+++ b/src/layers/VolumeLayer/utils.js
@@ -1,3 +1,5 @@
+import { COORDINATE_SYSTEM } from '@deck.gl/core';
+import { TextLayer } from '@deck.gl/layers';
 import { getImageSize } from '../../loaders/utils';
 
 /**
@@ -62,3 +64,21 @@ export async function getVolume({
     depth: depthDownsampled
   };
 }
+
+export const getTextLayer = (text, viewport, id) => {
+  return new TextLayer({
+    id: `webgl1-warning-layer-${id}`,
+    coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+    data: [
+      {
+        text,
+        position: viewport.position
+      }
+    ],
+    getColor: [220, 220, 220, 255],
+    getSize: 25,
+    sizeUnits: 'meters',
+    sizeScale: 2 ** -viewport.zoom,
+    fontFamily: 'Helvetica'
+  });
+};

--- a/src/layers/VolumeLayer/utils.js
+++ b/src/layers/VolumeLayer/utils.js
@@ -67,7 +67,7 @@ export async function getVolume({
 
 export const getTextLayer = (text, viewport, id) => {
   return new TextLayer({
-    id: `webgl1-warning-layer-${id}`,
+    id: `text-${id}`,
     coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
     data: [
       {


### PR DESCRIPTION
#### Background
Mentioned during the Vitessce meeting, would be good to have a standard warning available for WebGL1.
#### Change List
- Add warning and `useWebGL1Warning` prop to `VolumeLayer`
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
