### PR TITLE
Do not retain layer in pointer-event handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Do not retain layer in pointer-event handler
+
 ## 0.10.6
 
 ### Added

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -73,7 +73,7 @@ const defaultProps = {
  */
 const ImageLayer = class extends CompositeLayer {
   initializeState() {
-    const internalState = this.internalState;
+    const { internalState } = this;
     const handler = () => onPointer(internalState.layer);
     this.state = {
       onPointer: handler,

--- a/src/layers/ImageLayer.js
+++ b/src/layers/ImageLayer.js
@@ -73,7 +73,10 @@ const defaultProps = {
  */
 const ImageLayer = class extends CompositeLayer {
   initializeState() {
+    const internalState = this.internalState;
+    const handler = () => onPointer(internalState.layer);
     this.state = {
+      onPointer: handler,
       unprojectLensBounds: [0, 0, 0, 0],
       width: 0,
       height: 0,
@@ -81,15 +84,23 @@ const ImageLayer = class extends CompositeLayer {
     };
     if (this.context.deck) {
       this.context.deck.eventManager.on({
-        pointermove: () => onPointer(this),
-        pointerleave: () => onPointer(this),
-        wheel: () => onPointer(this)
+        pointermove: handler,
+        pointerleave: handler,
+        wheel: handler
       });
     }
   }
 
   finalizeState() {
     this.state.abortController.abort();
+    if (this.context.deck) {
+      this.context.deck.eventManager.off({
+        pointermove: this.state.onPointer,
+        pointerleave: this.state.onPointer,
+        wheel: this.state.onPointer
+      });
+    }
+    super.finalizeState();
   }
 
   updateState({ props, oldProps }) {

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -70,7 +70,7 @@ const defaultProps = {
  */
 const MultiscaleImageLayer = class extends CompositeLayer {
   initializeState() {
-    const internalState = this.internalState;
+    const { internalState } = this;
     const handler = () => onPointer(internalState.layer);
     this.state = {
       onPointer: handler,

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -70,16 +70,30 @@ const defaultProps = {
  */
 const MultiscaleImageLayer = class extends CompositeLayer {
   initializeState() {
+    const internalState = this.internalState;
+    const handler = () => onPointer(internalState.layer);
     this.state = {
+      onPointer: handler,
       unprojectLensBounds: [0, 0, 0, 0]
     };
     if (this.context.deck) {
       this.context.deck.eventManager.on({
-        pointermove: () => onPointer(this),
-        pointerleave: () => onPointer(this),
-        wheel: () => onPointer(this)
+        pointermove: handler,
+        pointerleave: handler,
+        wheel: handler
       });
     }
+  }
+
+  finalizeState() {
+    if (this.context.deck) {
+      this.context.deck.eventManager.off({
+        pointermove: this.state.onPointer,
+        pointerleave: this.state.onPointer,
+        wheel: this.state.onPointer
+      });
+    }
+    super.finalizeState();
   }
 
   renderLayers() {


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #504
<!-- For other PRs without open issue -->
#### Background
The pointer-event handlers in `MultiscaleImageLayer` and `ImageLayer` encapsulated the layer in the handler. That caused a memory leak in `MultiscaleImageHandlerBase` via `subLayers` and `parent.subLayers`, respectively.

This fixes the memory leak and `onPointer` is still being called as expected. Also, `super.finalizeState` gets called because `Layer.finalizeState` does some cleanup.

There is another memory leak but that may just be the TIFF cache.

#### Change List
- Do not retain layer in pointer-event handler
#### Checklist
 - [X] Make sure Avivator works as expected with your change.
