### PR TITLE
Add Expansion Button for Non-Interleaved RGB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Expansion button for non-interleaved RGB datasets that might be fluorescence.
+
 ### Changed
 
 ## 0.10.5

--- a/avivator/src/components/Controller/Controller.jsx
+++ b/avivator/src/components/Controller/Controller.jsx
@@ -4,6 +4,8 @@ import Grid from '@material-ui/core/Grid';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import Divider from '@material-ui/core/Divider';
+import UnfoldMoreIcon from '@material-ui/icons/UnfoldMore';
+import Button from '@material-ui/core/Button';
 
 import ChannelController from './components/ChannelController';
 import Menu from './components/Menu';
@@ -25,7 +27,12 @@ import {
   useImageSettingsStore,
   useChannelSetters
 } from '../../state';
-import { guessRgb, useWindowSize, getSingleSelectionStats } from '../../utils';
+import {
+  guessRgb,
+  useWindowSize,
+  getSingleSelectionStats,
+  isInterleaved
+} from '../../utils';
 import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../../constants';
 
 function TabPanel(props) {
@@ -75,6 +82,7 @@ const Controller = () => {
     isViewerLoading
   } = useViewerStore();
   const viewSize = useWindowSize();
+  const [areChannelsUnfolded, handleUnfoldChannels] = useState(false);
   const isRgb = metadata && guessRgb(metadata);
   const { shape, labels } = loader[0];
   const globalControlLabels = labels.filter(label =>
@@ -168,11 +176,22 @@ const Controller = () => {
           />
         )}
         {!use3d && globalControllers}
-        {!isViewerLoading && !isRgb ? (
+        {!isViewerLoading && (!isRgb || areChannelsUnfolded) ? (
           <Grid container>{channelControllers}</Grid>
         ) : (
           <Grid container justify="center">
-            {!isRgb && <CircularProgress />}
+            {!isRgb ? (
+              <CircularProgress />
+            ) : (
+              !isInterleaved(loader[0].shape) && (
+                <Button
+                  onClick={() => handleUnfoldChannels(true)}
+                  fullWidth
+                  startIcon={<UnfoldMoreIcon />}
+                  size="small"
+                />
+              )
+            )}
           </Grid>
         )}
         {!isRgb && <AddChannel />}


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #474.
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Add a expansion button for showing the channel settings when detected as RGB but not interleaved

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
