### PR TITLE
Fix Changelog Check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Upgrade deck.gl to 8.5
+- Fix changelog check in `bash`.
 
 ## 0.10.5
 

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@ end() { echo travis_fold':'end:$1; }
 die() { set +v; echo "$*" 1>&2 ; sleep 1; exit 1; }
 
 start changelog
-if [ "$GITHUB_REF" != 'refs/heads/master' && "$GITHUB_REF" != *'dependabot'* ]; then
+if [[ "$GITHUB_REF" != 'refs/heads/master' && "$GITHUB_REF" != *'dependabot'* ]]; then
   diff CHANGELOG.md <(curl "https://raw.githubusercontent.com/hms-dbmi/viv/master/CHANGELOG.md") \
     && die 'Update CHANGELOG.md'
 fi


### PR DESCRIPTION
We were getting a `./test.sh: line 9: [: missing `]'` warning previously.