### PR TITLE
[WIP] - Migrate off geotiff.js fork

### DIFF
--- a/avivator/empty-fs.js
+++ b/avivator/empty-fs.js
@@ -1,3 +1,0 @@
-export const close = '';
-export const open = '';
-export const read = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -2363,6 +2363,15 @@
         "gl-matrix": "^3.0.0"
       }
     },
+    "@petamoriken/float16": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
+      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
+      "requires": {
+        "lodash": ">=4.17.5 <5.0.0",
+        "lodash-es": ">=4.17.5 <5.0.0"
+      }
+    },
     "@probe.gl/stats": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.3.0.tgz",
@@ -2909,6 +2918,11 @@
         }
       }
     },
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -3374,8 +3388,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -3520,7 +3533,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3530,7 +3542,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -4136,6 +4147,11 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "dev": true
     },
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -4273,7 +4289,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -4281,8 +4296,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colorbrewer": {
       "version": "1.0.0",
@@ -4348,8 +4362,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -4435,6 +4448,11 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
+    },
+    "content-type-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
     },
     "continuable-cache": {
       "version": "0.3.1",
@@ -6585,8 +6603,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.3",
@@ -7412,7 +7429,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -7424,6 +7440,30 @@
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
+      }
+    },
+    "find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "requires": {
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+        }
       }
     },
     "flat-cache": {
@@ -7675,8 +7715,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.1.3",
@@ -7720,11 +7759,15 @@
       "dev": true
     },
     "geotiff": {
-      "version": "github:ilan-gold/geotiff.js#bbd334f2af6adb7f546b3f36a77963d6597082f3",
-      "from": "github:ilan-gold/geotiff.js#ilan-gold/viv_094",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.4.tgz",
+      "integrity": "sha512-JmtpvVHlxvyrWgT6Uf0sy7flmXhjWtG0cqVv+G9fMcupV4DAPdTv7tkhsoMnn9RpIIwolveB/VnyII8cRMOD7A==",
       "requires": {
-        "lzw-tiff-decoder": "^0.1.0",
+        "@petamoriken/float16": "^1.0.7",
+        "content-type-parser": "^1.0.2",
+        "lru-cache": "^6.0.0",
         "pako": "^1.0.11",
+        "parse-headers": "^2.0.2",
         "threads": "^1.3.1",
         "txml": "^3.1.2"
       }
@@ -8146,7 +8189,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -8638,8 +8680,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "h3-js": {
       "version": "3.7.1",
@@ -9170,7 +9211,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -9376,6 +9416,14 @@
       "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
     },
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "requires": {
+        "ci-info": "^2.0.0"
+      }
+    },
     "is-core-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
@@ -9435,6 +9483,11 @@
           "dev": true
         }
       }
+    },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -9511,8 +9564,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-object": {
       "version": "1.0.4",
@@ -9672,6 +9724,14 @@
       "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
       "dev": true
     },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -9681,8 +9741,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -9785,7 +9844,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -9832,6 +9890,14 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
+    },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
     },
     "labeled-stream-splicer": {
       "version": "2.0.2",
@@ -9963,8 +10029,12 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -10044,7 +10114,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -10606,7 +10675,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -10614,8 +10682,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -10840,6 +10907,11 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-abi": {
       "version": "2.19.1",
@@ -11135,9 +11207,9 @@
       }
     },
     "observable-fns": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.5.1.tgz",
-      "integrity": "sha512-wf7g4Jpo1Wt2KIqZKLGeiuLOEMqpaOZ5gJn7DmSdqXgTdxRwSdBhWegQQpPteQ2gZvzCKqNNpwb853wcpA0j7A=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -11152,9 +11224,17 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
       }
     },
     "optimist": {
@@ -11241,6 +11321,11 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -11361,6 +11446,11 @@
       "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
       "dev": true
     },
+    "parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -11422,6 +11512,107 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
+    "patch-package": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
+      "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.0",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -11443,8 +11634,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -12494,7 +12684,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -12610,8 +12799,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -12776,6 +12964,11 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -14163,14 +14356,14 @@
       }
     },
     "threads": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.4.tgz",
