### PR TITLE
`guessTileSize` for OME-TIFF loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Make OME-TIFF loader use a `guessTileSize` function just like the zarr loaders in order to handle pyramids that are not tiled, just downsampled.
+
 ## 0.10.3
 
 ### Added

--- a/src/loaders/tiff/lib/utils.ts
+++ b/src/loaders/tiff/lib/utils.ts
@@ -1,6 +1,6 @@
+import type { GeoTIFFImage } from 'geotiff';
 import { getDims, getLabels, prevPowerOf2 } from '../../utils';
 import type { OMEXML, UnitsLength } from '../../omexml';
-import { GeoTIFFImage } from 'geotiff';
 
 const DTYPE_LOOKUP = {
   uint8: 'Uint8',

--- a/src/loaders/tiff/lib/utils.ts
+++ b/src/loaders/tiff/lib/utils.ts
@@ -1,5 +1,6 @@
-import { getDims, getLabels } from '../../utils';
+import { getDims, getLabels, prevPowerOf2 } from '../../utils';
 import type { OMEXML, UnitsLength } from '../../omexml';
+import { GeoTIFFImage } from 'geotiff';
 
 const DTYPE_LOOKUP = {
   uint8: 'Uint8',
@@ -67,4 +68,12 @@ export function getOmePixelSourceMeta({ Pixels }: OMEXML[0]) {
   }
 
   return { labels, getShape, dtype };
+}
+
+export function guessTileSize(image: GeoTIFFImage) {
+  const tileWidth = image.getTileWidth();
+  const tileHeight = image.getTileHeight();
+  const size = Math.min(tileWidth, tileHeight);
+  // deck.gl requirement for power-of-two tile size.
+  return prevPowerOf2(size);
 }

--- a/src/loaders/tiff/ome-tiff.ts
+++ b/src/loaders/tiff/ome-tiff.ts
@@ -7,7 +7,7 @@ import {
   getOmeSubIFDIndexer,
   OmeTiffIndexer
 } from './lib/indexers';
-import { getOmePixelSourceMeta } from './lib/utils';
+import { getOmePixelSourceMeta, guessTileSize } from './lib/utils';
 
 export interface OmeTiffSelection {
   t: number;
@@ -47,7 +47,7 @@ export async function load(tiff: GeoTIFF) {
   const { labels, getShape, physicalSizes, dtype } = getOmePixelSourceMeta(
     imgMeta
   );
-  const tileSize = firstImage.getTileWidth();
+  const tileSize = guessTileSize(firstImage);
   const meta = { photometricInterpretation, physicalSizes };
 
   const data = Array.from({ length: levels }).map((_, resolution) => {

--- a/src/loaders/utils.ts
+++ b/src/loaders/utils.ts
@@ -162,4 +162,8 @@ export function getImageSize<T extends string[]>(source: PixelSource<T>) {
   return { height, width };
 }
 
+export function prevPowerOf2(x: number) {
+  return 2 ** Math.floor(Math.log2(x));
+}
+
 export const SIGNAL_ABORTED = '__vivSignalAborted';

--- a/src/loaders/zarr/lib/utils.ts
+++ b/src/loaders/zarr/lib/utils.ts
@@ -1,7 +1,7 @@
 import { openGroup } from 'zarr';
 import type { ZarrArray } from 'zarr';
 import type { OMEXML } from '../../omexml';
-import { getLabels, isInterleaved } from '../../utils';
+import { getLabels, isInterleaved, prevPowerOf2 } from '../../utils';
 
 import type { RootAttrs } from '../ome-zarr';
 
@@ -84,10 +84,6 @@ export async function loadMultiscales(store: ZarrArray['store'], path = '') {
     data: (await Promise.all(data)) as ZarrArray[],
     rootAttrs
   };
-}
-
-function prevPowerOf2(x: number) {
-  return 2 ** Math.floor(Math.log2(x));
 }
 
 export function guessTileSize(arr: ZarrArray) {


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #384
#### Change List
- Add ` guessTileSize` checker for TIFF pyramids
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
