### PR TITLE
Multiple OME Images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 ## In Progress
 
 ### Added
+
 - Setup workflow to deploy Avivator via GitHub Pages.
+- Support multiple images within an OME-TIFF file
 
 ### Changed
+
 - Fix image links in README.md.
 - Add extensions to docs.
 - Fix broken GH-pages workflow.

--- a/avivator/src/Avivator.jsx
+++ b/avivator/src/Avivator.jsx
@@ -28,7 +28,7 @@ export default function Avivator(props) {
       source: initSource,
       isNoImageUrlSnackbarOn: isDemoImage
     });
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
   useImage(source, history);
   return (
     <>

--- a/avivator/src/components/Controller/Controller.jsx
+++ b/avivator/src/components/Controller/Controller.jsx
@@ -193,7 +193,7 @@ const Controller = () => {
       <Divider />
       <TabPanel value={tab} index={0}>
         {useColormap && <ColormapSelect />}
-        {useLens && !colormap && shape[labels.indexOf('c')] > 1 && (
+        {useLens && !colormap && !use3d && shape[labels.indexOf('c')] > 1 && (
           <LensSelect
             channelOptions={selections.map(sel => channelOptions[sel.c])}
           />

--- a/avivator/src/components/Controller/Controller.jsx
+++ b/avivator/src/components/Controller/Controller.jsx
@@ -23,7 +23,9 @@ import CameraOptions from './components/CameraOptions';
 import {
   useChannelsStore,
   useViewerStore,
-  useImageSettingsStore
+  useImageSettingsStore,
+  useLoader,
+  useMetadata
 } from '../../state';
 import { guessRgb, useWindowSize, getSingleSelectionStats } from '../../utils';
 import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../../constants';
@@ -52,7 +54,6 @@ const Controller = () => {
     colors,
     domains,
     selections,
-    loader,
     ids,
     setPropertiesForChannel,
     toggleIsOnSetter,
@@ -64,7 +65,6 @@ const Controller = () => {
       store.colors,
       store.domains,
       store.selections,
-      store.loader,
       store.ids,
       store.setPropertiesForChannel,
       store.toggleIsOn,
@@ -72,10 +72,10 @@ const Controller = () => {
     ],
     shallow
   );
+  const loader = useLoader();
 
   const colormap = useImageSettingsStore(store => store.colormap);
   const [
-    metadata,
     channelOptions,
     useLinkedView,
     use3d,
@@ -88,7 +88,6 @@ const Controller = () => {
     isViewerLoading
   ] = useViewerStore(
     store => [
-      store.metadata,
       store.channelOptions,
       store.useLinkedView,
       store.use3d,
@@ -102,6 +101,7 @@ const Controller = () => {
     ],
     shallow
   );
+  const metadata = useMetadata();
   const viewSize = useWindowSize();
   const isRgb = metadata && guessRgb(metadata);
   const { shape, labels } = loader[0];

--- a/avivator/src/components/Controller/components/AddChannel.jsx
+++ b/avivator/src/components/Controller/components/AddChannel.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import Button from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/Add';
 import shallow from 'zustand/shallow';
@@ -7,7 +7,8 @@ import { MAX_CHANNELS } from '../../../constants';
 import {
   useChannelsStore,
   useViewerStore,
-  useImageSettingsStore
+  useImageSettingsStore,
+  useLoader
 } from '../../../state';
 import { getSingleSelectionStats } from '../../../utils';
 
@@ -28,22 +29,17 @@ const AddChannel = () => {
     ],
     shallow
   );
-  const [
-    loader,
-    selections,
-    addChannel,
-    setPropertiesForChannel
-  ] = useChannelsStore(
+  const [selections, addChannel, setPropertiesForChannel] = useChannelsStore(
     store => [
-      store.loader,
       store.selections,
       store.addChannel,
       store.setPropertiesForChannel
     ],
     shallow
   );
+  const loader = useLoader();
   const { labels } = loader[0];
-  const handleChannelAdd = () => {
+  const handleChannelAdd = useCallback(() => {
     let selection = Object.fromEntries(labels.map(l => [l, 0]));
     selection = { ...selection, ...globalSelection };
     const numSelectionsBeforeAdd = selections.length;
@@ -70,7 +66,7 @@ const AddChannel = () => {
         channelsVisible: false
       });
     });
-  };
+  }, [labels, loader, globalSelection, use3d]);
   return (
     <Button
       disabled={selections.length === MAX_CHANNELS || isViewerLoading}

--- a/avivator/src/components/Controller/components/AddChannel.jsx
+++ b/avivator/src/components/Controller/components/AddChannel.jsx
@@ -66,7 +66,17 @@ const AddChannel = () => {
         channelsVisible: false
       });
     });
-  }, [labels, loader, globalSelection, use3d]);
+  }, [
+    labels,
+    loader,
+    globalSelection,
+    use3d,
+    addChannel,
+    addIsChannelLoading,
+    selections,
+    setIsChannelLoading,
+    setPropertiesForChannel
+  ]);
   return (
     <Button
       disabled={selections.length === MAX_CHANNELS || isViewerLoading}

--- a/avivator/src/components/Controller/components/CameraOptions.jsx
+++ b/avivator/src/components/Controller/components/CameraOptions.jsx
@@ -11,7 +11,6 @@ import { getDefaultInitialViewState } from '@hms-dbmi/viv';
 import {
   useImageSettingsStore,
   useViewerStore,
-  useChannelsStore,
   useLoader
 } from '../../../state';
 import { useWindowSize } from '../../../utils';

--- a/avivator/src/components/Controller/components/CameraOptions.jsx
+++ b/avivator/src/components/Controller/components/CameraOptions.jsx
@@ -11,7 +11,8 @@ import { getDefaultInitialViewState } from '@hms-dbmi/viv';
 import {
   useImageSettingsStore,
   useViewerStore,
-  useChannelsStore
+  useChannelsStore,
+  useLoader
 } from '../../../state';
 import { useWindowSize } from '../../../utils';
 
@@ -28,7 +29,7 @@ const useStyles = makeStyles(theme =>
 );
 
 const CameraOptions = () => {
-  const loader = useChannelsStore(store => store.loader);
+  const loader = useLoader();
   const [useFixedAxis, toggleUseFixedAxis] = useImageSettingsStore(
     store => [store.useFixedAxis, store.toggleUseFixedAxis],
     shallow

--- a/avivator/src/components/Controller/components/ChannelController.jsx
+++ b/avivator/src/components/Controller/components/ChannelController.jsx
@@ -10,7 +10,7 @@ import shallow from 'zustand/shallow';
 import ChannelOptions from './ChannelOptions';
 import { FILL_PIXEL_VALUE } from '../../../constants';
 import {
-  useChannelsStore,
+  useLoader,
   useImageSettingsStore,
   useViewerStore
 } from '../../../state';
@@ -54,7 +54,7 @@ function ChannelController({
   handleColorSelect,
   isLoading
 }) {
-  const loader = useChannelsStore(store => store.loader);
+  const loader = useLoader();
   const colormap = useImageSettingsStore(store => store.colormap);
   const [channelOptions, useLinkedView, use3d] = useViewerStore(
     store => [store.channelOptions, store.useLinkedView, store.use3d],

--- a/avivator/src/components/Controller/components/GlobalSelectionSlider.jsx
+++ b/avivator/src/components/Controller/components/GlobalSelectionSlider.jsx
@@ -8,15 +8,17 @@ import { range, getMultiSelectionStats } from '../../../utils';
 import {
   useChannelsStore,
   useViewerStore,
-  useImageSettingsStore
+  useImageSettingsStore,
+  useLoader
 } from '../../../state';
 
 export default function GlobalSelectionSlider(props) {
   const { size, label } = props;
-  const [selections, loader, setPropertiesForChannel] = useChannelsStore(
-    store => [store.selections, store.loader, store.setPropertiesForChannel],
+  const [selections, setPropertiesForChannel] = useChannelsStore(
+    store => [store.selections, , store.setPropertiesForChannel],
     shallow
   );
+  const loader = useLoader();
   const globalSelection = useViewerStore(store => store.globalSelection);
   const changeSelection = debounce(
     (event, newValue) => {

--- a/avivator/src/components/Controller/components/Menu.jsx
+++ b/avivator/src/components/Controller/components/Menu.jsx
@@ -13,11 +13,12 @@ import Button from '@material-ui/core/Button';
 import SettingsIcon from '@material-ui/icons/Settings';
 import { makeStyles } from '@material-ui/core/styles';
 import shallow from 'zustand/shallow';
+import { Select } from '@material-ui/core';
 
 import MenuTitle from './MenuTitle';
 import DropzoneButton from './DropzoneButton';
 import { isMobileOrTablet, getNameFromUrl } from '../../../utils';
-import { useViewerStore } from '../../../state';
+import { useChannelsStore, useViewerStore } from '../../../state';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -51,7 +52,11 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function Header(props) {
-  const source = useViewerStore(store => store.source);
+  const image = useChannelsStore(store => store.image);
+  const [source, metadata] = useViewerStore(store => [
+    store.source,
+    store.metadata
+  ]);
   const handleSubmitNewUrl = (event, newUrl) => {
     event.preventDefault();
     const newSource = {
@@ -61,6 +66,10 @@ function Header(props) {
     };
     useViewerStore.setState({ source: newSource });
   };
+  const onImageSelectionChange = e =>
+    useChannelsStore.setState({
+      image: e.target.value
+    });
   const url = typeof source.urlOrFile === 'string' ? source.urlOrFile : '';
   const [text, setText] = useState(url);
   const [open, toggle] = useReducer(v => !v, false);
@@ -127,6 +136,17 @@ function Header(props) {
       {!isMobileOrTablet() && (
         <Grid item xs={12} style={{ paddingTop: 16 }}>
           <DropzoneButton />
+        </Grid>
+      )}
+      {Array.isArray(metadata) && (
+        <Grid item xs={12}>
+          <Select native value={image} onChange={onImageSelectionChange}>
+            {metadata.map((meta, i) => (
+              <option key={meta.Name} value={i}>
+                {meta.Name}
+              </option>
+            ))}
+          </Select>
         </Grid>
       )}
       <Grid item xs={12} className={classes.divider}>

--- a/avivator/src/components/Controller/components/Slicer.jsx
+++ b/avivator/src/components/Controller/components/Slicer.jsx
@@ -8,7 +8,8 @@ import shallow from 'zustand/shallow';
 import {
   useImageSettingsStore,
   useChannelsStore,
-  useViewerStore
+  useViewerStore,
+  useLoader
 } from '../../../state';
 import { getBoundingCube, truncateDecimalNumber } from '../../../utils';
 
@@ -35,7 +36,7 @@ const Slicer = () => {
     store => [store.xSlice, store.ySlice, store.zSlice],
     shallow
   );
-  const loader = useChannelsStore(store => store.loader);
+  const loader = useLoader();
   const use3d = useViewerStore(store => store.use3d);
   const [xSliceInit, ySliceInit, zSliceInit] = getBoundingCube(loader);
   const sliceValuesAndSetSliceFunctions = [

--- a/avivator/src/components/Controller/components/Slicer.jsx
+++ b/avivator/src/components/Controller/components/Slicer.jsx
@@ -7,7 +7,6 @@ import shallow from 'zustand/shallow';
 
 import {
   useImageSettingsStore,
-  useChannelsStore,
   useViewerStore,
   useLoader
 } from '../../../state';

--- a/avivator/src/components/Controller/components/VolumeButton.jsx
+++ b/avivator/src/components/Controller/components/VolumeButton.jsx
@@ -15,15 +15,9 @@ import {
   useImageSettingsStore,
   useViewerStore,
   useChannelsStore,
-  useLoader,
-  useMetadata
+  useLoader
 } from '../../../state';
-import {
-  range,
-  guessRgb,
-  getMultiSelectionStats,
-  getBoundingCube
-} from '../../../utils';
+import { range, getMultiSelectionStats, getBoundingCube } from '../../../utils';
 
 function formatBytes(bytes, decimals = 2) {
   if (bytes === 0) return '0 Bytes';
@@ -108,7 +102,6 @@ function VolumeButton() {
     ],
     shallow
   );
-  const metadata = useMetadata();
 
   const [open, toggle] = useReducer(v => !v, false);
   const anchorRef = useRef(null);

--- a/avivator/src/components/Controller/components/VolumeButton.jsx
+++ b/avivator/src/components/Controller/components/VolumeButton.jsx
@@ -14,7 +14,9 @@ import shallow from 'zustand/shallow';
 import {
   useImageSettingsStore,
   useViewerStore,
-  useChannelsStore
+  useChannelsStore,
+  useLoader,
+  useMetadata
 } from '../../../state';
 import {
   range,
@@ -87,26 +89,26 @@ const useStyles = makeStyles(() => ({
 }));
 
 function VolumeButton() {
-  const [loader, selections, setPropertiesForChannel] = useChannelsStore(
-    store => [store.loader, store.selections, store.setPropertiesForChannel],
+  const [selections, setPropertiesForChannel] = useChannelsStore(
+    store => [store.selections, store.setPropertiesForChannel],
     shallow
   );
+  const loader = useLoader();
   const [
     use3d,
     toggleUse3d,
-    metadata,
     toggleIsVolumeRenderingWarningOn,
     isViewerLoading
   ] = useViewerStore(
     store => [
       store.use3d,
       store.toggleUse3d,
-      store.metadata,
       store.toggleIsVolumeRenderingWarningOn,
       store.isViewerLoading
     ],
     shallow
   );
+  const metadata = useMetadata();
 
   const [open, toggle] = useReducer(v => !v, false);
   const anchorRef = useRef(null);

--- a/avivator/src/components/Controller/components/VolumeButton.jsx
+++ b/avivator/src/components/Controller/components/VolumeButton.jsx
@@ -151,9 +151,6 @@ function VolumeButton() {
               }
             );
             const isRgb = metadata && guessRgb(metadata);
-            if (!isRgb && metadata) {
-              useViewerStore.setState({ useLens: true });
-            }
           }
         }}
         fullWidth
@@ -228,7 +225,6 @@ function VolumeButton() {
                                 toggleIsVolumeRenderingWarningOn();
                               }
                             });
-                            useViewerStore.setState({ useLens: false });
                           }}
                           key={`(${height}, ${width}, ${depthDownsampled})`}
                         >

--- a/avivator/src/components/Controller/components/VolumeButton.jsx
+++ b/avivator/src/components/Controller/components/VolumeButton.jsx
@@ -150,7 +150,6 @@ function VolumeButton() {
                 });
               }
             );
-            const isRgb = metadata && guessRgb(metadata);
           }
         }}
         fullWidth

--- a/avivator/src/components/Footer.jsx
+++ b/avivator/src/components/Footer.jsx
@@ -6,11 +6,7 @@ import shallow from 'zustand/shallow';
 
 import { makeStyles } from '@material-ui/core/styles';
 
-import {
-  useImageSettingsStore,
-  useChannelsStore,
-  useViewerStore
-} from '../state';
+import { useImageSettingsStore, useLoader, useViewerStore } from '../state';
 
 const useStyles = makeStyles(theme => ({
   typography: {
@@ -34,7 +30,7 @@ export default function Footer() {
     store => [store.use3d, store.pyramidResolution],
     shallow
   );
-  const loader = useChannelsStore(store => store.loader);
+  const loader = useLoader();
   const volumeResolution = useImageSettingsStore(store => store.resolution);
 
   const resolution = use3d ? volumeResolution : pyramidResolution;

--- a/avivator/src/components/Viewer.jsx
+++ b/avivator/src/components/Viewer.jsx
@@ -13,7 +13,8 @@ import {
 import {
   useImageSettingsStore,
   useViewerStore,
-  useChannelsStore
+  useChannelsStore,
+  useLoader
 } from '../state';
 import { useWindowSize } from '../utils';
 import { DEFAULT_OVERVIEW } from '../constants';
@@ -27,18 +28,17 @@ const Viewer = () => {
     colors,
     contrastLimits,
     channelsVisible,
-    selections,
-    loader
+    selections
   ] = useChannelsStore(
     store => [
       store.colors,
       store.contrastLimits,
       store.channelsVisible,
-      store.selections,
-      store.loader
+      store.selections
     ],
     shallow
   );
+  const loader = useLoader();
   const viewSize = useWindowSize();
   const [
     lensSelection,

--- a/avivator/src/hooks.js
+++ b/avivator/src/hooks.js
@@ -24,10 +24,6 @@ export const useImage = (source, history) => {
     store => [store.use3d, store.toggleUse3d, store.toggleIsOffsetsSnackbarOn],
     shallow
   );
-  const [addChannels, resetChannels] = useChannelsStore(
-    store => [store.addChannels, store.resetChannels],
-    shallow
-  );
   const [lensEnabled, toggleLensEnabled] = useImageSettingsStore(
     store => [store.lensEnabled, store.toggleLensEnabled],
     shallow
@@ -115,7 +111,7 @@ export const useImage = (source, history) => {
         useViewerStore.setState({ useColormap: false, useLens: false });
       } else {
         const stats = await getMultiSelectionStats({
-          loader: loader,
+          loader,
           selections: newSelections,
           use3d
         });

--- a/avivator/src/hooks.js
+++ b/avivator/src/hooks.js
@@ -153,7 +153,7 @@ export const useImage = (source, history) => {
       });
     };
     if (metadata) changeSettings();
-  }, [loader, metadata]);
+  }, [loader, metadata]); // eslint-disable-line react-hooks/exhaustive-deps
 };
 
 export const useDropzone = () => {

--- a/avivator/src/hooks.js
+++ b/avivator/src/hooks.js
@@ -35,6 +35,7 @@ export const useImage = (source, history) => {
       // Placeholder
       useViewerStore.setState({ isChannelLoading: [true] });
       useViewerStore.setState({ isViewerLoading: true });
+      if (use3d) toggleUse3d();
       const { urlOrFile } = source;
       const newLoader = await createLoader(
         urlOrFile,
@@ -74,6 +75,7 @@ export const useImage = (source, history) => {
       // Placeholder
       useViewerStore.setState({ isChannelLoading: [true] });
       useViewerStore.setState({ isViewerLoading: true });
+      if (use3d) toggleUse3d();
       const newSelections = buildDefaultSelection(loader[0]);
       const { Channels } = metadata.Pixels;
       const channelOptions = Channels.map((c, i) => c.Name ?? `Channel ${i}`);
@@ -113,7 +115,7 @@ export const useImage = (source, history) => {
         const stats = await getMultiSelectionStats({
           loader,
           selections: newSelections,
-          use3d
+          use3d: false
         });
         newDomains = stats.domains;
         newContrastLimits = stats.contrastLimits;

--- a/avivator/src/hooks.js
+++ b/avivator/src/hooks.js
@@ -5,6 +5,8 @@ import shallow from 'zustand/shallow';
 import {
   useChannelsStore,
   useImageSettingsStore,
+  useLoader,
+  useMetadata,
   useViewerStore
 } from './state';
 import {
@@ -30,110 +32,130 @@ export const useImage = (source, history) => {
     store => [store.lensEnabled, store.toggleLensEnabled],
     shallow
   );
+  const loader = useLoader();
+  const metadata = useMetadata();
   useEffect(() => {
     async function changeLoader() {
       // Placeholder
       useViewerStore.setState({ isChannelLoading: [true] });
       useViewerStore.setState({ isViewerLoading: true });
-      resetChannels();
       const { urlOrFile } = source;
-      const {
-        data: nextLoader,
-        metadata: nextMeta
-      } = await createLoader(urlOrFile, toggleIsOffsetsSnackbarOn, message =>
-        useViewerStore.setState({ loaderErrorSnackbar: { on: true, message } })
+      const newLoader = await createLoader(
+        urlOrFile,
+        toggleIsOffsetsSnackbarOn,
+        message =>
+          useViewerStore.setState({
+            loaderErrorSnackbar: { on: true, message }
+          })
       );
+      let nextMeta;
+      let nextLoader;
+      if (Array.isArray(newLoader)) {
+        nextMeta = newLoader.map(l => l.metadata);
+        nextLoader = newLoader.map(l => l.data);
+      } else {
+        nextMeta = newLoader.metadata;
+        nextLoader = newLoader.data;
+      }
       console.info(
         'Metadata (in JSON-like form) for current file being viewed: ',
         nextMeta
       );
-
-      if (nextLoader) {
-        const newSelections = buildDefaultSelection(nextLoader[0]);
-        const { Channels } = nextMeta.Pixels;
-        const channelOptions = Channels.map((c, i) => c.Name ?? `Channel ${i}`);
-        // Default RGB.
-        let newContrastLimits = [];
-        let newDomains = [];
-        let newColors = [];
-        const isRgb = guessRgb(nextMeta);
-        if (isRgb) {
-          if (isInterleaved(nextLoader[0].shape)) {
-            // These don't matter because the data is interleaved.
-            newContrastLimits = [[0, 255]];
-            newDomains = [[0, 255]];
-            newColors = [[255, 0, 0]];
-          } else {
-            newContrastLimits = [
-              [0, 255],
-              [0, 255],
-              [0, 255]
-            ];
-            newDomains = [
-              [0, 255],
-              [0, 255],
-              [0, 255]
-            ];
-            newColors = [
-              [255, 0, 0],
-              [0, 255, 0],
-              [0, 0, 255]
-            ];
-          }
-          if (lensEnabled) {
-            toggleLensEnabled();
-          }
-          useViewerStore.setState({ useColormap: false, useLens: false });
-        } else {
-          const stats = await getMultiSelectionStats({
-            loader: nextLoader,
-            selections: newSelections,
-            use3d
-          });
-          newDomains = stats.domains;
-          newContrastLimits = stats.contrastLimits;
-          // If there is only one channel, use white.
-          newColors =
-            newDomains.length === 1
-              ? [[255, 255, 255]]
-              : newDomains.map((_, i) => COLOR_PALLETE[i]);
-          useViewerStore.setState({
-            useLens: channelOptions.length !== 1,
-            useColormap: true
-          });
-        }
-        addChannels({
-          ids: newDomains.map(() => String(Math.random())),
-          selections: newSelections,
-          domains: newDomains,
-          contrastLimits: newContrastLimits,
-          colors: newColors
-        });
-        useChannelsStore.setState({ loader: nextLoader });
-        useViewerStore.setState({
-          isChannelLoading: newSelections.map(i => !i),
-          isViewerLoading: false,
-          metadata: nextMeta,
-          pixelValues: new Array(newSelections.length).fill(FILL_PIXEL_VALUE),
-          // Set the global selections (needed for the UI). All selections have the same global selection.
-          globalSelection: newSelections[0],
-          channelOptions
-        });
-        const [xSlice, ySlice, zSlice] = getBoundingCube(nextLoader);
-        useImageSettingsStore.setState({
-          xSlice,
-          ySlice,
-          zSlice
-        });
-        if (use3d) toggleUse3d();
-        // eslint-disable-next-line no-unused-expressions
-        history?.push(
-          typeof urlOrFile === 'string' ? `?image_url=${urlOrFile}` : ''
-        );
-      }
+      useChannelsStore.setState({ loader: nextLoader });
+      useViewerStore.setState({
+        metadata: nextMeta
+      });
+      if (use3d) toggleUse3d();
+      // eslint-disable-next-line no-unused-expressions
+      history?.push(
+        typeof urlOrFile === 'string' ? `?image_url=${urlOrFile}` : ''
+      );
     }
     if (source) changeLoader();
   }, [source, history]); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const changeSettings = async () => {
+      // Placeholder
+      useViewerStore.setState({ isChannelLoading: [true] });
+      useViewerStore.setState({ isViewerLoading: true });
+      const newSelections = buildDefaultSelection(loader[0]);
+      const { Channels } = metadata.Pixels;
+      const channelOptions = Channels.map((c, i) => c.Name ?? `Channel ${i}`);
+      // Default RGB.
+      let newContrastLimits = [];
+      let newDomains = [];
+      let newColors = [];
+      const isRgb = guessRgb(metadata);
+      if (isRgb) {
+        if (isInterleaved(loader[0].shape)) {
+          // These don't matter because the data is interleaved.
+          newContrastLimits = [[0, 255]];
+          newDomains = [[0, 255]];
+          newColors = [[255, 0, 0]];
+        } else {
+          newContrastLimits = [
+            [0, 255],
+            [0, 255],
+            [0, 255]
+          ];
+          newDomains = [
+            [0, 255],
+            [0, 255],
+            [0, 255]
+          ];
+          newColors = [
+            [255, 0, 0],
+            [0, 255, 0],
+            [0, 0, 255]
+          ];
+        }
+        if (lensEnabled) {
+          toggleLensEnabled();
+        }
+        useViewerStore.setState({ useColormap: false, useLens: false });
+      } else {
+        const stats = await getMultiSelectionStats({
+          loader: loader,
+          selections: newSelections,
+          use3d
+        });
+        newDomains = stats.domains;
+        newContrastLimits = stats.contrastLimits;
+        // If there is only one channel, use white.
+        newColors =
+          newDomains.length === 1
+            ? [[255, 255, 255]]
+            : newDomains.map((_, i) => COLOR_PALLETE[i]);
+        useViewerStore.setState({
+          useLens: channelOptions.length !== 1,
+          useColormap: true
+        });
+      }
+      useChannelsStore.setState({
+        ids: newDomains.map(() => String(Math.random())),
+        selections: newSelections,
+        domains: newDomains,
+        contrastLimits: newContrastLimits,
+        colors: newColors,
+        channelsVisible: newColors.map(() => true)
+      });
+      useViewerStore.setState({
+        isChannelLoading: newSelections.map(i => !i),
+        isViewerLoading: false,
+        pixelValues: new Array(newSelections.length).fill(FILL_PIXEL_VALUE),
+        // Set the global selections (needed for the UI). All selections have the same global selection.
+        globalSelection: newSelections[0],
+        channelOptions
+      });
+      const [xSlice, ySlice, zSlice] = getBoundingCube(loader);
+      useImageSettingsStore.setState({
+        xSlice,
+        ySlice,
+        zSlice
+      });
+    };
+    if (metadata) changeSettings();
+  }, [loader, metadata]);
 };
 
 export const useDropzone = () => {

--- a/avivator/src/hooks.js
+++ b/avivator/src/hooks.js
@@ -48,25 +48,32 @@ export const useImage = (source, history) => {
       let nextMeta;
       let nextLoader;
       if (Array.isArray(newLoader)) {
-        nextMeta = newLoader.map(l => l.metadata);
-        nextLoader = newLoader.map(l => l.data);
+        if (newLoader.length > 1) {
+          nextMeta = newLoader.map(l => l.metadata);
+          nextLoader = newLoader.map(l => l.data);
+        } else {
+          nextMeta = newLoader[0].metadata;
+          nextLoader = newLoader[0].data;
+        }
       } else {
         nextMeta = newLoader.metadata;
         nextLoader = newLoader.data;
       }
-      console.info(
-        'Metadata (in JSON-like form) for current file being viewed: ',
-        nextMeta
-      );
-      useChannelsStore.setState({ loader: nextLoader });
-      useViewerStore.setState({
-        metadata: nextMeta
-      });
-      if (use3d) toggleUse3d();
-      // eslint-disable-next-line no-unused-expressions
-      history?.push(
-        typeof urlOrFile === 'string' ? `?image_url=${urlOrFile}` : ''
-      );
+      if (nextLoader) {
+        console.info(
+          'Metadata (in JSON-like form) for current file being viewed: ',
+          nextMeta
+        );
+        useChannelsStore.setState({ loader: nextLoader });
+        useViewerStore.setState({
+          metadata: nextMeta
+        });
+        if (use3d) toggleUse3d();
+        // eslint-disable-next-line no-unused-expressions
+        history?.push(
+          typeof urlOrFile === 'string' ? `?image_url=${urlOrFile}` : ''
+        );
+      }
     }
     if (source) changeLoader();
   }, [source, history]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/avivator/src/state.js
+++ b/avivator/src/state.js
@@ -27,7 +27,8 @@ const DEFAUlT_CHANNEL_STATE = {
   domains: [],
   selections: [],
   ids: [],
-  loader: [{ labels: [], shape: [] }]
+  loader: [{ labels: [], shape: [] }],
+  image: 0
 };
 
 const DEFAUlT_CHANNEL_VALUES = {
@@ -82,26 +83,7 @@ export const useChannelsStore = create(set => ({
         }
       });
       return newState;
-    }),
-  addChannels: newProperties =>
-    set(state => {
-      const entries = Object.entries(newProperties);
-      const newState = { ...state };
-      entries.forEach(([property, values]) => {
-        newState[property] = [...state[property], ...values];
-      });
-      const numNewChannels = entries[0][1].length;
-      Object.entries(DEFAUlT_CHANNEL_VALUES).forEach(([k, v]) => {
-        if (!newState[k].length) {
-          newState[k] = [
-            ...state[k],
-            ...Array.from({ length: numNewChannels }).map(() => v)
-          ];
-        }
-      });
-      return newState;
-    }),
-  resetChannels: () => set(state => ({ ...state, ...DEFAUlT_CHANNEL_STATE }))
+    })
 }));
 
 const DEFAULT_IMAGE_STATE = {
@@ -170,3 +152,17 @@ export const useViewerStore = create(set => ({
       return { ...state, isChannelLoading: newIsChannelLoading };
     })
 }));
