### PR TITLE
Upgrade geotiff to solve 416 issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Upgrade geotiff fork to viv-0.0.3 to resolve 416 issue
 
 ## 0.12.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7976,8 +7976,8 @@
       "dev": true
     },
     "geotiff": {
-      "version": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.2.tar.gz",
-      "integrity": "sha512-wxoQZWBOK0vMgmWnTiVjj/T7Ia1TVKcYR0LYLZAeCoWNkQ6NJENqjb+G7TndVNWRqCCOXvuC8wbOajt9tIHZ9w==",
+      "version": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.3.tar.gz",
+      "integrity": "sha512-4k0bAdYvPArX3SPFrLe5AXd3CSFLGzgU9FCOLVhr+9OgN1hcynsBT82O5zLW38bjE/6hARNh6CxSUltDEhiWHQ==",
       "requires": {
         "@petamoriken/float16": "^1.0.7",
         "content-type-parser": "^1.0.2",
@@ -14721,9 +14721,9 @@
       }
     },
     "threads": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
-      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.7.0.tgz",
+      "integrity": "sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==",
       "requires": {
         "callsites": "^3.1.0",
         "debug": "^4.2.0",
@@ -15172,9 +15172,9 @@
       "dev": true
     },
     "txml": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
-      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.1.1.tgz",
+      "integrity": "sha512-TwMDLnXQ09enNaxybLVvKZU7rqog8LgnuAs4ZYXM0nV0eu10iLsSFwlX3AEknAXXtH1wT3CYfoiXAjyBexcmuw==",
       "requires": {
         "through2": "^3.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@math.gl/culling": "^3.4.2",
     "fast-deep-equal": "^3.1.3",
     "fast-xml-parser": "^3.16.0",
-    "geotiff": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.2.tar.gz",
+    "geotiff": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.3.tar.gz",
     "math.gl": "^3.3.0",
     "quickselect": "^2.0.0",
     "zarr": "^0.5.1"


### PR DESCRIPTION

#### Background
Toward https://github.com/hubmapconsortium/portal-ui/issues/2345
#### Change List
- Upgrade geotiff with fix
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
