### PR TITLE
Remove usage of `changeFlags` for `updateState` prop diffing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Don't use `changeFlags` for `updateState` prop diffing.
+
 ## 0.10.3
 
 ### Added

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -92,10 +92,8 @@ const ImageLayer = class extends CompositeLayer {
     this.state.abortController.abort();
   }
 
-  updateState({ changeFlags, props, oldProps }) {
-    const { propsChanged } = changeFlags;
-    const loaderChanged =
-      typeof propsChanged === 'string' && propsChanged.includes('props.loader');
+  updateState({ props, oldProps }) {
+    const loaderChanged = props.loader !== oldProps.loader;
     const loaderSelectionChanged =
       props.loaderSelection !== oldProps.loaderSelection;
 

--- a/src/layers/VolumeLayer/VolumeLayer.js
+++ b/src/layers/VolumeLayer/VolumeLayer.js
@@ -88,13 +88,9 @@ const VolumeLayer = class extends CompositeLayer {
     this.state.abortController.abort();
   }
 
-  updateState({ changeFlags, oldProps, props }) {
-    const { propsChanged } = changeFlags;
-    const loaderChanged =
-      typeof propsChanged === 'string' && propsChanged.includes('props.loader');
-    const resolutionChanged =
-      typeof propsChanged === 'string' &&
-      propsChanged.includes('props.resolution');
+  updateState({ oldProps, props }) {
+    const loaderChanged = props.loader !== oldProps.loader;
+    const resolutionChanged = props.resolution !== oldProps.resolution;
     const loaderSelectionChanged =
       props.loaderSelection !== oldProps.loaderSelection;
     // Only fetch new data to render if loader has changed


### PR DESCRIPTION
#### Background
If more than one prop changes at a time, our current prop diffing mechanism only picks up one of the diffs.
#### Change List
- Don't use `changeFlags` for `updateState` prop diffing.
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
