### PR TITLE
Better Handling of Thin 3D Volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Update README to note Node version restrictions.
 - Maintain the value of the channel color in HSV when applying intensity (3D + 2D)
 - Fix documentation for React Components.
+- Fix channel stats for thin 3D volumes in Avivator.
 
 ## 0.10.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Maintain the value of the channel color in HSV when applying intensity (3D + 2D)
 - Fix documentation for React Components.
 - Fix channel stats for thin 3D volumes in Avivator.
+- Better checking for viewable volumes at certain resolutions.
 
 ## 0.10.5
 

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -224,7 +224,7 @@ export async function getSingleSelectionStats3D({ loader, selection }) {
     selection: { ...selection, z: Math.floor(sizeZ / 2) }
   });
   const rasterTop = await lowResSource.getRaster({
-    selection: { ...selection, z: sizeZ - 1 }
+    selection: { ...selection, z: Math.max(0, sizeZ - 1) }
   });
   const stats0 = getChannelStats(raster0.data);
   const statsMid = getChannelStats(rasterMid.data);

--- a/src/layers/VolumeLayer/utils.js
+++ b/src/layers/VolumeLayer/utils.js
@@ -29,7 +29,7 @@ export async function getVolume({
   const { shape, labels, dtype } = source;
   const { height, width } = getImageSize(source);
   const depth = shape[labels.indexOf('z')];
-  const depthDownsampled = Math.floor(depth / downsampleDepth);
+  const depthDownsampled = Math.max(1, Math.floor(depth / downsampleDepth));
   const rasterSize = height * width;
   const name = `${dtype}Array`;
   const TypedArray = globalThis[name];


### PR DESCRIPTION
@keller-mark raised this issue with some data (not public).  We should have been checking texture dimensions against the general standard limit of 2048 (some browsers/computers go larger but then there is the question of how practical downloading so much data is).
#### Background
<!-- For all the PRs -->
#### Change List
- Fix selection bug for thin volumes in channel stats
- Create checks against 1-depth volumes and those too large in the downsampled resolutions dropdown for volumes
- Ensure selections are valid within the layer utils (i.e the same bug as the first point)

#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
