### PR TITLE
Extend/Document Shader API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - props like `lensBorderRadius` no longer used in favor of using the `extensions` prop with new `LensExtension`
     - These props are now `opts` on the extension itself
     - See https://deck.gl/docs/developer-guide/custom-layers/layer-extensions for more information on how to use `extensions` and what they are
+  - Expose `DECKGL_FILTER_COLOR`, `DECKGL_PROCESS_INTENSITY`, AND `DECKGL_MUTATE_COLOR` hooks and document them.
 
 ### Changed
 

--- a/docs/CUSTOM_SHADERS.md
+++ b/docs/CUSTOM_SHADERS.md
@@ -1,0 +1,15 @@
+Viv's layer allow for custom shader hooks to be defined via [deck.gl hook functions](https://deck.gl/docs/developer-guide/custom-layers/writing-shaders#standard-shader-hooks). To take advantage of these, please pass in a deck.gl [layer extension](https://deck.gl/docs/api-reference/extensions/overview) whose `getShaders` function has a definition in `inject` for one of these hooks. Viv supports 3 hooks on the fragment shader:
+
+### `DECKGL_PROCESS_INTENSITY(inout float intensity, int channelIndex)`
+
+This hook allows for custom processing of the raw intensities of the pixels. You may for example want to apply a nonlinear or otherwise different function instead of the standard ramp function with 2 contrast limit endpoints we apply. This hook is available on all layers in all modes
+
+### `DECKGL_MUTATE_COLOR(inout float intensity, int channelIndex)`
+
+This hook allows for users to mutate conversion of a processed intensity (from `DECKGL_PROCESS_INTENSITY`) into a color when not using a colormap like `viridis` or `jet` via the `colormap` prop. This is only available in 2D layers.
+
+### `DECKGL_FILTER_COLOR(inout vec4 color, FragmentGeometry geometry)`
+
+Please see deck.gl's [documentation](https://deck.gl/docs/developer-guide/custom-layers/writing-shaders#fsdeckgl_filter_color) as this is a stnadard hook. For example in this function, you may wish to apply a gamma transformation to the output colors.
+
+Using these is fully optional and up to the discretion of the user.

--- a/documentation.yml
+++ b/documentation.yml
@@ -1,42 +1,44 @@
 toc:
-- name: Introduction
-  file: README.md
-- name: Getting Started
-  file: docs/SAMPLES.md
-- name: API Structure
-  file: docs/API_STRUCTURE.md
-- name: Data preparation
-  file: tutorial/README.md
-- name: 3D Rendering
-  file: docs/3D_RENDERING_BRIEF.md
-- name: Viewers (React Components)
-- PictureInPictureViewer
-- SideBySideViewer
-- VolumeViewer
-- VivViewer
-- name: Views
-- VivView
-- OverviewView
-- DetailView
-- VolumeView
-- SideBySideView
-- name: Utility Methods
-- getChannelStats
-- getDefaultInitialViewState
-- name: Layers
-  file: docs/LAYERS_DOCS_NOTE.md
-- MultiscaleImageLayer
-- ImageLayer
-- XRLayer
-- VolumeLayer
-- XR3DLayer
-- BitmapLayer
-- OverviewLayer
-- ScaleBarLayer
-- name: Extensions
-- LensExtension
-- name: Loaders
-- loadOmeTiff
-- loadOmeZarr
-- loadBioformatsZarr
-- name: Misc
+  - name: Introduction
+    file: README.md
+  - name: Getting Started
+    file: docs/SAMPLES.md
+  - name: API Structure
+    file: docs/API_STRUCTURE.md
+  - name: Data preparation
+    file: tutorial/README.md
+  - name: 3D Rendering
+    file: docs/3D_RENDERING_BRIEF.md
+  - name: Custom Shaders
+    file: docs/CUSTOM_SHADERS.md
+  - name: Viewers (React Components)
+  - PictureInPictureViewer
+  - SideBySideViewer
+  - VolumeViewer
+  - VivViewer
+  - name: Views
+  - VivView
+  - OverviewView
+  - DetailView
+  - VolumeView
+  - SideBySideView
+  - name: Utility Methods
+  - getChannelStats
+  - getDefaultInitialViewState
+  - name: Layers
+    file: docs/LAYERS_DOCS_NOTE.md
+  - MultiscaleImageLayer
+  - ImageLayer
+  - XRLayer
+  - VolumeLayer
+  - XR3DLayer
+  - BitmapLayer
+  - OverviewLayer
+  - ScaleBarLayer
+  - name: Extensions
+  - LensExtension
+  - name: Loaders
+  - loadOmeTiff
+  - loadOmeZarr
+  - loadBioformatsZarr
+  - name: Misc