-      "integrity": "sha512-A+9MQFAUha9W8MjIPmrvETy98qVmZFr5Unox9D95y7kvz3fBpGiFS7JOZs07B2KvTHoRNI5MrGudRVeCmv4Alw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
+      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
       "requires": {
         "callsites": "^3.1.0",
         "debug": "^4.2.0",
         "is-observable": "^2.1.0",
-        "observable-fns": "^0.5.1",
+        "observable-fns": "^0.6.1",
         "tiny-worker": ">= 2"
       }
     },
@@ -14302,6 +14495,14 @@
         "esm": "^3.2.25"
       }
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
@@ -14360,7 +14561,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -14829,8 +15029,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -15431,8 +15630,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -15491,8 +15689,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,10 @@
     "@math.gl/culling": "^3.4.2",
     "fast-deep-equal": "^3.1.3",
     "fast-xml-parser": "^3.16.0",
-    "geotiff": "ilan-gold/geotiff.js#ilan-gold/viv_094",
+    "geotiff": "^1.0.4",
+    "lzw-tiff-decoder": "^0.1.1",
     "math.gl": "^3.3.0",
+    "patch-package": "^6.4.7",
     "quickselect": "^2.0.0",
     "zarr": "^0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "format:write": "npm run format -- --write",
     "version": "./version.sh",
     "postversion": "git push && git push --tags",
+    "postinstall": "patch-package",
     "docs": "mkdir -p dist_docs || rm -r dist_docs && mkdir -p dist_docs && documentation build dist/viv.es.js -f html --document-exported --config documentation.yml --shallow -o dist_docs"
   },
   "repository": {

--- a/patches/geotiff+1.0.4.patch
+++ b/patches/geotiff+1.0.4.patch
@@ -161,6 +161,37 @@ index 7179948..8b27399 100644
 +    return decoded.buffer;
    }
  }
