### PR TITLE
Use viv-0.0.1 geotiff release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Upgrade deck.gl to 8.5
+- Update fork of geotiff.js
 
 ## 0.10.5
 

--- a/avivator/empty-fs.js
+++ b/avivator/empty-fs.js
@@ -1,3 +1,0 @@
-export const close = '';
-export const open = '';
-export const read = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8040,8 +8040,8 @@
       "dev": true
     },
     "geotiff": {
-      "version": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.1.tar.gz",
-      "integrity": "sha512-mElaB9eE/ucgMZIKpYuRSAxL79cCHIRxfeiZmNx8CB02HDsSSLgZxNDEBxkvcalCCyeDNzJQiP0dWqAO7HjnsQ==",
+      "version": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.2.tar.gz",
+      "integrity": "sha512-wxoQZWBOK0vMgmWnTiVjj/T7Ia1TVKcYR0LYLZAeCoWNkQ6NJENqjb+G7TndVNWRqCCOXvuC8wbOajt9tIHZ9w==",
       "requires": {
         "@petamoriken/float16": "^1.0.7",
         "content-type-parser": "^1.0.2",
@@ -15012,9 +15012,9 @@
       "dev": true
     },
     "txml": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.0.tgz",
-      "integrity": "sha512-K3BcNWDRmRTTQ4QVMzxrVqtFjovpLAqCuxgKKUOFab9uFiLqo+mPKCfLaKlAiUpeCcu5zp8EohrKTJ0jgzBJJw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
       "requires": {
         "through2": "^3.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2528,6 +2528,15 @@
         "gl-matrix": "^3.0.0"
       }
     },
+    "@petamoriken/float16": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
+      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
+      "requires": {
+        "lodash": ">=4.17.5 <5.0.0",
+        "lodash-es": ">=4.17.5 <5.0.0"
+      }
+    },
     "@probe.gl/stats": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.3.0.tgz",
@@ -4723,6 +4732,11 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
+    },
+    "content-type-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
     },
     "continuable-cache": {
       "version": "0.3.1",
@@ -8026,13 +8040,25 @@
       "dev": true
     },
     "geotiff": {
-      "version": "github:ilan-gold/geotiff.js#bbd334f2af6adb7f546b3f36a77963d6597082f3",
-      "from": "github:ilan-gold/geotiff.js#ilan-gold/viv_094",
+      "version": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.1.tar.gz",
+      "integrity": "sha512-mElaB9eE/ucgMZIKpYuRSAxL79cCHIRxfeiZmNx8CB02HDsSSLgZxNDEBxkvcalCCyeDNzJQiP0dWqAO7HjnsQ==",
       "requires": {
-        "lzw-tiff-decoder": "^0.1.0",
-        "pako": "^1.0.11",
+        "@petamoriken/float16": "^1.0.7",
+        "content-type-parser": "^1.0.2",
+        "lerc": "^2.0.0",
+        "lru-cache": "^6.0.0",
+        "lzw-tiff-decoder": "^0.1.1",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
         "threads": "^1.3.1",
-        "txml": "^3.1.2"
+        "txml": "^5.0.0"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+          "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+        }
       }
     },
     "get-assigned-identifiers": {
@@ -10220,6 +10246,11 @@
         "flush-write-stream": "^1.0.2"
       }
     },
+    "lerc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-2.0.0.tgz",
+      "integrity": "sha512-7qo1Mq8ZNmaR4USHHm615nEW2lPeeWJ3bTyoqFbd35DLx0LUH7C6ptt5FDCTAlbIzs3+WKrk5SkJvw8AFDE2hg=="
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -10275,8 +10306,12 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -10362,7 +10397,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -11687,6 +11721,11 @@
       "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
       "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
       "dev": true
+    },
+    "parse-headers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
+      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
     },
     "parse-json": {
       "version": "2.2.0",
@@ -14973,9 +15012,9 @@
       "dev": true
     },
     "txml": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-3.2.5.tgz",
-      "integrity": "sha512-AtN8AgJLiDanttIXJaQlxH8/R0NOCNwto8kcO7BaxdLgsN9b7itM9lnTD7c2O3TadP+hHB9j7ra5XGFRPNnk/g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.0.tgz",
+      "integrity": "sha512-K3BcNWDRmRTTQ4QVMzxrVqtFjovpLAqCuxgKKUOFab9uFiLqo+mPKCfLaKlAiUpeCcu5zp8EohrKTJ0jgzBJJw==",
       "requires": {
         "through2": "^3.0.1"
       }
@@ -15886,8 +15925,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@math.gl/culling": "^3.4.2",
     "fast-deep-equal": "^3.1.3",
     "fast-xml-parser": "^3.16.0",
-    "geotiff": "ilan-gold/geotiff.js#ilan-gold/viv_094",
+    "geotiff": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.1.tar.gz",
     "math.gl": "^3.3.0",
     "quickselect": "^2.0.0",
     "zarr": "^0.4.0"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@math.gl/culling": "^3.4.2",
     "fast-deep-equal": "^3.1.3",
     "fast-xml-parser": "^3.16.0",
-    "geotiff": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.1.tar.gz",
+    "geotiff": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.2.tar.gz",
     "math.gl": "^3.3.0",
     "quickselect": "^2.0.0",
     "zarr": "^0.4.0"

--- a/rollup.config.test.js
+++ b/rollup.config.test.js
@@ -6,10 +6,8 @@ export default {
   output: {
     format: 'cjs'
   },
-  // All non-relative paths are external
-  external: [/^[^.\/]|^\.[^.\/]|^\.\.[^\/]/],
   plugins: [
-    resolve(),
+    resolve({ resolveOnly: ['geotiff'] }),
     glslify(),
     sucrase({ transforms: ['jsx', 'typescript'] })
   ]

--- a/src/loaders/tiff/index.ts
+++ b/src/loaders/tiff/index.ts
@@ -32,7 +32,10 @@ export async function loadOmeTiff(
 
   // Create tiff source
   if (typeof source === 'string') {
-    tiff = await fromUrl(source, headers);
+    // https://github.com/ilan-gold/geotiff.js/tree/viv#abortcontroller-support
+    // https://www.npmjs.com/package/lru-cache#options
+    // Cache size needs to be infinite due to consistency issues.
+    tiff = await fromUrl(source, { ...headers, cacheSize: Infinity });
   } else {
     tiff = await fromBlob(source);
   }

--- a/vite.config.js
+++ b/vite.config.js
@@ -53,12 +53,6 @@ const configAvivator = defineConfig({
       '@hms-dbmi/viv': resolve(__dirname, 'src'),
       'react': resolve(__dirname, 'avivator/node_modules/react'),
       'react-dom': resolve(__dirname, 'avivator/node_modules/react-dom'),
-      /**
-       * Geotiff.js uses node-builtins in its source. We don't use these
-       * module exports in our code. Rather than polyfilling these modules,
-       * we use resolve to empty exports.
-       */
-      'fs': resolve(__dirname, 'avivator/empty-fs.js'),
     }
   }
 });


### PR DESCRIPTION
Uses tagged release of `ilan-gold/geotiff.js` https://github.com/ilan-gold/geotiff.js/tree/viv. Removes need for `empty-fs.js` in vite config.