### PR TITLE
Maintain the value of the channel color in HSV when applying intensity (3D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Upgrade deck.gl to 8.5
 - Fix changelog check in `bash`.
 - Update README to note Node version restrictions.
-- Maintain the value of the channel color in HSV when applying intensity.
+- Maintain the value of the channel color in HSV when applying intensity (3D + 2D)
 - Fix documentation for React Components.
 
 ## 0.10.5

--- a/src/layers/XR3DLayer/rendering-modes.js
+++ b/src/layers/XR3DLayer/rendering-modes.js
@@ -19,7 +19,7 @@ export const RENDERING_MODES_BLEND = {
       vec3 rgbCombo = vec3(0.0);
       for(int i = 0; i < 6; i++) {
         vec3 hsvCombo = rgb2hsv(vec3(colorValues[i]));
-        hsvCombo = vec3(hsvCombo.xy, maxVals[i]);
+        hsvCombo = vec3(hsvCombo.xy, hsvCombo.z * max(0.0, min(1.0, maxVals[i])));
         rgbCombo += hsv2rgb(hsvCombo);
       }
       color = vec4(rgbCombo, 1.0);
@@ -43,7 +43,7 @@ export const RENDERING_MODES_BLEND = {
       vec3 rgbCombo = vec3(0.0);
       for(int i = 0; i < 6; i++) {
         vec3 hsvCombo = rgb2hsv(vec3(colorValues[i]));
-        hsvCombo = vec3(hsvCombo.xy, minVals[i]);
+        hsvCombo = vec3(hsvCombo.xy, hsvCombo.z * max(0.0, min(1.0, minVals[i])));
         rgbCombo += hsv2rgb(hsvCombo);
       }
       color = vec4(rgbCombo, 1.0);
@@ -59,7 +59,7 @@ export const RENDERING_MODES_BLEND = {
       for(int i = 0; i < 6; i++) {
         float intensityValue = intensityArray[i];
         hsvCombo = rgb2hsv(vec3(colorValues[i]));
-        hsvCombo = vec3(hsvCombo.xy, intensityValue);
+        hsvCombo = vec3(hsvCombo.xy, hsvCombo.z * max(0.0, min(1.0, intensityValue)));
         rgbCombo += hsv2rgb(hsvCombo);
         total += intensityValue;
       }


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Follow up to #491
<!-- For other PRs without open issue -->
<!-- For all the PRs -->
#### Change List
- #491 for 3D
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
