### PR TITLE
Fix `loaders` docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@
 - Update README to note Node version restrictions.
 - Maintain the value of the channel color in HSV when applying intensity (3D + 2D)
 - Fix documentation for React Components.
+- Fix documentation for TypeScript exports.
 - Fix channel stats for thin 3D volumes in Avivator.
 - Better checking for viewable volumes at certain resolutions.
-- Don't do RGB-HSV conversion on shaders.  Instead, scale RGB linearly.
+- Don't do RGB-HSV conversion on shaders. Instead, scale RGB linearly.
 - Consistent shader floats `n.0` -> `n.`
 - Pin deck.gl to minor versions
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format:write": "npm run format -- --write",
     "version": "./version.sh",
     "postversion": "git push && git push --tags",
-    "docs": "mkdir -p dist_docs || rm -r dist_docs && mkdir -p dist_docs && documentation build src/**/*.jsx dist/viv.es.js -f html --document-exported --config documentation.yml --shallow -o dist_docs"
+    "docs": "mkdir -p dist_docs || rm -r dist_docs && mkdir -p dist_docs && documentation build src/**/*.jsx src/loaders/**/*.ts dist/viv.es.js -f html --document-exported --config documentation.yml --shallow -o dist_docs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### Background
Similar to #486, the docs for the loaders regressed as well: http://viv.gehlenborglab.org/#loadometiff
#### Change List
- Add check for `src/loaders/**/*.ts ` to the `documentation` cli
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
