### PR TITLE
Fix Viv 0.12 types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 - Fix image links in README.md.
 - Add extensions to docs.
+- Fix exported types for Viv v0.12.
 
 ## 0.12.0
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,9 +53,9 @@ export interface PixelSource<S extends string[]> {
   meta?: PixelSourceMeta;
 }
 
+// Not exported types. Used below with `Viv` utility type.
 type Color = [r: number, g: number, b: number];
 
-// Not exported types. Used below with `Viv` utility type.
 type ColorPaletteExtensionProps = {
   colors: Color[];
   opacity: number;
@@ -74,7 +74,7 @@ type LensExtensionProps = {
   lensSelection: number;
   lensRadius: number;
   lensBorderRadius: number;
-  colors: Color[]
+  colors: Color[];
   lensBorderColor: Color;
 };
 
@@ -99,9 +99,11 @@ type ExtractLoader<LayerProps, S extends string[]> = LayerProps extends {
 
 // if loader is defined on layer, it is a extension-able layer and we should extend
 type WithExtensionProps<LayerProps> = LayerProps extends { loader: unknown }
-  ? Partial<ColorPaletteExtensionProps &
-      AdditiveColormapExtensionProps &
-      LensExtensionProps> & { [extensionProp: string]: any }
+  ? Partial<
+      ColorPaletteExtensionProps &
+        AdditiveColormapExtensionProps &
+        LensExtensionProps
+    > & { [extensionProp: string]: any }
   : {};
 
 /**
@@ -117,4 +119,6 @@ type WithExtensionProps<LayerProps> = LayerProps extends { loader: unknown }
 export type Viv<LayerProps, S extends string[] = string[]> = Override<
   Omit<LayerProps, 'loader'>,
   PreciseLayerProps<S>
-> & ExtractLoader<LayerProps, S> & WithExtensionProps<LayerProps>;
+> &
+  ExtractLoader<LayerProps, S> &
+  WithExtensionProps<LayerProps>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,8 +97,8 @@ type ExtractLoader<LayerProps, S extends string[]> = LayerProps extends {
   ? { loader: PixelSource<S> }
   : {};
 
-// if loader is defined on layer, it is a extension-able layer and we should extend
-type WithExtensionProps<LayerProps> = LayerProps extends { loader: unknown }
+// Add optional extention props to layer if 'extensions' is defined on LayerProps.
+type WithExtensionProps<LayerProps> = LayerProps extends { extensions: unknown }
   ? Partial<
       ColorPaletteExtensionProps &
         AdditiveColormapExtensionProps &


### PR DESCRIPTION
Latest types don't have the desired effect (tested in Vizarr). The `Viv` type refines only the properties that are defined on the JSdoc `LayerProps` for the the corresponding layer. This PR refactors the types and conditionally adds the optional extension props if `loader` is defined for the layerprops.