+diff --git a/node_modules/geotiff/src/source/blockedsource.js b/node_modules/geotiff/src/source/blockedsource.js
+index 92569a5..bef45c7 100644
+--- a/node_modules/geotiff/src/source/blockedsource.js
++++ b/node_modules/geotiff/src/source/blockedsource.js
+@@ -1,6 +1,6 @@
+ import LRUCache from 'lru-cache';
+ import { BaseSource } from './basesource';
+-import { AbortError, AggregateError, wait, zip } from '../utils';
++import { AbortError, AggregateError, zip } from '../utils';
+ 
+ class Block {
+   /**
+@@ -101,8 +101,7 @@ export class BlockedSource extends BaseSource {
+     }
+ 
+     // allow additional block requests to accumulate
+-    await wait();
+-    this.fetchBlocks(signal);
++    await this.fetchBlocks(signal);
+ 
+     for (const blockId of missingBlockIds) {
+       const block = this.blockRequests.get(blockId);
+@@ -177,7 +176,7 @@ export class BlockedSource extends BaseSource {
+    *
+    * @param {AbortSignal} signal
+    */
+-  fetchBlocks(signal) {
++  async fetchBlocks(signal) {
+     // check if we still need to
+     if (this.blockIdsToFetch.size > 0) {
+       const groups = this.groupBlocks(this.blockIdsToFetch);
 diff --git a/node_modules/geotiff/src/source/file.js b/node_modules/geotiff/src/source/file.js
 index cc6964c..d95b104 100644
 --- a/node_modules/geotiff/src/source/file.js

--- a/patches/geotiff+1.0.4.patch
+++ b/patches/geotiff+1.0.4.patch
@@ -1,0 +1,163 @@
+diff --git a/node_modules/geotiff/src/compression/index.js b/node_modules/geotiff/src/compression/index.js
+index 4d420ca..1eebd58 100644
+--- a/node_modules/geotiff/src/compression/index.js
++++ b/node_modules/geotiff/src/compression/index.js
+@@ -10,7 +10,7 @@ export function getDecoder(fileDirectory) {
+     case 1: // no compression
+       return new RawDecoder();
+     case 5: // LZW
+-      return new LZWDecoder();
++      return new LZWDecoder(fileDirectory);
+     case 6: // JPEG
+       throw new Error('old style JPEG compression is not supported.');
+     case 7: // JPEG
+diff --git a/node_modules/geotiff/src/compression/lzw.js b/node_modules/geotiff/src/compression/lzw.js
+index 7179948..8b27399 100644
+--- a/node_modules/geotiff/src/compression/lzw.js
++++ b/node_modules/geotiff/src/compression/lzw.js
+@@ -1,132 +1,18 @@
++import { decompress } from 'lzw-tiff-decoder';
+ import BaseDecoder from './basedecoder';
+ 
+-
+-const MIN_BITS = 9;
+-const CLEAR_CODE = 256; // clear code
+-const EOI_CODE = 257; // end of information
+-const MAX_BYTELENGTH = 12;
+-
+-function getByte(array, position, length) {
+-  const d = position % 8;
+-  const a = Math.floor(position / 8);
+-  const de = 8 - d;
+-  const ef = (position + length) - ((a + 1) * 8);
+-  let fg = (8 * (a + 2)) - (position + length);
+-  const dg = ((a + 2) * 8) - position;
+-  fg = Math.max(0, fg);
+-  if (a >= array.length) {
+-    console.warn('ran off the end of the buffer before finding EOI_CODE (end on input code)');
+-    return EOI_CODE;
+-  }
+-  let chunk1 = array[a] & ((2 ** (8 - d)) - 1);
+-  chunk1 <<= (length - de);
+-  let chunks = chunk1;
+-  if (a + 1 < array.length) {
+-    let chunk2 = array[a + 1] >>> fg;
+-    chunk2 <<= Math.max(0, (length - dg));
+-    chunks += chunk2;
+-  }
+-  if (ef > 8 && a + 2 < array.length) {
+-    const hi = ((a + 3) * 8) - (position + length);
+-    const chunk3 = array[a + 2] >>> hi;
+-    chunks += chunk3;
+-  }
+-  return chunks;
+-}
+-
+-function appendReversed(dest, source) {
+-  for (let i = source.length - 1; i >= 0; i--) {
+-    dest.push(source[i]);
+-  }
+-  return dest;
+-}
+-
+-function decompress(input) {
+-  const dictionaryIndex = new Uint16Array(4093);
+-  const dictionaryChar = new Uint8Array(4093);
+-  for (let i = 0; i <= 257; i++) {
+-    dictionaryIndex[i] = 4096;
+-    dictionaryChar[i] = i;
+-  }
+-  let dictionaryLength = 258;
+-  let byteLength = MIN_BITS;
+-  let position = 0;
+-
+-  function initDictionary() {
+-    dictionaryLength = 258;
+-    byteLength = MIN_BITS;
+-  }
+-  function getNext(array) {
+-    const byte = getByte(array, position, byteLength);
+-    position += byteLength;
+-    return byte;
+-  }
+-  function addToDictionary(i, c) {
+-    dictionaryChar[dictionaryLength] = c;
+-    dictionaryIndex[dictionaryLength] = i;
+-    dictionaryLength++;
+-    return dictionaryLength - 1;
+-  }
+-  function getDictionaryReversed(n) {
+-    const rev = [];
+-    for (let i = n; i !== 4096; i = dictionaryIndex[i]) {
+-      rev.push(dictionaryChar[i]);
+-    }
+-    return rev;
+-  }
+-
+-  const result = [];
+-  initDictionary();
+-  const array = new Uint8Array(input);
+-  let code = getNext(array);
+-  let oldCode;
+-  while (code !== EOI_CODE) {
+-    if (code === CLEAR_CODE) {
+-      initDictionary();
+-      code = getNext(array);
+-      while (code === CLEAR_CODE) {
+-        code = getNext(array);
+-      }
+-
+-      if (code === EOI_CODE) {
+-        break;
+-      } else if (code > CLEAR_CODE) {
+-        throw new Error(`corrupted code at scanline ${code}`);
+-      } else {
+-        const val = getDictionaryReversed(code);
+-        appendReversed(result, val);
+-        oldCode = code;
+-      }
+-    } else if (code < dictionaryLength) {
+-      const val = getDictionaryReversed(code);
+-      appendReversed(result, val);
+-      addToDictionary(oldCode, val[val.length - 1]);
+-      oldCode = code;
+-    } else {
+-      const oldVal = getDictionaryReversed(oldCode);
+-      if (!oldVal) {
+-        throw new Error(`Bogus entry. Not in dictionary, ${oldCode} / ${dictionaryLength}, position: ${position}`);
+-      }
+-      appendReversed(result, oldVal);
+-      result.push(oldVal[oldVal.length - 1]);
+-      addToDictionary(oldCode, oldVal[oldVal.length - 1]);
+-      oldCode = code;
+-    }
+-
+-    if (dictionaryLength + 1 >= (2 ** byteLength)) {
+-      if (byteLength === MAX_BYTELENGTH) {
+-        oldCode = undefined;
+-      } else {
+-        byteLength++;
+-      }
+-    }
+-    code = getNext(array);
+-  }
+-  return new Uint8Array(result);
+-}
+-
+ export default class LZWDecoder extends BaseDecoder {
+-  decodeBlock(buffer) {
+-    return decompress(buffer, false).buffer;
++  constructor(fileDirectory) {
++    super();
++    const width = fileDirectory.TileWidth || fileDirectory.ImageWidth;
++    const height = fileDirectory.TileLength || fileDirectory.ImageLength;
++    const nbytes = fileDirectory.BitsPerSample[0] / 8;
++    this.maxUncompressedSize = width * height * nbytes;
++  }
++
++  async decodeBlock(buffer) {
++    const bytes = new Uint8Array(buffer);
++    const decoded = await decompress(bytes, this.maxUncompressedSize);
++    return decoded.buffer;
+   }
+ }

--- a/patches/geotiff+1.0.4.patch
+++ b/patches/geotiff+1.0.4.patch
@@ -161,3 +161,37 @@ index 7179948..8b27399 100644
 +    return decoded.buffer;
    }
  }
+diff --git a/node_modules/geotiff/src/source/file.js b/node_modules/geotiff/src/source/file.js
+index cc6964c..d95b104 100644
+--- a/node_modules/geotiff/src/source/file.js
++++ b/node_modules/geotiff/src/source/file.js
+@@ -1,9 +1,9 @@
+-import { read, open, close } from 'fs';
++import * as fs from 'fs';
+ import { BaseSource } from './basesource';
+ 
+ function closeAsync(fd) {
+   return new Promise((resolve, reject) => {
+-    close(fd, (err) => {
++    fs.close(fd, (err) => {
+       if (err) {
+         reject(err);
+       } else {
+@@ -15,7 +15,7 @@ function closeAsync(fd) {
+ 
+ function openAsync(path, flags, mode = undefined) {
+   return new Promise((resolve, reject) => {
+-    open(path, flags, mode, (err, fd) => {
++    fs.open(path, flags, mode, (err, fd) => {
+       if (err) {
+         reject(err);
+       } else {
+@@ -27,7 +27,7 @@ function openAsync(path, flags, mode = undefined) {
+ 
+ function readAsync(...args) {
+   return new Promise((resolve, reject) => {
+-    read(...args, (err, bytesRead, buffer) => {
++    fs.read(...args, (err, bytesRead, buffer) => {
+       if (err) {
+         reject(err);
+       } else {

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -4,7 +4,7 @@ import GL from '@luma.gl/constants';
 import XRLayer from './XRLayer';
 import BitmapLayer from './BitmapLayer';
 import { onPointer } from './utils';
-import { isInterleaved, SIGNAL_ABORTED } from '../loaders/utils';
+import { isInterleaved } from '../loaders/utils';
 
 const defaultProps = {
   pickable: { type: 'boolean', value: true, compare: true },
@@ -131,8 +131,8 @@ const ImageLayer = class extends CompositeLayer {
           this.setState({ ...raster });
         })
         .catch(e => {
-          if (e !== SIGNAL_ABORTED) {
-            throw e; // re-throws error if not our signal
+          if (e.name !== 'AbortError') {
+            throw e; // re-throws any non AbortError
           }
         });
     }

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -162,7 +162,7 @@ const MultiscaleImageLayer = class extends CompositeLayer {
          * Signal is aborted. We handle the custom value thrown
          * by our pixel sources here and return falsy to deck.gl.
          */
-        if (err === SIGNAL_ABORTED) {
+        if (err?.name === 'AbortError') {
           return null;
         }
 

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -5,10 +5,7 @@ import GL from '@luma.gl/constants';
 import MultiscaleImageLayerBase from './MultiscaleImageLayerBase';
 import ImageLayer from '../ImageLayer';
 import { onPointer } from '../utils';
-import {
-  getImageSize,
-  isInterleaved,
-} from '../../loaders/utils';
+import { getImageSize, isInterleaved } from '../../loaders/utils';
 
 // From https://github.com/visgl/deck.gl/pull/4616/files#diff-4d6a2e500c0e79e12e562c4f1217dc80R128
 const DECK_GL_TILE_SIZE = 512;
@@ -129,8 +126,8 @@ const MultiscaleImageLayer = class extends CompositeLayer {
 
       try {
         /*
-         * Try to request the tile data. Our pixels sources _always_ 
-         * have the same return type, and optional throw an 
+         * Try to request the tile data. Our pixels sources _always_
+         * have the same return type, and optional throw an
          * 'AbortError' for performance.
          */
         const tiles = await Promise.all(loaderSelection.map(getTile));

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -8,7 +8,6 @@ import { onPointer } from '../utils';
 import {
   getImageSize,
   isInterleaved,
-  SIGNAL_ABORTED
 } from '../../loaders/utils';
 
 // From https://github.com/visgl/deck.gl/pull/4616/files#diff-4d6a2e500c0e79e12e562c4f1217dc80R128
@@ -130,12 +129,9 @@ const MultiscaleImageLayer = class extends CompositeLayer {
 
       try {
         /*
-         * Try to request the tile data. The pixels sources can throw
-         * special SIGNAL_ABORTED string that we pick up in the catch
-         * block to return null to deck.gl.
-         *
-         * This means that our pixels sources _always_ have the same
-         * return type, and optional throw for performance.
+         * Try to request the tile data. Our pixels sources _always_ 
+         * have the same return type, and optional throw an 
+         * 'AbortError' for performance.
          */
         const tiles = await Promise.all(loaderSelection.map(getTile));
 

--- a/src/loaders/tiff/lib/decoder.worker.ts
+++ b/src/loaders/tiff/lib/decoder.worker.ts
@@ -1,5 +1,5 @@
 import type { FileDirectory } from 'geotiff';
-import { getDecoder } from 'geotiff';
+import { getDecoder } from 'geotiff/src/compression';
 
 async function decode(fileDirectory: FileDirectory, buffer: ArrayBuffer) {
   const decoder = getDecoder(fileDirectory);

--- a/src/loaders/tiff/lib/decoder.worker.ts
+++ b/src/loaders/tiff/lib/decoder.worker.ts
@@ -1,5 +1,5 @@
 import type { FileDirectory } from 'geotiff';
-import { getDecoder } from 'geotiff/src/compression';
+import { getDecoder } from 'geotiff';
 
 async function decode(fileDirectory: FileDirectory, buffer: ArrayBuffer) {
   const decoder = getDecoder(fileDirectory);

--- a/src/loaders/tiff/pixel-source.ts
+++ b/src/loaders/tiff/pixel-source.ts
@@ -1,6 +1,6 @@
 import type { GeoTIFFImage, RasterOptions } from 'geotiff';
 import type { TypedArray } from 'zarr';
-import { getImageSize, isInterleaved, SIGNAL_ABORTED } from '../utils';
+import { getImageSize, isInterleaved } from '../utils';
 
 import type Pool from './lib/Pool';
 import type {
@@ -51,10 +51,6 @@ class TiffPixelSource<S extends string[]> implements PixelSource<S> {
       ...props,
       pool: this.pool
     });
-
-    if (props?.signal?.aborted) {
-      throw SIGNAL_ABORTED;
-    }
 
     /*
      * geotiff.js returns objects with different structure

--- a/src/loaders/utils.ts
+++ b/src/loaders/utils.ts
@@ -165,4 +165,3 @@ export function getImageSize<T extends string[]>(source: PixelSource<T>) {
 export function prevPowerOf2(x: number) {
   return 2 ** Math.floor(Math.log2(x));
 }
-

--- a/src/loaders/utils.ts
+++ b/src/loaders/utils.ts
@@ -166,4 +166,3 @@ export function prevPowerOf2(x: number) {
   return 2 ** Math.floor(Math.log2(x));
 }
 
-export const SIGNAL_ABORTED = '__vivSignalAborted';

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,14 +35,12 @@ const bundleWebWorker = () => {
   }
 }
 
-const plugins = [
-  reactRefresh(),
-  glslify(),
-  bundleWebWorker(),
-];
-
 const configAvivator = defineConfig({
-  plugins,
+  plugins: [
+    reactRefresh(),
+    glslify(),
+    bundleWebWorker(),
+  ],
   base: './',
   root: 'avivator',
   publicDir: 'avivator/public',
@@ -52,11 +50,13 @@ const configAvivator = defineConfig({
       'react': resolve(__dirname, 'avivator/node_modules/react'),
       'react-dom': resolve(__dirname, 'avivator/node_modules/react-dom'),
     }
-  }
+  },
 });
 
 const configViv = defineConfig({
-  plugins,
+  plugins: [
+    glslify(),
+  ],
   build: {
     target: 'esnext',
     minify: false,

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,17 +6,15 @@ import reactRefresh from '@vitejs/plugin-react-refresh';
 import glslify from 'rollup-plugin-glslify';
 import esbuild from 'esbuild';
 
-const plugins = [
-  reactRefresh(),
-  glslify(),
-  {
-    /**
-     * Bundles code in `src/loaders/tiff/lib/decoder.worker.ts` into a single file
-     * during _development only_. WebWorker modules are only stable in chromium
-     * browsers, so this is a work-around to allow us to develop in other browsers.
-     * 
-     * see: https://github.com/hms-dbmi/viv/pull/469#issuecomment-877276110
-     */
+/**
+  * Bundles code in `src/loaders/tiff/lib/decoder.worker.ts` into a single file
+  * during _development only_. WebWorker modules are only stable in chromium
+  * browsers, so this is a work-around to allow us to develop in other browsers.
+  *
+  * see: https://github.com/hms-dbmi/viv/pull/469#issuecomment-877276110
+  */
+const bundleWebWorker = () => {
+  return {
     name: 'bundle-web-worker',
     apply: 'serve', // plugin only applied with dev-server
     async transform(_, id) {
@@ -26,7 +24,7 @@ const plugins = [
           entryPoints: [id],
           format: 'esm',
           bundle: true,
-          write: false
+          write: false,
         });
         if (bundle.outputFiles.length !== 1) {
           throw new Error('Worker must be a single module.');
@@ -35,6 +33,12 @@ const plugins = [
       }
     }
   }
+}
+
+const plugins = [
+  reactRefresh(),
+  glslify(),
+  bundleWebWorker(),
 ];
 
 const configAvivator = defineConfig({

--- a/vite.config.js
+++ b/vite.config.js
@@ -47,12 +47,6 @@ const configAvivator = defineConfig({
       '@hms-dbmi/viv': resolve(__dirname, 'src'),
       'react': resolve(__dirname, 'avivator/node_modules/react'),
       'react-dom': resolve(__dirname, 'avivator/node_modules/react-dom'),
-      /**
-       * Geotiff.js uses node-builtins in its source. We don't use these
-       * module exports in our code. Rather than polyfilling these modules,
-       * we use resolve to empty exports.
-       */
-      'fs': resolve(__dirname, 'avivator/empty-fs.js')
     }
   }
 });


### PR DESCRIPTION
Our fork of geotiff has diverged quite a bit from the latest geotiff release. I noticed that many of the features from our branch seem to be implemented (at least in part) on the `master` branch. 

This is an experiment to see if we can move _back_ on the the current release of `geotiff.js` and sprinkle in the changes we need using [`patch-package`](https://www.npmjs.com/package/patch-package). `lzw-tiff-decoder` now becomes a dependency of Viv, since we use it in the patch.