### PR TITLE
Maintain the value of the channel color in HSV when applying intensity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Upgrade deck.gl to 8.5
 - Fix changelog check in `bash`.
 - Update README to note Node version restrictions.
+- Maintain the value of the channel color in HSV when applying intensity.
+
 ## 0.10.5
 
 ### Added

--- a/src/layers/XRLayer/shader-modules/channel-intensity.glsl
+++ b/src/layers/XRLayer/shader-modules/channel-intensity.glsl
@@ -85,8 +85,8 @@ vec3 process_channel_intensity(float intensity, vec3 colorValues, int channelInd
   float useColorValue = float(int((inLensAndUseLens && channelIndex == lensSelection) || (!inLensAndUseLens)));
   // Use arithmetic instead of if-then for useColorValue.
   vec3 hsvCombo = rgb_to_hsv(max(vec3(colorValues), (1.0 - useColorValue) * vec3(255, 255, 255)));
-  // Sum up the intesitiies in additive blending.
-  hsvCombo = vec3(hsvCombo.xy, max(0.0, intensity));
+  // Sum up the intensities in additive blending.
+  hsvCombo = vec3(hsvCombo.xy, hsvCombo.z * max(0.0, min(1.0, intensity)));
   return hsv_to_rgb(hsvCombo);
 }
 


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #490
<!-- For other PRs without open issue -->
#### Background

This maintains the channel color and doesn't use the maximum-value HSV equivalent.

Usual behavior with `rgb(0,255,0)`.
![Screen Shot 2021-08-20 at 4 43 45 PM](https://user-images.githubusercontent.com/15636985/130303332-819aac76-5d62-4aff-ac94-795070fd9b52.png)

New behavior with `rgb(0,128,0)`.
![Screen Shot 2021-08-20 at 4 42 39 PM](https://user-images.githubusercontent.com/15636985/130303336-fff4bcb3-ff89-4b4a-a69b-a2b175fb2edd.png)

#### Change List
- Maintain the value of the channel color in HSV when applying intensity
#### Checklist
 - [X] Make sure Avivator works as expected with your change.
