### PR TITLE
Upgrade Vite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - `channelIsOn` -> `channelsVisible`
   - `loaderSelection` -> `selections`
   - `MAX_SLIDERS_AND_CHANNELS` -> `MAX_CHANNELS`
+- Upgrade `Vite` to `~2.5.4`
 
 ## 0.10.6
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4514,12 +4514,6 @@
       "integrity": "sha1-T5czO5abp2Ejgr5LwzlLNB+0yKI=",
       "dev": true
     },
-    "colorette": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "dev": true
-    },
     "combine-source-map": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
@@ -6876,9 +6870,9 @@
       }
     },
     "esbuild": {
-      "version": "0.12.15",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
-      "integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
+      "version": "0.12.29",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
+      "integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
       "dev": true
     },
     "escalade": {
@@ -11150,10 +11144,16 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true
     },
+    "nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+      "dev": true
+    },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "nanomatch": {
@@ -11979,13 +11979,13 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
-      "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
+      "version": "8.3.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.7.tgz",
+      "integrity": "sha512-9SaY7nnyQ63/WittqZYAvkkYPyKxchMKH71UDzeTmWuLSvxTRpeEeABZAzlCi55cuGcoFyoV/amX2BdsafQidQ==",
       "dev": true,
       "requires": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
+        "nanocolors": "^0.1.5",
+        "nanoid": "^3.1.25",
         "source-map-js": "^0.6.2"
       }
     },
@@ -15681,14 +15681,14 @@
       }
     },
     "vite": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.4.1.tgz",
-      "integrity": "sha512-4BpKRis9uxIqPfIEcJ18LTBsamqnDFxTx45CXwagHjNltHa6PFEvf8Pe6OpgIHb0OyWT30OXOSSQvdOaX4OBiQ==",
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.5.10.tgz",
+      "integrity": "sha512-0ObiHTi5AHyXdJcvZ67HMsDgVpjT5RehvVKv6+Q0jFZ7zDI28PF5zK9mYz2avxdA+4iJMdwCz6wnGNnn4WX5Gg==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.12.8",
+        "esbuild": "^0.12.17",
         "fsevents": "~2.3.2",
-        "postcss": "^8.3.5",
+        "postcss": "^8.3.6",
         "resolve": "^1.20.0",
         "rollup": "^2.38.5"
       },
@@ -15701,9 +15701,9 @@
           "optional": true
         },
         "is-core-module": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-          "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+          "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
           "dev": true,
           "requires": {
             "has": "^1.0.3"
@@ -15720,9 +15720,9 @@
           }
         },
         "rollup": {
-          "version": "2.52.8",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.8.tgz",
-          "integrity": "sha512-IjAB0C6KK5/lvqzJWAzsvOik+jV5Bt907QdkQ/gDP4j+R9KYNI1tjqdxiPitGPVrWC21Mf/ucXgowUjN/VemaQ==",
+          "version": "2.57.0",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.57.0.tgz",
+          "integrity": "sha512-bKQIh1rWKofRee6mv8SrF2HdP6pea5QkwBZSMImJysFj39gQuiV8MEPBjXOCpzk3wSYp63M2v2wkWBmFC8O/rg==",
           "dev": true,
           "requires": {
             "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "tape-catch": "^1.0.6",
     "tape-run": "^8.0.0",
     "typescript": "^4.1.3",
-    "vite": "^2.4.1"
+    "vite": "^2.5.4"
   },
   "dependencies": {
     "@math.gl/culling": "^3.4.2",

--- a/src/loaders/tiff/ome-tiff.ts
+++ b/src/loaders/tiff/ome-tiff.ts
@@ -5,10 +5,10 @@ import TiffPixelSource from './pixel-source';
 import {
   getOmeLegacyIndexer,
   getOmeSubIFDIndexer,
-  OmeTiffIndexer
 } from './lib/indexers';
 import { getOmePixelSourceMeta, guessTileSize } from './lib/utils';
 import type Pool from './lib/Pool';
+import type { OmeTiffIndexer } from './lib/indexers';
 
 export interface OmeTiffSelection {
   t: number;

--- a/src/loaders/tiff/ome-tiff.ts
+++ b/src/loaders/tiff/ome-tiff.ts
@@ -2,10 +2,7 @@ import type { GeoTIFF } from 'geotiff';
 import { fromString } from '../omexml';
 
 import TiffPixelSource from './pixel-source';
-import {
-  getOmeLegacyIndexer,
-  getOmeSubIFDIndexer,
-} from './lib/indexers';
+import { getOmeLegacyIndexer, getOmeSubIFDIndexer } from './lib/indexers';
 import { getOmePixelSourceMeta, guessTileSize } from './lib/utils';
 import type Pool from './lib/Pool';
 import type { OmeTiffIndexer } from './lib/indexers';

--- a/src/loaders/tiff/ome-tiff.ts
+++ b/src/loaders/tiff/ome-tiff.ts
@@ -2,10 +2,13 @@ import type { GeoTIFF } from 'geotiff';
 import { fromString } from '../omexml';
 
 import TiffPixelSource from './pixel-source';
-import { getOmeLegacyIndexer, getOmeSubIFDIndexer } from './lib/indexers';
+import {
+  getOmeLegacyIndexer,
+  getOmeSubIFDIndexer,
+  OmeTiffIndexer
+} from './lib/indexers';
 import { getOmePixelSourceMeta, guessTileSize } from './lib/utils';
 import type Pool from './lib/Pool';
-import type { OmeTiffIndexer } from './lib/indexers';
 
 export interface OmeTiffSelection {
   t: number;

--- a/src/loaders/tiff/ome-tiff.ts
+++ b/src/loaders/tiff/ome-tiff.ts
@@ -2,13 +2,10 @@ import type { GeoTIFF } from 'geotiff';
 import { fromString } from '../omexml';
 
 import TiffPixelSource from './pixel-source';
-import {
-  getOmeLegacyIndexer,
-  getOmeSubIFDIndexer,
-  OmeTiffIndexer
-} from './lib/indexers';
+import { getOmeLegacyIndexer, getOmeSubIFDIndexer } from './lib/indexers';
 import { getOmePixelSourceMeta, guessTileSize } from './lib/utils';
 import type Pool from './lib/Pool';
+import type { OmeTiffIndexer } from './lib/indexers';
 
 export interface OmeTiffSelection {
   t: number;


### PR DESCRIPTION

Fixes #303 (I think)

#### Change List
- Upgrade Vite to `~2.5.4`
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