--- a/src/extensions/lens-module.js
+++ b/src/extensions/lens-module.js
@@ -4,7 +4,7 @@ export default {
   name: 'lens-module',
   fs,
   inject: {
-    'fs:DECKGL_PROCESS_INTENSITY': `
+    'fs:DECKGL_MUTATE_COLOR': `
     process_channel_intensity_with_lens(rgbOut, intensity, color, vTexCoord, channelIndex);
   `,
     'fs:#main-end': `

--- a/src/layers/XR3DLayer/XR3DLayer.js
+++ b/src/layers/XR3DLayer/XR3DLayer.js
@@ -28,6 +28,8 @@ More information about that is detailed in the comments there.
 import GL from '@luma.gl/constants';
 import { COORDINATE_SYSTEM, Layer } from '@deck.gl/core';
 import { Model, Geometry, Texture3D } from '@luma.gl/core';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { ProgramManager } from '@luma.gl/engine';
 import { Matrix4 } from 'math.gl';
 import { Plane } from '@math.gl/culling';
 import vs from './xr-layer-vertex.glsl';
@@ -137,15 +139,28 @@ function removeExtraColormapFunctionsFromShader(colormap) {
 const XR3DLayer = class extends Layer {
   initializeState() {
     const { gl } = this.context;
-    this.setState({
-      model: this._getModel(gl)
-    });
     // This tells WebGL how to read row data from the texture.  For example, the default here is 4 (i.e for RGBA, one byte per channel) so
     // each row of data is expected to be a multiple of 4.  This setting (i.e 1) allows us to have non-multiple-of-4 row sizes.  For example, for 2 byte (16 bit data),
     // we could use 2 as the value and it would still work, but 1 also works fine (and is more flexible for 8 bit - 1 byte - textures as well).
     // https://stackoverflow.com/questions/42789896/webgl-error-arraybuffer-not-big-enough-for-request-in-case-of-gl-luminance
     gl.pixelStorei(GL.UNPACK_ALIGNMENT, 1);
     gl.pixelStorei(GL.PACK_ALIGNMENT, 1);
+    const programManager = ProgramManager.getDefaultProgramManager(gl);
+    const processStr = `fs:DECKGL_PROCESS_INTENSITY(inout float intensity, int channelIndex)`;
+    if (!programManager._hookFunctions.includes(processStr)) {
+      programManager.addShaderHook(processStr);
+    }
+  }
+
+  _isHookDefinedByExtensions(hookName) {
+    const { extensions } = this.props;
+    return extensions?.some(e => {
+      const shaders = e.getShaders();
+      const { inject = {}, modules = [] } = shaders;
+      const definesInjection = inject[hookName];
+      const moduleDefinesInjection = modules.some(m => m?.inject[hookName]);
+      return definesInjection || moduleDefinesInjection;
+    });
   }
 
   /**
@@ -158,6 +173,15 @@ const XR3DLayer = class extends Layer {
       ? RENDERING_MODES_COLORMAP[renderingMode]
       : RENDERING_MODES_BLEND[renderingMode];
     const channelsModules = removeExtraColormapFunctionsFromShader(colormap);
+    const extensionDefinesDeckglProcessIntensity = this._isHookDefinedByExtensions(
+      'fs:DECKGL_PROCESS_INTENSITY'
+    );
+    const newChannelsModule = { ...channelsModules, inject: {} };
+    if (!extensionDefinesDeckglProcessIntensity) {
+      newChannelsModule.inject['fs:DECKGL_PROCESS_INTENSITY'] = `
+        intensity = apply_contrast_limits(intensity, channelIndex);
+      `;
+    }
     return super.getShaders({
       vs,
       fs: fs
@@ -169,7 +193,7 @@ const XR3DLayer = class extends Layer {
         COLORMAP_FUNCTION: colormap || 'viridis',
         NUM_PLANES: String(clippingPlanes.length || NUM_PLANES_DEFAULT)
       },
-      modules: [channelsModules]
+      modules: [newChannelsModule]
     });
   }
 

--- a/src/layers/XR3DLayer/channel-intensity.glsl
+++ b/src/layers/XR3DLayer/channel-intensity.glsl
@@ -43,9 +43,11 @@
 #pragma glslify: velocity-green = require("glsl-colormap/velocity-green")
 #pragma glslify: cubehelix = require("glsl-colormap/cubehelix")
 
-float sample_and_apply_contrast_limits(SAMPLER_TYPE channel, vec3 vTexCoord, vec2 contrastLimits) {
-  float fragIntensity = float(texture(channel, vTexCoord).r);
-  float contrastLimitsAppliedToIntensity = (fragIntensity - contrastLimits[0]) / max(0.0005, (contrastLimits[1] - contrastLimits[0]));
+// range
+uniform vec2 contrastLimits[6];
+
+float apply_contrast_limits(float intensity, int channelIndex) {
+  float contrastLimitsAppliedToIntensity = (intensity - contrastLimits[channelIndex][0]) / max(0.0005, (contrastLimits[channelIndex][1] - contrastLimits[channelIndex][0]));
   return max(0., contrastLimitsAppliedToIntensity);
 }
 

--- a/src/layers/XR3DLayer/xr-layer-fragment.glsl
+++ b/src/layers/XR3DLayer/xr-layer-fragment.glsl
@@ -17,9 +17,6 @@ uniform mat4 scale;
 uniform vec3 normals[NUM_PLANES];
 uniform float distances[NUM_PLANES];
 
-// range
-uniform vec2 contrastLimits[6];
-
 // color
 uniform vec3 colors[6];
 
@@ -107,12 +104,24 @@ void main(void) {
 		float canShowZCoordinate = max(p.z - 0., 0.) * max(1. - p.z , 0.);
 		float canShowCoordinate = float(ceil(canShowXCoordinate * canShowYCoordinate * canShowZCoordinate));
 		canShow = canShowCoordinate * canShow;
-    float intensityValue0 = canShow * sample_and_apply_contrast_limits(volume0, p, contrastLimits[0]);
-    float intensityValue1 = canShow * sample_and_apply_contrast_limits(volume1, p, contrastLimits[1]);
-		float intensityValue2 = canShow * sample_and_apply_contrast_limits(volume2, p, contrastLimits[2]);
-		float intensityValue3 = canShow * sample_and_apply_contrast_limits(volume3, p, contrastLimits[3]);
-    float intensityValue4 = canShow * sample_and_apply_contrast_limits(volume4, p, contrastLimits[4]);
-		float intensityValue5 = canShow * sample_and_apply_contrast_limits(volume5, p, contrastLimits[5]);
+    float intensityValue0 = float(texture(volume0, p).r);
+  	DECKGL_PROCESS_INTENSITY(intensityValue0, 0);
+		intensityValue0 = canShow * intensityValue0;
+    float intensityValue1 = float(texture(volume1, p).r);
+  	DECKGL_PROCESS_INTENSITY(intensityValue1, 1);
+		intensityValue1 = canShow * intensityValue1;
+		float intensityValue2 = float(texture(volume2, p).r);
+  	DECKGL_PROCESS_INTENSITY(intensityValue2, 2);
+		intensityValue2 = canShow * intensityValue2;
+		float intensityValue3 = float(texture(volume3, p).r);
+  	DECKGL_PROCESS_INTENSITY(intensityValue3, 3);
+		intensityValue3 = canShow * intensityValue3;
+    float intensityValue4 = float(texture(volume4, p).r);
+  	DECKGL_PROCESS_INTENSITY(intensityValue4, 4);
+		intensityValue4 = canShow * intensityValue4;
+		float intensityValue5 = float(texture(volume5, p).r);
+  	DECKGL_PROCESS_INTENSITY(intensityValue5, 5);
+		intensityValue5 = canShow * intensityValue5;
 
 		_RENDER
 

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -124,23 +124,34 @@ const XRLayer = class extends Layer {
       this.context.gl,
       interpolation
     );
+    const fs = colormap ? shaderModule.fscmap : shaderModule.fs;
+    const extensionDefinesDeckglMutateColor = this._isHookDefinedByExtensions(
+      'fs:DECKGL_MUTATE_COLOR'
+    );
     const extensionDefinesDeckglProcessIntensity = this._isHookDefinedByExtensions(
       'fs:DECKGL_PROCESS_INTENSITY'
     );
-    const inject = !extensionDefinesDeckglProcessIntensity && {
-      'fs:DECKGL_PROCESS_INTENSITY': `
+    const inject = {};
+    if (!extensionDefinesDeckglMutateColor) {
+      inject['fs:DECKGL_MUTATE_COLOR'] = `
         rgbOut += max(0., min(1., intensity)) * vec3(color);
-      `
-    };
+      `;
+    }
+    const newChannelsModule = { ...channels, inject: {} };
+    if (!extensionDefinesDeckglProcessIntensity) {
+      newChannelsModule.inject['fs:DECKGL_PROCESS_INTENSITY'] = `
+        intensity = apply_contrast_limits(intensity, channelIndex);
+      `;
+    }
     return super.getShaders({
-      fs: colormap ? shaderModule.fscmap : shaderModule.fs,
+      fs,
       vs: shaderModule.vs,
       defines: {
         SAMPLER_TYPE: sampler,
         COLORMAP_FUNCTION: colormap || 'viridis'
       },
       inject,
-      modules: [project32, picking, channels]
+      modules: [project32, picking, newChannelsModule]
     });
   }
 
@@ -159,6 +170,7 @@ const XRLayer = class extends Layer {
    * This function initializes the internal state.
    */
   initializeState() {
+    console.log('here!!');
     const { gl } = this.context;
     // This tells WebGL how to read row data from the texture.  For example, the default here is 4 (i.e for RGBA, one byte per channel) so
     // each row of data is expected to be a multiple of 4.  This setting (i.e 1) allows us to have non-multiple-of-4 row sizes.  For example, for 2 byte (16 bit data),
@@ -182,14 +194,18 @@ const XRLayer = class extends Layer {
     });
     const programManager = ProgramManager.getDefaultProgramManager(gl);
 
-    const processStr =
-      'fs:DECKGL_PROCESS_INTENSITY(inout vec3 rgbOut, float intensity, vec3 color, vec2 vTexCoord, int channelIndex)';
+    const mutateStr =
+      'fs:DECKGL_MUTATE_COLOR(inout vec3 rgbOut, float intensity, vec3 color, vec2 vTexCoord, int channelIndex)';
+    const processStr = `fs:DECKGL_PROCESS_INTENSITY(inout float intensity, int channelIndex)`;
 
     // Only initialize shader hook functions _once globally_
     // Since the program manager is shared across all layers, but many layers
     // might be created, this solves the performance issue of always adding new
     // hook functions.
     // See https://github.com/kylebarron/deck.gl-raster/blob/2eb91626f0836558f0be4cd201ea18980d7f7f2d/src/deckgl/raster-layer/raster-layer.js#L21-L40
+    if (!programManager._hookFunctions.includes(mutateStr)) {
+      programManager.addShaderHook(mutateStr);
+    }
     if (!programManager._hookFunctions.includes(processStr)) {
       programManager.addShaderHook(processStr);
     }

--- a/src/layers/XRLayer/shader-modules/channel-intensity.glsl
+++ b/src/layers/XRLayer/shader-modules/channel-intensity.glsl
@@ -43,17 +43,19 @@
 #pragma glslify: velocity-green = require("glsl-colormap/velocity-green")
 #pragma glslify: cubehelix = require("glsl-colormap/cubehelix")
 
-float sample_and_apply_contrast_limits(SAMPLER_TYPE channel, vec2 vTexCoord, vec2 contrastLimits) {
-  float fragIntensity = float(texture(channel, vTexCoord).r);
-  float contrastLimitsAppliedToIntensity = (fragIntensity - contrastLimits[0]) / max(0.0005, (contrastLimits[1] - contrastLimits[0]));
-  return max(0., contrastLimitsAppliedToIntensity);
-}
 
-vec3 process_channel_intensity(float intensity, vec3 colors, int channelIndex, bool inLensAndUseLens, int lensSelection) {
-  float useColorValue = float(int((inLensAndUseLens && channelIndex == lensSelection) || (!inLensAndUseLens)));
-  // Use arithmetic instead of if-then for useColorValue.
-  vec3 rgb = max(0., min(1., intensity)) * max(vec3(colors), (1. - useColorValue) * vec3(1., 1., 1.));
-  return rgb;
+// range
+uniform vec2 contrastLimits[6];
+
+float apply_contrast_limits(float intensity, int channelIndex) {
+  // Because WebGL1 cannot index the contrastLimits array dynamically, we need to use this assignment trick to apply the contrast funtion.
+  intensity =  float(channelIndex != 0) * intensity + float(channelIndex == 0) * max(0., (intensity - contrastLimits[0][0]) / max(0.0005, (contrastLimits[0][1] - contrastLimits[0][0])));
+  intensity =  float(channelIndex != 1) * intensity + float(channelIndex == 1) * max(0., (intensity - contrastLimits[1][0]) / max(0.0005, (contrastLimits[1][1] - contrastLimits[1][0])));
+  intensity =  float(channelIndex != 2) * intensity + float(channelIndex == 2) * max(0., (intensity - contrastLimits[2][0]) / max(0.0005, (contrastLimits[2][1] - contrastLimits[2][0])));
+  intensity =  float(channelIndex != 3) * intensity + float(channelIndex == 3) * max(0., (intensity - contrastLimits[3][0]) / max(0.0005, (contrastLimits[3][1] - contrastLimits[3][0])));
+  intensity =  float(channelIndex != 4) * intensity + float(channelIndex == 4) * max(0., (intensity - contrastLimits[4][0]) / max(0.0005, (contrastLimits[4][1] - contrastLimits[4][0])));
+  intensity =  float(channelIndex != 5) * intensity + float(channelIndex == 5) * max(0., (intensity - contrastLimits[5][0]) / max(0.0005, (contrastLimits[5][1] - contrastLimits[5][0])));
+  return intensity;
 }
 
 vec4 apply_opacity(vec3 color, bool useTransparentColor, vec3 transparentColor, float opacity){

--- a/src/layers/XRLayer/xr-layer-fragment-colormap.webgl1.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment-colormap.webgl1.glsl
@@ -10,9 +10,6 @@ uniform sampler2D channel3;
 uniform sampler2D channel4;
 uniform sampler2D channel5;
 
-// range
-uniform vec2 contrastLimits[6];
-
 // opacity
 uniform float opacity;
 uniform float divisor;
@@ -24,12 +21,18 @@ varying vec2 vTexCoord;
 
 
 void main() {
-  float intensityValue0 = sample_and_apply_contrast_limits(channel0, vTexCoord, contrastLimits[0]);
-  float intensityValue1 = sample_and_apply_contrast_limits(channel1, vTexCoord, contrastLimits[1]);
-  float intensityValue2 = sample_and_apply_contrast_limits(channel2, vTexCoord, contrastLimits[2]);
-  float intensityValue3 = sample_and_apply_contrast_limits(channel3, vTexCoord, contrastLimits[3]);
-  float intensityValue4 = sample_and_apply_contrast_limits(channel4, vTexCoord, contrastLimits[4]);
-  float intensityValue5 = sample_and_apply_contrast_limits(channel5, vTexCoord, contrastLimits[5]);
+  float intensityValue0 = float(texture(channel0, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue0, 0);
+  float intensityValue1 = float(texture(channel1, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue1, 1);
+  float intensityValue2 = float(texture(channel2, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue2, 2);
+  float intensityValue3 = float(texture(channel3, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue3, 3);
+  float intensityValue4 = float(texture(channel4, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue4, 4);
+  float intensityValue5 = float(texture(channel5, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue5, 5);
 
   float intensityCombo = 0.;
   

--- a/src/layers/XRLayer/xr-layer-fragment-colormap.webgl2.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment-colormap.webgl2.glsl
@@ -12,9 +12,6 @@ uniform SAMPLER_TYPE channel3;
 uniform SAMPLER_TYPE channel4;
 uniform SAMPLER_TYPE channel5;
 
-// range
-uniform vec2 contrastLimits[6];
-
 // opacity
 uniform float opacity;
 
@@ -28,12 +25,18 @@ out vec4 color;
 
 
 void main() {
-  float intensityValue0 = sample_and_apply_contrast_limits(channel0, vTexCoord, contrastLimits[0]);
-  float intensityValue1 = sample_and_apply_contrast_limits(channel1, vTexCoord, contrastLimits[1]);
-  float intensityValue2 = sample_and_apply_contrast_limits(channel2, vTexCoord, contrastLimits[2]);
-  float intensityValue3 = sample_and_apply_contrast_limits(channel3, vTexCoord, contrastLimits[3]);
-  float intensityValue4 = sample_and_apply_contrast_limits(channel4, vTexCoord, contrastLimits[4]);
-  float intensityValue5 = sample_and_apply_contrast_limits(channel5, vTexCoord, contrastLimits[5]);
+  float intensityValue0 = float(texture(channel0, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue0, 0);
+  float intensityValue1 = float(texture(channel1, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue1, 1);
+  float intensityValue2 = float(texture(channel2, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue2, 2);
+  float intensityValue3 = float(texture(channel3, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue3, 3);
+  float intensityValue4 = float(texture(channel4, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue4, 4);
+  float intensityValue5 = float(texture(channel5, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue5, 5);
 
   float intensityArray[6] = float[6](intensityValue0, intensityValue1, intensityValue2, intensityValue3, intensityValue4, intensityValue5);
   float intensityCombo = 0.;

--- a/src/layers/XRLayer/xr-layer-fragment.webgl1.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment.webgl1.glsl
@@ -9,9 +9,6 @@ uniform sampler2D channel3;
 uniform sampler2D channel4;
 uniform sampler2D channel5;
 
-// range
-uniform vec2 contrastLimits[6];
-
 // color
 uniform vec3 colors[6];
 uniform float intensityArray[6];
@@ -27,20 +24,26 @@ varying vec2 vTexCoord;
 
 void main() {
 
-  float intensityValue0 = sample_and_apply_contrast_limits(channel0, vTexCoord, contrastLimits[0]);
-  float intensityValue1 = sample_and_apply_contrast_limits(channel1, vTexCoord, contrastLimits[1]);
-  float intensityValue2 = sample_and_apply_contrast_limits(channel2, vTexCoord, contrastLimits[2]);
-  float intensityValue3 = sample_and_apply_contrast_limits(channel3, vTexCoord, contrastLimits[3]);
-  float intensityValue4 = sample_and_apply_contrast_limits(channel4, vTexCoord, contrastLimits[4]);
-  float intensityValue5 = sample_and_apply_contrast_limits(channel5, vTexCoord, contrastLimits[5]);
+  float intensityValue0 = float(texture(channel0, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue0, 0);
+  float intensityValue1 = float(texture(channel1, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue1, 1);
+  float intensityValue2 = float(texture(channel2, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue2, 2);
+  float intensityValue3 = float(texture(channel3, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue3, 3);
+  float intensityValue4 = float(texture(channel4, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue4, 4);
+  float intensityValue5 = float(texture(channel5, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue5, 5);
 
   vec3 rgbCombo = vec3(0.);
-  DECKGL_PROCESS_INTENSITY(rgbCombo, intensityValue0, colors[0], vTexCoord, 0);
-  DECKGL_PROCESS_INTENSITY(rgbCombo, intensityValue1, colors[1], vTexCoord, 1);
-  DECKGL_PROCESS_INTENSITY(rgbCombo, intensityValue2, colors[2], vTexCoord, 2);
-  DECKGL_PROCESS_INTENSITY(rgbCombo, intensityValue3, colors[3], vTexCoord, 3);
-  DECKGL_PROCESS_INTENSITY(rgbCombo, intensityValue4, colors[4], vTexCoord, 4);
-  DECKGL_PROCESS_INTENSITY(rgbCombo, intensityValue5, colors[5], vTexCoord, 5);
+  DECKGL_MUTATE_COLOR(rgbCombo, intensityValue0, colors[0], vTexCoord, 0);
+  DECKGL_MUTATE_COLOR(rgbCombo, intensityValue1, colors[1], vTexCoord, 1);
+  DECKGL_MUTATE_COLOR(rgbCombo, intensityValue2, colors[2], vTexCoord, 2);
+  DECKGL_MUTATE_COLOR(rgbCombo, intensityValue3, colors[3], vTexCoord, 3);
+  DECKGL_MUTATE_COLOR(rgbCombo, intensityValue4, colors[4], vTexCoord, 4);
+  DECKGL_MUTATE_COLOR(rgbCombo, intensityValue5, colors[5], vTexCoord, 5);
 
   gl_FragColor = apply_opacity(rgbCombo, useTransparentColor, transparentColor, opacity);
   geometry.uv = vTexCoord;

--- a/src/layers/XRLayer/xr-layer-fragment.webgl2.glsl
+++ b/src/layers/XRLayer/xr-layer-fragment.webgl2.glsl
@@ -12,9 +12,6 @@ uniform SAMPLER_TYPE channel3;
 uniform SAMPLER_TYPE channel4;
 uniform SAMPLER_TYPE channel5;
 
-// range
-uniform vec2 contrastLimits[6];
-
 // color
 uniform vec3 colors[6];
 
@@ -29,19 +26,26 @@ in vec2 vTexCoord;
 
 void main() {
 
-  float intensityValue0 = sample_and_apply_contrast_limits(channel0, vTexCoord, contrastLimits[0]);
-  float intensityValue1 = sample_and_apply_contrast_limits(channel1, vTexCoord, contrastLimits[1]);
-  float intensityValue2 = sample_and_apply_contrast_limits(channel2, vTexCoord, contrastLimits[2]);
-  float intensityValue3 = sample_and_apply_contrast_limits(channel3, vTexCoord, contrastLimits[3]);
-  float intensityValue4 = sample_and_apply_contrast_limits(channel4, vTexCoord, contrastLimits[4]);
-  float intensityValue5 = sample_and_apply_contrast_limits(channel5, vTexCoord, contrastLimits[5]);
+  float intensityValue0 = float(texture(channel0, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue0, 0);
+  float intensityValue1 = float(texture(channel1, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue1, 1);
+  float intensityValue2 = float(texture(channel2, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue2, 2);
+  float intensityValue3 = float(texture(channel3, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue3, 3);
+  float intensityValue4 = float(texture(channel4, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue4, 4);
+  float intensityValue5 = float(texture(channel5, vTexCoord).r);
+  DECKGL_PROCESS_INTENSITY(intensityValue5, 5);
+
 
   float intensityArray[6] = float[6](intensityValue0, intensityValue1, intensityValue2, intensityValue3, intensityValue4, intensityValue5);
 
   vec3 rgbCombo = vec3(0.);
 
   for(int i = 0; i < 6; i++) {
-    DECKGL_PROCESS_INTENSITY(rgbCombo, intensityArray[i], colors[i], vTexCoord, i);
+    DECKGL_MUTATE_COLOR(rgbCombo, intensityArray[i], colors[i], vTexCoord, i);
   }
 
 


### PR DESCRIPTION
#### Background
Following up #507 I think documenting its contents (i.e how to use the exposed hooks) is important.  This PR also adds another hook at a natural point for not only the (non-`viridis`, `jet` etc.) color mapping but also now processing raw intensities.  For example, following up on @manzt and @tlambert03's point [here](https://github.com/hms-dbmi/viv/pull/499#issuecomment-916114196) we can now apply different functions to the contrast, for example.  This PR also adds some documentation around our hooks (which existed in `DECKGL_FILTER_COLOR` but was not documented).
#### Change List
- Expose `DECKGL_PROCESS_INTENSITY` for handling raw intensities. 
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
