### PR TITLE
feat(Avivator): add basic ome-ngff support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Expose `DECKGL_FILTER_COLOR`, `DECKGL_PROCESS_INTENSITY`, AND `DECKGL_MUTATE_COLOR` hooks and document them.
 - Upgrade deck.gl to 8.6
 - Add `@data` alias for serving local data during development
+- Support basic OME-NGFF in Avivator
 
 ### Changed
 - Remove special selection mechanism in `Viewers`/`Views` by using deck.gl's fixed `TileLayer` capabilities for caching the tileset.

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -100,11 +100,10 @@ export async function createLoader(
       );
     }
 
-    const source = await loadBioformatsZarr(urlOrFile).catch(async _ => {
+    const source = await loadBioformatsZarr(urlOrFile).catch(async () => {
       // try ome-zarr
       const res = await loadOmeZarr(urlOrFile, { type: 'multiscales' });
-      // extract metadata into form expected for OME-TIFF
-      console.log(res.metadata);
+      // extract metadata into OME-XML-like form
       const metadata = {
         Pixels: {
           Channels: res.metadata.omero.channels.map(c => ({

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -5,6 +5,7 @@ import { Matrix4 } from '@math.gl/core';
 import {
   loadOmeTiff,
   loadBioformatsZarr,
+  loadOmeZarr,
   getChannelStats
   // eslint-disable-next-line import/no-unresolved
 } from '@hms-dbmi/viv';
@@ -99,7 +100,21 @@ export async function createLoader(
       );
     }
 
-    const source = await loadBioformatsZarr(urlOrFile);
+    const source = await loadBioformatsZarr(urlOrFile).catch(async _ => {
+      // try ome-zarr
+      const res = await loadOmeZarr(urlOrFile, { type: 'multiscales' });
+      // extract metadata into form expected for OME-TIFF
+      console.log(res.metadata);
+      const metadata = {
+        Pixels: {
+          Channels: res.metadata.omero.channels.map(c => ({
+            Name: c.label,
+            SamplesPerPixel: 1
+          }))
+        }
+      };
+      return { data: res.data, metadata };
+    });
     return source;
   } catch (e) {
     if (e instanceof UnsupportedBrowserError) {


### PR DESCRIPTION
Keeps previous behavior, but now also tries to load multiscale OME-NGFF if loading bioformats fails. 

You can test this PR by loading the sub-resolution of the current Zarr example, which adheres to the OME-NGFF (v0.2) spec. It's important to note that the latest NGFF (v0.3) spec does not require there to be `omero` metadata, which is relied on here to fill in channel names, and also allows for non 5D images. Additionally rendering information from the omero metadata is ignored.

- http://localhost:3000/?image_url=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr
- http://localhost:3000/?image_url=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001251.zarr

<img width="1007" alt="Screen Shot 2021-11-22 at 12 33 19 AM" src="https://user-images.githubusercontent.com/24403730/142806164-d07bac6c-5d71-4adc-a5d1-d2cc3b0e42c1.png">


You can try more links from here: https://www.openmicroscopy.org/2020/11/04/zarr-data.html