+
+export const useLoader = () => {
+  const [fullLoader, image] = useChannelsStore(store => [
+    store.loader,
+    store.image
+  ]);
+  return Array.isArray(fullLoader[0]) ? fullLoader[image] : fullLoader;
+};
+
+export const useMetadata = () => {
+  const image = useChannelsStore(store => store.image);
+  const metadata = useViewerStore(store => store.metadata);
+  return Array.isArray(metadata) ? metadata[image] : metadata;
+};

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -34,20 +34,30 @@ class UnsupportedBrowserError extends Error {
 /**
  *
  * @param {string | File} src
- * @param {import('../../src/loaders/omexml').OMEXML[0]} imgMeta
+ * @param {import('../../src/loaders/omexml').OMEXML} rootMeta
  * @param {number} levels
+ * @param {import('../../src/loaders/tiff/pixel-source').TiffPixelSource[]} data
  */
-async function getTotalImageCount(src, imgMeta, levels) {
+async function getTotalImageCount(src, rootMeta, data) {
   const from = typeof src === 'string' ? fromUrl : fromBlob;
   const tiff = await from(src);
-  const {
-    Pixels: { SizeC, SizeT, SizeZ }
-  } = imgMeta;
-  const numImagesPerResolution = SizeC * SizeT * SizeZ;
-
   const firstImage = await tiff.getImage(0);
   const hasSubIFDs = Boolean(firstImage?.fileDirectory?.SubIFDs);
-  return numImagesPerResolution * (hasSubIFDs ? 1 : levels);
+  if (hasSubIFDs) {
+    return rootMeta.reduce((sum, imgMeta) => {
+      const {
+        Pixels: { SizeC, SizeT, SizeZ }
+      } = imgMeta;
+      const numImagesPerResolution = SizeC * SizeT * SizeZ;
+      return numImagesPerResolution + sum;
+    }, 1);
+  }
+  const levels = data[0].length;
+  const {
+    Pixels: { SizeC, SizeT, SizeZ }
+  } = rootMeta[0];
+  const numImagesPerResolution = SizeC * SizeT * SizeZ;
+  return numImagesPerResolution * levels;
 }
 
 /**
@@ -68,22 +78,22 @@ export async function createLoader(
     // OME-TIFF
     if (isOMETIFF(urlOrFile)) {
       if (urlOrFile instanceof File) {
-        const source = await loadOmeTiff(urlOrFile);
+        const source = await loadOmeTiff(urlOrFile, use, true);
         return source;
       }
       const url = urlOrFile;
       const res = await fetch(url.replace(/ome\.tif(f?)/gi, 'offsets.json'));
       const isOffsets404 = res.status === 404;
       const offsets = !isOffsets404 ? await res.json() : undefined;
-      const source = await loadOmeTiff(urlOrFile, { offsets });
+      const source = await loadOmeTiff(urlOrFile, { offsets }, true);
 
       // Show a warning if the total number of channels/images exceeds a fixed amount.
       // Non-Bioformats6 pyramids use Image tags for pyramid levels and do not have offsets
       // built in to the format for them, hence the ternary.
       const totalImageCount = await getTotalImageCount(
         urlOrFile,
-        source.metadata,
-        source.data.length
+        source.map(s => s.metadata),
+        source.map(s => s.data)
       );
       if (isOffsets404 && totalImageCount > MAX_CHANNELS_FOR_SNACKBAR_WARNING) {
         handleOffsetsNotFound(true);
@@ -122,6 +132,8 @@ export async function createLoader(
     if (e instanceof UnsupportedBrowserError) {
       handleLoaderError(e.message);
     } else {
+      console.log(e);
+
       handleLoaderError(null);
     }
     return { data: null };

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -78,7 +78,7 @@ export async function createLoader(
     // OME-TIFF
     if (isOMETIFF(urlOrFile)) {
       if (urlOrFile instanceof File) {
-        const source = await loadOmeTiff(urlOrFile, use, true);
+        const source = await loadOmeTiff(urlOrFile, {}, true);
         return source;
       }
       const url = urlOrFile;
@@ -132,8 +132,6 @@ export async function createLoader(
     if (e instanceof UnsupportedBrowserError) {
       handleLoaderError(e.message);
     } else {
-      console.log(e);
-
       handleLoaderError(null);
     }
     return { data: null };

--- a/avivator/src/utils.js
+++ b/avivator/src/utils.js
@@ -78,14 +78,14 @@ export async function createLoader(
     // OME-TIFF
     if (isOMETIFF(urlOrFile)) {
       if (urlOrFile instanceof File) {
-        const source = await loadOmeTiff(urlOrFile, {}, true);
+        const source = await loadOmeTiff(urlOrFile, { images: 'all' });
         return source;
       }
       const url = urlOrFile;
       const res = await fetch(url.replace(/ome\.tif(f?)/gi, 'offsets.json'));
       const isOffsets404 = res.status === 404;
       const offsets = !isOffsets404 ? await res.json() : undefined;
-      const source = await loadOmeTiff(urlOrFile, { offsets }, true);
+      const source = await loadOmeTiff(urlOrFile, { offsets, images: 'all' });
 
       // Show a warning if the total number of channels/images exceeds a fixed amount.
       // Non-Bioformats6 pyramids use Image tags for pyramid levels and do not have offsets

--- a/src/loaders/tiff/index.ts
+++ b/src/loaders/tiff/index.ts
@@ -20,9 +20,10 @@ interface TiffOptions {
  * Options for initializing a tiff pixel source. Headers are passed to each underlying fetch request. Offests are
  * a performance enhancment to index the remote tiff source using pre-computed byte-offsets. Pool indicates whether a
  * multi-threaded pool of image decoders should be used to decode tiles (default = true).
- * @param {{ boolean }} useMultiImage Whether or not to return an array of multiple images in the OMEXML -
- * if false, only the first iamge is returned.
- * @return {Promise<{ data: TiffPixelSource[], metadata: ImageMeta }>} data source and associated OME-Zarr metadata.
+ * @param {{ boolean }} useMultiImage Whether or not to return an array of multiple images if present in the OMEXML -
+ * if false, only the first iamge is returned as Promise<{ data: TiffPixelSource[], metadata: ImageMeta }> and if true, an array of images
+ * Promise<{ data: TiffPixelSource[], metadata: ImageMeta }>[] is returned.
+ * @return {Promise<{ data: TiffPixelSource[], metadata: ImageMeta }> | Promise<{ data: TiffPixelSource[], metadata: ImageMeta }>[]} data source and associated OME-Zarr metadata.
  */
 export async function loadOmeTiff(
   source: string | File,

--- a/src/loaders/tiff/index.ts
+++ b/src/loaders/tiff/index.ts
@@ -20,11 +20,14 @@ interface TiffOptions {
  * Options for initializing a tiff pixel source. Headers are passed to each underlying fetch request. Offests are
  * a performance enhancment to index the remote tiff source using pre-computed byte-offsets. Pool indicates whether a
  * multi-threaded pool of image decoders should be used to decode tiles (default = true).
+ * @param {{ boolean }} useMultiImage Whether or not to return an array of multiple images in the OMEXML -
+ * if false, only the first iamge is returned.
  * @return {Promise<{ data: TiffPixelSource[], metadata: ImageMeta }>} data source and associated OME-Zarr metadata.
  */
 export async function loadOmeTiff(
   source: string | File,
-  opts: TiffOptions = {}
+  opts: TiffOptions = {},
+  useMultiImage: boolean = false
 ) {
   const { headers, offsets, pool = true } = opts;
 
@@ -48,12 +51,13 @@ export async function loadOmeTiff(
      */
     tiff = createOffsetsProxy(tiff, offsets);
   }
-
   /*
    * Inspect tiff source for our performance enhancing proxies.
    * Prints warnings to console if `offsets` or `pool` are missing.
    */
   checkProxies(tiff);
 
-  return pool ? load(tiff, new Pool()) : load(tiff);
+  return pool
+    ? load(tiff, useMultiImage, new Pool())
+    : load(tiff, useMultiImage);
 }

--- a/src/loaders/tiff/index.ts
+++ b/src/loaders/tiff/index.ts
@@ -13,21 +13,47 @@ interface TiffOptions {
   images?: 'first' | 'all';
 }
 
+interface OmeTiffOptions extends TiffOptions {
+  images?: 'first' | 'all';
+}
+
+type UnwrapPromise<T> = T extends Promise<infer Inner> ? Inner : T;
+type MultiImage = UnwrapPromise<ReturnType<typeof load>>; // get return-type from `load`
+
+/** @ignore */
+export async function loadOmeTiff(
+  source: string | File,
+  opts: TiffOptions & { images: 'all' }
+): Promise<MultiImage>;
+/** @ignore */
+export async function loadOmeTiff(
+  source: string | File,
+  opts: TiffOptions & { images: 'first' }
+): Promise<MultiImage[0]>;
+/** @ignore */
+export async function loadOmeTiff(
+  source: string | File,
+  opts: TiffOptions
+): Promise<MultiImage[0]>;
+/** @ignore */
+export async function loadOmeTiff(
+  source: string | File
+): Promise<MultiImage[0]>;
 /**
- * Opens an OME-TIFF via URL and returns data source and associated metadata for first image.
+ * Opens an OME-TIFF via URL and returns data source and associated metadata for first or all images in files.
  *
  * @param {(string | File)} source url or File object.
- * @param {{ headers: (undefined | Headers), offsets: (undefined | number[]), pool: (undefined | boolean ), images: (undefined | string) }} opts
- * Options for initializing a tiff pixel source. Headers are passed to each underlying fetch request. Offests are
- * a performance enhancment to index the remote tiff source using pre-computed byte-offsets. Pool indicates whether a
- * multi-threaded pool of image decoders should be used to decode tiles (default = true). images indicates whether
- * or not to return an array of multiple images if present in the OMEXML - if images is 'first', only the first image is returned
- * and if images is 'all`, then all images are returned (default = 'first').
+ * @param {Object} opts
+ * @param {Headers=} opts.header - Headers passed to each underlying fetch request.
+ * @param {Array<number>=} opts.offsets - [Indexed-Tiff](https://github.com/hms-dbmi/generate-tiff-offsets) IFD offsets.
+ * @param {pool} [opts.bool=true] - Whether to use a multi-threaded pool of image decoders.
+ * @param {images} [opts.images='first'] - Whether to return 'all' or only the 'first' image in the OME-TIFF.
+ * Promise<{ data: TiffPixelSource[], metadata: ImageMeta }>[] is returned.
  * @return {Promise<{ data: TiffPixelSource[], metadata: ImageMeta }> | Promise<{ data: TiffPixelSource[], metadata: ImageMeta }>[]} data source and associated OME-Zarr metadata.
  */
 export async function loadOmeTiff(
   source: string | File,
-  opts: TiffOptions = {}
+  opts: OmeTiffOptions = {}
 ) {
   const { headers, offsets, pool = true, images = 'first' } = opts;
 

--- a/src/loaders/tiff/ome-tiff.ts
+++ b/src/loaders/tiff/ome-tiff.ts
@@ -51,13 +51,14 @@ export async function load(
     );
   }
   const omexml = fromString(ImageDescription);
+
   let levels: number;
   if (SubIFDs) {
     // Image is >= Bioformats 6.0 and resolutions are stored using SubIFDs.
     levels = SubIFDs.length + 1;
   } else {
     // Image is legacy format; resolutions are stored as separate images.
-    levels = omexml.length + 1;
+    levels = omexml.length;
   }
   if (!useMultiImage) {
     const image = 0;
@@ -84,7 +85,6 @@ export async function load(
       );
       return source;
     });
-
     return {
       data,
       metadata: imgMeta

--- a/tests/loaders/ome-tiff.spec.js
+++ b/tests/loaders/ome-tiff.spec.js
@@ -7,7 +7,7 @@ test('Creates correct TiffPixelSource for OME-TIFF.', async t => {
   t.plan(5);
   try {
     const tiff = await fromFile('tests/loaders/fixtures/multi-channel.ome.tif');
-    const { data } = await load(tiff);
+    const [{ data }] = await load(tiff);
     t.equal(data.length, 1, 'image should not be pyramidal.');
     const [base] = data;
     t.deepEqual(
@@ -35,7 +35,7 @@ test('Get raster data.', async t => {
   t.plan(13);
   try {
     const tiff = await fromFile('tests/loaders/fixtures/multi-channel.ome.tif');
-    const { data } = await load(tiff);
+    const [{ data }] = await load(tiff);
     const [base] = data;
 
     for (let c = 0; c < 3; c += 1) {
@@ -61,7 +61,7 @@ test('Correct OME-XML.', async t => {
   t.plan(9);
   try {
     const tiff = await fromFile('tests/loaders/fixtures/multi-channel.ome.tif');
-    const { metadata } = await load(tiff);
+    const [{ metadata }] = await load(tiff);
     const { Name, Pixels } = metadata;
     t.equal(
       Name,


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #344 - see https://github.com/hms-dbmi/viv/discussions/546#discussioncomment-1782740 as well
<!-- For all the PRs -->
#### Change List
- Allow `loadOmeTiff` to return an array `Promise<{ data: TiffPixelSource[], metadata: ImageMeta }>[]` of images.  This should not be a breaking change because I added the `useMultiImage` flag and set it to `false`.   In a future major release, we can set this to `true` by default (or just get rid of it).
- Update Avivator to handle an array of images.  The behavior is that if the "Image" changes, Avivator completely resets, including the 3D mode


#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
