### PR TITLE
Fix Multi-Image Indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Fix multi-image tiff indexing.
+
 ## 0.12.2
 
 ### Added


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
#### Background
Fixes a small bug where we offset uniformly by the first image's dimensions but in reality we need to offset by whatever the previous images' dimensions were.
#### Change List
- FIx OME-TIFF muti-image indexing.
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
