### PR TITLE
fix: restore React component documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Upgrade deck.gl to 8.5
 - Fix changelog check in `bash`.
+- Fix documentation for React Components.
 
 ## 0.10.5
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format:write": "npm run format -- --write",
     "version": "./version.sh",
     "postversion": "git push && git push --tags",
-    "docs": "mkdir -p dist_docs || rm -r dist_docs && mkdir -p dist_docs && documentation build dist/viv.es.js -f html --document-exported --config documentation.yml --shallow -o dist_docs"
+    "docs": "mkdir -p dist_docs || rm -r dist_docs && mkdir -p dist_docs && documentation build src/**/*.jsx dist/viv.es.js -f html --document-exported --config documentation.yml --shallow -o dist_docs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #486 

We use the final bundle (`dist/viv.es.js`) with `documentation.js`'s `--document-exports` to generated our documentation. Something about Vite's JSX transform strips the comments from the final bundle, meaning there is nothing in `dist/viv.es.js` to autogenerate documentation.

Fortunately this issue is isolated to all files with `.jsx` extensions, and the only thing in each of those files that is exported is a React Component. This PR just adds `src/**/*.jsx` to the `npm run docs` script, telling `documentation.js` to both look at `dist/viv.es.js` as well as the source code with `.jsx` extensions when generating our docs.