### PR TITLE
Fix `onViewportLoad` callback for `MultiscaleImageLayer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Bold format names in README
 - Add description of "Indexed TIFF" to Avivator snackbar warning when offsets are missing
 - Refactor `zustand` stores to follow best practice in Avivator.
+- Fix `onViewportLoad` callback for `MultiscaleImageLayer`
 
 ## 0.11.0
 

--- a/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
+++ b/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js
@@ -197,12 +197,14 @@ const MultiscaleImageLayer = class extends CompositeLayer {
           // since the background image might not have the same color output from the fragment shader
           // as the tiled layer at a higher resolution level.
           !transparentColor,
-        pickable: { type: 'boolean', value: true, compare: true },
         onHover,
         onClick,
         // Background image is nicest when LINEAR in my opinion.
         interpolation: GL.LINEAR,
-        extensions: []
+        extensions: [],
+        // If the background image loads before the multiscale image,
+        // We don't want this to be called.
+        onViewportLoad: null
       });
     const layers = [baseLayer, tiledLayer];
     return layers;


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
Becuase the `onViewportLoad` call back is passed to the background layer, it can be called before the actual layer loads.  This only became noticeable once we upgraded to deck.gl 8.6 since the whole layer no longer clears on selection changes.

#### Change List
- Set `onViewportLoad` to `null` for background layer.

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
