### PR TITLE
Update TIFF Offsets Snackbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Update tutorial
 - Clean up README.md with latest additions to Viv
 - Bold format names in README
-- Update snackbar.
+- Add description of "Indexed TIFF" to Avivator snackbar warning when offsets are missing
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Update tutorial
 - Clean up README.md with latest additions to Viv
 - Bold format names in README
+- Update snackbar.
 
 ## 0.11.0
 

--- a/avivator/src/components/Snackbars/SnackbarAlerts.jsx
+++ b/avivator/src/components/Snackbars/SnackbarAlerts.jsx
@@ -11,9 +11,9 @@ export function OffsetsWarning() {
       <Link
         target="_blank"
         rel="noopener noreferrer"
-        href="http://viv.gehlenborglab.org/#data-preparation"
+        href="http://viv.gehlenborglab.org/#indexed-tiff"
       >
-        here
+       in this section of our documentation 
       </Link>{' '}
       and then place the offsets.json adjacent to the OME-TIFF wherever hosted.
     </>

--- a/avivator/src/components/Snackbars/SnackbarAlerts.jsx
+++ b/avivator/src/components/Snackbars/SnackbarAlerts.jsx
@@ -5,9 +5,10 @@ import Link from '@material-ui/core/Link';
 export function OffsetsWarning() {
   return (
     <>
-      A lot of channels have been detected in the requested OME-TIFF. To learn
-      how to speed up load times by providing byte offsets, refer to the point
-      about &quot;Indexed TIFF&quot;{' '}
+      Avivator could not find an IFD index for the requested OME-TIFF, and
+      therefore longer latencies are expected. Please read our documentation on
+      &quot;Indexed TIFF&quot; to generate an IFD index for your OME-TIFF and
+      improve initial load times.
       <Link
         target="_blank"
         rel="noopener noreferrer"

--- a/avivator/src/components/Snackbars/SnackbarAlerts.jsx
+++ b/avivator/src/components/Snackbars/SnackbarAlerts.jsx
@@ -6,12 +6,12 @@ export function OffsetsWarning() {
   return (
     <>
       A lot of channels have been detected in the requested OME-TIFF. To learn
-      how to speed up load times by providing byte offsets, refer to the first
-      point{' '}
+      how to speed up load times by providing byte offsets, refer to the point
+      about indexed TIFF{' '}
       <Link
         target="_blank"
         rel="noopener noreferrer"
-        href="http://viv.gehlenborglab.org/#ome-tiff-loading"
+        href="http://viv.gehlenborglab.org/#data-preparation"
       >
         here
       </Link>{' '}

--- a/avivator/src/components/Snackbars/SnackbarAlerts.jsx
+++ b/avivator/src/components/Snackbars/SnackbarAlerts.jsx
@@ -7,7 +7,7 @@ export function OffsetsWarning() {
     <>
       A lot of channels have been detected in the requested OME-TIFF. To learn
       how to speed up load times by providing byte offsets, refer to the point
-      about indexed TIFF{' '}
+      about "Indexed TIFF"{' '}
       <Link
         target="_blank"
         rel="noopener noreferrer"

--- a/avivator/src/components/Snackbars/SnackbarAlerts.jsx
+++ b/avivator/src/components/Snackbars/SnackbarAlerts.jsx
@@ -13,7 +13,7 @@ export function OffsetsWarning() {
         rel="noopener noreferrer"
         href="http://viv.gehlenborglab.org/#data-preparation"
       >
-       in this section of our documentation 
+        in this section of our documentation
       </Link>{' '}
       and then place the offsets.json adjacent to the OME-TIFF wherever hosted.
     </>

--- a/avivator/src/components/Snackbars/SnackbarAlerts.jsx
+++ b/avivator/src/components/Snackbars/SnackbarAlerts.jsx
@@ -7,7 +7,7 @@ export function OffsetsWarning() {
     <>
       A lot of channels have been detected in the requested OME-TIFF. To learn
       how to speed up load times by providing byte offsets, refer to the point
-      about "Indexed TIFF"{' '}
+      about &quot;Indexed TIFF&quot;{' '}
       <Link
         target="_blank"
         rel="noopener noreferrer"

--- a/avivator/src/components/Snackbars/SnackbarAlerts.jsx
+++ b/avivator/src/components/Snackbars/SnackbarAlerts.jsx
@@ -11,7 +11,7 @@ export function OffsetsWarning() {
       <Link
         target="_blank"
         rel="noopener noreferrer"
-        href="http://viv.gehlenborglab.org/#indexed-tiff"
+        href="http://viv.gehlenborglab.org/#data-preparation"
       >
        in this section of our documentation 
       </Link>{' '}

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -69,7 +69,7 @@ Therefore for larger images, please use `bioformats2raw + raw2ometiff`.
 > by `raw2ometiff` - `LZW`, `zlib`, and `Uncompressed` as well as `jpeg` compression for 8 bit data. Support
 > for JPEG-2000 for >8 bit data is planned. Please open an issue if you would like this more immediately.
 
-### Indexed TIFF
+### Indexed OME-TIFF
 
 The TIFF file format is not designed for the cloud, and therefore certain images are less suitable to be natively read remotely. If your OME-TIFF image contains large non-XY dimensions (e.g. Z=100, T=50), you are likely to experience latencies when switching planes in Avivator due to seeking the file over HTTP. We recommend generating an index (`offsets.json`) that contains the byte-offsets for each plane to complement OME-TIFF, solving this latency issue and enabling fast interactions.
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -69,12 +69,17 @@ Therefore for larger images, please use `bioformats2raw + raw2ometiff`.
 > by `raw2ometiff` - `LZW`, `zlib`, and `Uncompressed` as well as `jpeg` compression for 8 bit data. Support
 > for JPEG-2000 for >8 bit data is planned. Please open an issue if you would like this more immediately.
 
+#### Indexed TIFF
+
 The TIFF file format is not designed for the cloud, and therefore certain images are less suitable to be natively read remotely. If your OME-TIFF image contains large non-XY dimensions (e.g. Z=100, T=50), you are likely to experience latencies when switching planes in Avivator due to seeking the file over HTTP. We recommend generating an index (`offsets.json`) that contains the byte-offsets for each plane to complement OME-TIFF, solving this latency issue and enabling fast interactions.
 
  ```bash
  $ pip install generate-tiff-offsets
  $ generate_tiff_offsets --input_file Luca-7color_Scan1.ome.tif 
  ```
+
+Alternatively you may use our [web application](https://hms-dbmi.github.io/generate-tiff-offsets) for generating the offsets.
+
 > ⚠️ IMPORTANT ⚠️ 
 Avivator requires the `offsets.json` file to be adjacent to the OME-TIFF on the server in order to leverage this feature. For example, if an index is generated for the dataset in this tutorial, the following directory structure is correct:
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -69,7 +69,7 @@ Therefore for larger images, please use `bioformats2raw + raw2ometiff`.
 > by `raw2ometiff` - `LZW`, `zlib`, and `Uncompressed` as well as `jpeg` compression for 8 bit data. Support
 > for JPEG-2000 for >8 bit data is planned. Please open an issue if you would like this more immediately.
 
-#### Indexed TIFF
+### Indexed TIFF
 
 The TIFF file format is not designed for the cloud, and therefore certain images are less suitable to be natively read remotely. If your OME-TIFF image contains large non-XY dimensions (e.g. Z=100, T=50), you are likely to experience latencies when switching planes in Avivator due to seeking the file over HTTP. We recommend generating an index (`offsets.json`) that contains the byte-offsets for each plane to complement OME-TIFF, solving this latency issue and enabling fast interactions.
 


### PR DESCRIPTION
#### Background
I noticed (a) our snackbar for `offsets.json` was lacking a working URL and (b) the documentation could be updated slightly to include both a clearer section and a link to your web app.

#### Change List
- Update docs to include link to indexing web app and make section heading clear for indexed TIFF
- Fix snackbar URL

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
