### PR TITLE
Restore decoder pool behavior; add `Pool` to `TiffPixelSource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Make OME-TIFF loader use a `guessTileSize` function just like the zarr loaders in order to handle pyramids that are not tiled, just downsampled.
 - Don't use `changeFlags` for `updateState` prop diffing.
+- Fix broken decoder Pool. Remove pool proxy.
 
 ## 0.10.3
 

--- a/src/loaders/tiff/index.ts
+++ b/src/loaders/tiff/index.ts
@@ -2,7 +2,6 @@ import { fromUrl, fromBlob } from 'geotiff';
 import type { GeoTIFF } from 'geotiff';
 
 import {
-  createPoolProxy,
   createOffsetsProxy,
   checkProxies
 } from './lib/proxies';
@@ -41,14 +40,6 @@ export async function loadOmeTiff(
     tiff = await fromBlob(source);
   }
 
-  if (pool) {
-    /*
-     * Creates a worker pool to decode tiff tiles. Wraps tiff
-     * in a Proxy that injects 'pool' into `tiff.readRasters`.
-     */
-    tiff = createPoolProxy(tiff, new Pool());
-  }
-
   if (offsets) {
     /*
      * Performance enhancement. If offsets are provided, we
@@ -64,5 +55,5 @@ export async function loadOmeTiff(
    */
   checkProxies(tiff);
 
-  return load(tiff);
+  return pool ? load(tiff, new Pool()) : load(tiff);
 }

--- a/src/loaders/tiff/index.ts
+++ b/src/loaders/tiff/index.ts
@@ -1,10 +1,7 @@
 import { fromUrl, fromBlob } from 'geotiff';
 import type { GeoTIFF } from 'geotiff';
 
-import {
-  createOffsetsProxy,
-  checkProxies
-} from './lib/proxies';
+import { createOffsetsProxy, checkProxies } from './lib/proxies';
 import Pool from './lib/Pool';
 
 import { load } from './ome-tiff';

--- a/src/loaders/tiff/lib/Pool.ts
+++ b/src/loaders/tiff/lib/Pool.ts
@@ -48,7 +48,7 @@ export default class Pool {
       currentWorker.onmessage = event => {
         // this.workers.push(currentWorker);
         this.finishTask(currentWorker);
-        resolve(event.data[0]);
+        resolve(event.data);
       };
       currentWorker.onerror = error => {
         // this.workers.push(currentWorker);

--- a/src/loaders/tiff/ome-tiff.ts
+++ b/src/loaders/tiff/ome-tiff.ts
@@ -61,7 +61,7 @@ export async function load(tiff: GeoTIFF, pool?: Pool) {
       shape,
       labels,
       meta,
-      pool,
+      pool
     );
     return source;
   });

--- a/src/loaders/tiff/ome-tiff.ts
+++ b/src/loaders/tiff/ome-tiff.ts
@@ -8,6 +8,7 @@ import {
   OmeTiffIndexer
 } from './lib/indexers';
 import { getOmePixelSourceMeta, guessTileSize } from './lib/utils';
+import type Pool from './lib/Pool';
 
 export interface OmeTiffSelection {
   t: number;
@@ -15,7 +16,7 @@ export interface OmeTiffSelection {
   z: number;
 }
 
-export async function load(tiff: GeoTIFF) {
+export async function load(tiff: GeoTIFF, pool?: Pool) {
   // Get first image from tiff and inspect OME-XML metadata
   const firstImage = await tiff.getImage(0);
   const {
@@ -59,7 +60,8 @@ export async function load(tiff: GeoTIFF) {
       tileSize,
       shape,
       labels,
-      meta
+      meta,
+      pool,
     );
     return source;
   });

--- a/src/loaders/tiff/pixel-source.ts
+++ b/src/loaders/tiff/pixel-source.ts
@@ -2,6 +2,7 @@ import type { GeoTIFFImage, RasterOptions } from 'geotiff';
 import type { TypedArray } from 'zarr';
 import { getImageSize, isInterleaved, SIGNAL_ABORTED } from '../utils';
 
+import type Pool from './lib/Pool';
 import type {
   PixelSource,
   PixelSourceSelection,
@@ -22,7 +23,8 @@ class TiffPixelSource<S extends string[]> implements PixelSource<S> {
     public tileSize: number,
     public shape: number[],
     public labels: Labels<S>,
-    public meta?: PixelSourceMeta
+    public meta?: PixelSourceMeta,
+    public pool?: Pool,
   ) {
     this._indexer = indexer;
   }
@@ -44,7 +46,7 @@ class TiffPixelSource<S extends string[]> implements PixelSource<S> {
 
   private async _readRasters(image: GeoTIFFImage, props?: RasterOptions) {
     const interleave = isInterleaved(this.shape);
-    const raster = await image.readRasters({ interleave, ...props });
+    const raster = await image.readRasters({ interleave, ...props, pool: this.pool });
 
     if (props?.signal?.aborted) {
       throw SIGNAL_ABORTED;

--- a/src/loaders/tiff/pixel-source.ts
+++ b/src/loaders/tiff/pixel-source.ts
@@ -24,7 +24,7 @@ class TiffPixelSource<S extends string[]> implements PixelSource<S> {
     public shape: number[],
     public labels: Labels<S>,
     public meta?: PixelSourceMeta,
-    public pool?: Pool,
+    public pool?: Pool
   ) {
     this._indexer = indexer;
   }
@@ -46,7 +46,11 @@ class TiffPixelSource<S extends string[]> implements PixelSource<S> {
 
   private async _readRasters(image: GeoTIFFImage, props?: RasterOptions) {
     const interleave = isInterleaved(this.shape);
-    const raster = await image.readRasters({ interleave, ...props, pool: this.pool });
+    const raster = await image.readRasters({
+      interleave,
+      ...props,
+      pool: this.pool
+    });
 
     if (props?.signal?.aborted) {
       throw SIGNAL_ABORTED;

--- a/tests/loaders/tiff-lib.spec.js
+++ b/tests/loaders/tiff-lib.spec.js
@@ -1,45 +1,18 @@
 import { test } from 'tape';
 import { fromFile } from 'geotiff';
-import { getDecoder } from 'geotiff/src/compression';
 
-import {
-  createPoolProxy,
-  createOffsetsProxy
-} from '../../src/loaders/tiff/lib/proxies';
-
-/*
- * rollup-plugin-web-worker-loader relies on `atob` which isn't in Node.
- * This is a shim for "Pool" for testing the proxies.
- */
-const pool = {
-  async decode(fileDirectory, buffer) {
-    const decoder = getDecoder(fileDirectory);
-    const result = await decoder.decode(fileDirectory, buffer);
-    return result;
-  }
-};
+import { createOffsetsProxy } from '../../src/loaders/tiff/lib/proxies';
 
 test('Inspect tiff proxies.', async t => {
-  t.plan(6);
+  t.plan(2);
   try {
     let tiff = await fromFile('tests/loaders/fixtures/multi-channel.ome.tif');
-    t.equal(
-      tiff['__viv-decoder-pool'],
-      undefined,
-      'Regular tiff should not have any proxies.'
-    );
     t.equal(
       tiff['__viv-offsets'],
       undefined,
       'Regular tiff should not have any proxies.'
     );
-
-    tiff = createPoolProxy(tiff, pool);
-    t.equal(tiff['__viv-decoder-pool'], true, 'Should have pool proxy.');
-    t.equal(tiff['__viv-offsets'], undefined, 'Should not have offsets proxy.');
-
     tiff = createOffsetsProxy(tiff, []);
-    t.equal(tiff['__viv-decoder-pool'], true, 'Should have pool proxy.');
     t.equal(tiff['__viv-offsets'], true, 'Should have both proxies.');
   } catch (e) {
     t.fail(e);


### PR DESCRIPTION
This is my mistake. The proxies are applied to the `GeoTIFF` source, and `readRasters` is a method on the _derived_ `GeoTIFFImage` object, so the proxied method with the decoder pool is never called.

It would be nice if you could configure a pool as an option on the _source_ `GeoTIFF` object, rather than needing to pass the `pool` and `tiff` around in unison. I tried to get this working with Proxies, but ran into a bit of a wall sadly. 

The fix is just to add `pool` as an optional constructor argument on the `TiffPixelSource`. 

Another option would be to wrap the return of a `pyramidIndexer` with a proxy, but this seems a bit overly complicated...

```javascript
 let pyramidIndexer: OmeTiffIndexer;

  if (SubIFDs) {
    // Image is >= Bioformats 6.0 and resolutions are stored using SubIFDs.
    levels = SubIFDs.length + 1;
    pyramidIndexer = getOmeSubIFDIndexer(tiff, omexml);
  } else {
    // Image is legacy format; resolutions are stored as separate images.
    levels = omexml.length;
    pyramidIndexer = getOmeLegacyIndexer(tiff, omexml);
  }

if (pool) {
  pyramidIndexer = wrapIndexer(pyramidIndexer, pool);
}
```