### PR TITLE
Add general `deckProps` prop to Viewer components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - `MAX_SLIDERS_AND_CHANNELS` -> `MAX_CHANNELS`
 - Upgrade `Vite` to `~2.5.4`
 - Fix value-picking for `VivViewer`.
+- `glOptions` is removed in favor of a general `deckProps` for Viewer components for all props that can be passed to the `DeckGL` component.
 
 ## 0.10.6
 

--- a/src/viewers/PictureInPictureViewer.jsx
+++ b/src/viewers/PictureInPictureViewer.jsx
@@ -43,7 +43,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition when making a new selection: Default: ['t', 'z'].
  * @param {function} [props.onViewportLoad] Function that gets called when the data in the viewport loads.
- * @param {Object} [props.deckProps] Additional options used when creating the DeckGL component.
+ * @param {Object} [props.deckProps] Additional options used when creating the DeckGL component.  See [the deck.gl docs.](https://deck.gl/docs/api-reference/core/deck#initialization-settings).  `layerFilter`, `layers`, `onViewStateChange`, `views`, `viewState`, `useDevicePixels`, and `getCursor` are already set.
  */
 
 const PictureInPictureViewer = props => {

--- a/src/viewers/PictureInPictureViewer.jsx
+++ b/src/viewers/PictureInPictureViewer.jsx
@@ -43,7 +43,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition when making a new selection: Default: ['t', 'z'].
  * @param {function} [props.onViewportLoad] Function that gets called when the data in the viewport loads.
- * @param {Object} [props.glOptions] Additional options used when creating the WebGLContext.
+ * @param {Object} [props.deckProps] Additional options used when creating the DeckGL component.
  */
 
 const PictureInPictureViewer = props => {
@@ -71,7 +71,7 @@ const PictureInPictureViewer = props => {
     onHover,
     transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS,
     onViewportLoad,
-    glOptions
+    deckProps
   } = props;
   const {
     newselections,
@@ -139,7 +139,7 @@ const PictureInPictureViewer = props => {
       hoverHooks={hoverHooks}
       onViewStateChange={onViewStateChange}
       onHover={onHover}
-      glOptions={glOptions}
+      deckProps={deckProps}
     />
   );
 };

--- a/src/viewers/SideBySideViewer.jsx
+++ b/src/viewers/SideBySideViewer.jsx
@@ -32,7 +32,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition: Default: ['t', 'z'].
- * @param {Object} [props.deckProps] Additional options used when creating the DeckGL component.
+ * @param {Object} [props.deckProps] Additional options used when creating the DeckGL component.  See [the deck.gl docs.](https://deck.gl/docs/api-reference/core/deck#initialization-settings).  `layerFilter`, `layers`, `onViewStateChange`, `views`, `viewState`, `useDevicePixels`, and `getCursor` are already set.
  */
 const SideBySideViewer = props => {
   const {

--- a/src/viewers/SideBySideViewer.jsx
+++ b/src/viewers/SideBySideViewer.jsx
@@ -32,7 +32,7 @@ import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../constants';
  * @param {import('./VivViewer').Hover} [props.onHover] Callback that returns the picking info and the event (https://deck.gl/docs/api-reference/core/layer#onhover
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {Array} [props.transitionFields] A string array indicating which fields require a transition: Default: ['t', 'z'].
- * @param {Object} [props.glOptions] Additional options used when creating the WebGLContext.
+ * @param {Object} [props.deckProps] Additional options used when creating the DeckGL component.
  */
 const SideBySideViewer = props => {
   const {
@@ -57,7 +57,7 @@ const SideBySideViewer = props => {
     onHover,
     transitionFields = GLOBAL_SLIDER_DIMENSION_FIELDS,
     onViewportLoad,
-    glOptions
+    deckProps
   } = props;
   const {
     newselections,
@@ -127,7 +127,7 @@ const SideBySideViewer = props => {
       onViewStateChange={onViewStateChange}
       onHover={onHover}
       viewStates={viewStates}
-      glOptions={glOptions}
+      deckProps={deckProps}
     />
   ) : null;
 };

--- a/src/viewers/VivViewer.jsx
+++ b/src/viewers/VivViewer.jsx
@@ -277,7 +277,7 @@ class VivViewerWrapper extends PureComponent {
 
   render() {
     /* eslint-disable react/destructuring-assignment */
-    const { views, randomize, useDevicePixels = true, glOptions } = this.props;
+    const { views, randomize, useDevicePixels = true, deckProps } = this.props;
     const { viewStates } = this.state;
     const deckGLViews = views.map(view => view.getDeckGlView());
     // DeckGL seems to use the first view more than the second for updates
@@ -299,7 +299,8 @@ class VivViewerWrapper extends PureComponent {
     }
     return (
       <DeckGL
-        glOptions={glOptions ?? {}}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...deckProps ?? {}}
         layerFilter={this.layerFilter}
         layers={this._renderLayers()}
         onViewStateChange={this._onViewStateChange}
@@ -326,7 +327,7 @@ class VivViewerWrapper extends PureComponent {
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {HoverHooks} [props.hoverHooks] Object including utility hooks - an object with key handleValue like { handleValue: (valueArray) => {}, handleCoordinate: (coordinate) => {} } where valueArray
  * has the pixel values for the image under the hover location and coordinate is the coordinate in the image from which the values are picked.
- * @param {Object} [props.glOptions] Additional options used when creating the WebGLContext.
+ * @param {Object} [props.deckProps] Additional options used when creating the DeckGL component.
  */
 // eslint-disable-next-line react/jsx-props-no-spreading
 const VivViewer = props => <VivViewerWrapper {...props} />;

--- a/src/viewers/VivViewer.jsx
+++ b/src/viewers/VivViewer.jsx
@@ -327,7 +327,7 @@ class VivViewerWrapper extends PureComponent {
  *     https://deck.gl/docs/developer-guide/interactivity#the-picking-info-object)
  * @param {HoverHooks} [props.hoverHooks] Object including utility hooks - an object with key handleValue like { handleValue: (valueArray) => {}, handleCoordinate: (coordinate) => {} } where valueArray
  * has the pixel values for the image under the hover location and coordinate is the coordinate in the image from which the values are picked.
- * @param {Object} [props.deckProps] Additional options used when creating the DeckGL component.
+ * @param {Object} [props.deckProps] Additional options used when creating the DeckGL component.  See [the deck.gl docs.](https://deck.gl/docs/api-reference/core/deck#initialization-settings).  `layerFilter`, `layers`, `onViewStateChange`, `views`, `viewState`, `useDevicePixels`, and `getCursor` are already set.
  */
 // eslint-disable-next-line react/jsx-props-no-spreading
 const VivViewer = props => <VivViewerWrapper {...props} />;

--- a/src/viewers/VivViewer.jsx
+++ b/src/viewers/VivViewer.jsx
@@ -300,7 +300,7 @@ class VivViewerWrapper extends PureComponent {
     return (
       <DeckGL
         // eslint-disable-next-line react/jsx-props-no-spreading
-        {...deckProps ?? {}}
+        {...(deckProps ?? {})}
         layerFilter={this.layerFilter}
         layers={this._renderLayers()}
         onViewStateChange={this._onViewStateChange}


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #503
<!-- For all the PRs -->
#### Change List
- Add `deckProps` prop to viewer components
- Remove `glOptions` prop (which can be set via `deckProps`)
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
