### PR TITLE
Use OME-Zarr multiscales[].axes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+*.tgz
 
 npm-debug.log*
 yarn-debug.log*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 - Add `@data` alias for serving local data during development
 - Add Avivator video tutorial to README.md
 - Support basic OME-NGFF in Avivator
-  - Add support for the `multiscales[].axes` field introduced in OME-NGFF v0.3
-  - Bump zarr.js to get support for both `/` and `.` dimension separators
+- Add support for the `multiscales[].axes` field introduced in OME-NGFF v0.3
+- Bump zarr.js to get support for both `/` and `.` dimension separators
 
 ### Changed
 - Remove special selection mechanism in `Viewers`/`Views` by using deck.gl's fixed `TileLayer` capabilities for caching the tileset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Add `@data` alias for serving local data during development
 - Add Avivator video tutorial to README.md
 - Support basic OME-NGFF in Avivator
+  - Add support for the `multiscales[].axes` field introduced in OME-NGFF v0.3
+  - Bump zarr.js to get support for both `/` and `.` dimension separators
 
 ### Changed
 - Remove special selection mechanism in `Viewers`/`Views` by using deck.gl's fixed `TileLayer` capabilities for caching the tileset.

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -116,7 +116,7 @@ export async function createLoader(
         }
       };
       source = { data: res.data, metadata };
-    };
+    }
     return source;
   } catch (e) {
     if (e instanceof UnsupportedBrowserError) {

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -100,7 +100,10 @@ export async function createLoader(
       );
     }
 
-    const source = await loadBioformatsZarr(urlOrFile).catch(async () => {
+    let source;
+    try {
+      source = await loadBioformatsZarr(urlOrFile);
+    } catch {
       // try ome-zarr
       const res = await loadOmeZarr(urlOrFile, { type: 'multiscales' });
       // extract metadata into OME-XML-like form
@@ -112,8 +115,8 @@ export async function createLoader(
           }))
         }
       };
-      return { data: res.data, metadata };
-    });
+      source = { data: res.data, metadata };
+    };
     return source;
   } catch (e) {
     if (e instanceof UnsupportedBrowserError) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11277,12 +11277,9 @@
       "dev": true
     },
     "numcodecs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.1.1.tgz",
-      "integrity": "sha512-UjKulZ6GIFKLdBIczEbsoXNZQmiHafpoIdo39YcdecHVGyMKh0+azsfHTrybXm5RZwepqLZv24mkjqGdZGm24Q==",
-      "requires": {
-        "pako": "^1.0.11"
-      }
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
+      "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -11608,7 +11605,8 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -16113,11 +16111,11 @@
       "dev": true
     },
     "zarr": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.4.0.tgz",
-      "integrity": "sha512-zvxdX3aRWxjy6H3OtA7R05NNZvRKxn/7bkNJhUsVKKbNoJ3DBqYERQfzI4WfAV1OTcclqvlYwkQ7DWsGJA5QEw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.5.1.tgz",
+      "integrity": "sha512-eL7S5gza/ednVr9wJMd5UF7jcc72qgMlMxuHbFYkWWX9dvb7n0SJL6PS3dCJ5TqyRSamCpAm+ssuodcL4uBTUQ==",
       "requires": {
-        "numcodecs": "^0.1.0",
+        "numcodecs": "^0.2.1",
         "p-queue": "6.2.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "geotiff": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.2.tar.gz",
     "math.gl": "^3.3.0",
     "quickselect": "^2.0.0",
-    "zarr": "^0.4.0"
+    "zarr": "^0.5.1"
   },
   "prettier": {
     "singleQuote": true,

--- a/src/loaders/zarr/lib/utils.ts
+++ b/src/loaders/zarr/lib/utils.ts
@@ -3,6 +3,7 @@ import type { ZarrArray } from 'zarr';
 import type { OMEXML } from '../../omexml';
 import { getLabels, isInterleaved, prevPowerOf2 } from '../../utils';
 
+import type { Labels } from '../../../types';
 import type { RootAttrs } from '../ome-zarr';
 
 /*
@@ -74,15 +75,21 @@ export async function loadMultiscales(store: ZarrArray['store'], path = '') {
   const rootAttrs = (await grp.attrs.asObject()) as RootAttrs;
 
   let paths = ['0'];
+  // Default axes used for v0.1 and v0.2.
+  let labels = ['t', 'c', 'z', 'y', 'x'] as Labels<string[]>;
   if ('multiscales' in rootAttrs) {
-    const { datasets } = rootAttrs.multiscales[0];
+    const { datasets, axes } = rootAttrs.multiscales[0];
     paths = datasets.map(d => d.path);
+    if(axes) {
+      labels = axes;
+    }
   }
 
   const data = paths.map(path => grp.getItem(path));
   return {
     data: (await Promise.all(data)) as ZarrArray[],
-    rootAttrs
+    rootAttrs,
+    labels,
   };
 }
 

--- a/src/loaders/zarr/lib/utils.ts
+++ b/src/loaders/zarr/lib/utils.ts
@@ -80,7 +80,7 @@ export async function loadMultiscales(store: ZarrArray['store'], path = '') {
   if ('multiscales' in rootAttrs) {
     const { datasets, axes } = rootAttrs.multiscales[0];
     paths = datasets.map(d => d.path);
-    if(axes) {
+    if (axes) {
       labels = axes;
     }
   }
@@ -89,7 +89,7 @@ export async function loadMultiscales(store: ZarrArray['store'], path = '') {
   return {
     data: (await Promise.all(data)) as ZarrArray[],
     rootAttrs,
-    labels,
+    labels
   };
 }
 

--- a/src/loaders/zarr/ome-zarr.ts
+++ b/src/loaders/zarr/ome-zarr.ts
@@ -1,7 +1,7 @@
 import type { ZarrArray } from 'zarr';
+import type { Labels } from '../../types';
 import { loadMultiscales, guessTileSize } from './lib/utils';
 import ZarrPixelSource from './pixel-source';
-import type { Labels } from '../../types';
 
 interface Channel {
   channelsVisible: boolean;
@@ -27,6 +27,7 @@ interface Omero {
 
 interface Multiscale {
   datasets: { path: string }[];
+  axes?: Labels<string[]>;
   version?: string;
 }
 
@@ -36,8 +37,7 @@ export interface RootAttrs {
 }
 
 export async function load(store: ZarrArray['store']) {
-  const { data, rootAttrs } = await loadMultiscales(store);
-  const labels = ['t', 'c', 'z', 'y', 'x'] as Labels<['t', 'c', 'z']>;
+  const { data, rootAttrs, labels } = await loadMultiscales(store);
   const tileSize = guessTileSize(data[0]);
   const pyramid = data.map(arr => new ZarrPixelSource(arr, labels, tileSize));
   return {


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
This pull request adds support for OME-NGFF v0.3 images:
- bump zarr.js to get support for "/" as a dimension separator 
- use multiscales[].axes to get the dimension ordering if available
- fix the catch statement in avivator

To try it, open https://minio-dev.openmicroscopy.org/idr/v0.3/idr0062-blin-nuclearsegmentation/6001240.zarr in avivator

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
