### PR TITLE
Clarify Docs on and Fix Extensions on `OverviewLayer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Update dev dependencies
 - Drop `fast-xml-parser` dependency in `@vivjs/loaders`
 - Validate expected OME-XML data-types
+- Set default `extensions` in `OverviewLayer`
 
 ## 0.13.8
 

--- a/packages/layers/src/overview-layer.js
+++ b/packages/layers/src/overview-layer.js
@@ -1,6 +1,7 @@
 import { CompositeLayer, COORDINATE_SYSTEM } from '@deck.gl/core';
 import { PolygonLayer } from '@deck.gl/layers';
 import { getImageSize } from '@vivjs/loaders';
+import { ColorPaletteExtension } from '@vivjs/extensions';
 import { Matrix4 } from '@math.gl/core';
 
 import ImageLayer from './image-layer';
@@ -32,7 +33,12 @@ const defaultProps = {
   viewportOutlineColor: { type: 'array', value: [255, 190, 0], compare: true },
   viewportOutlineWidth: { type: 'number', value: 2, compare: true },
   overviewScale: { type: 'number', value: 1, compare: true },
-  zoom: { type: 'number', value: 1, compare: true }
+  zoom: { type: 'number', value: 1, compare: true },
+  extensions: {
+    type: 'array',
+    value: [new ColorPaletteExtension()],
+    compare: true
+  }
 };
 
 /**

--- a/packages/layers/src/overview-layer.js
+++ b/packages/layers/src/overview-layer.js
@@ -39,18 +39,15 @@ const defaultProps = {
  * @typedef LayerProps
  * @type {Object}
  * @property {Array.<Array.<number>>} contrastLimits List of [begin, end] values to control each channel's ramp function.
- * @property {Array.<Array.<number>>} colors List of [r, g, b] values for each channel.
  * @property {Array.<boolean>} channelsVisible List of boolean values for each channel for whether or not it is visible.
  * @property {Array} loader PixelSource[]. Assumes multiscale if loader.length > 1.
  * @property {Array} selections Selection to be used for fetching data.
- * @property {number=} opacity Opacity of the layer.
- * @property {string=} colormap String indicating a colormap (default: '').  The full list of options is here: https://github.com/glslify/glsl-colormap#glsl-colormap
- * @property {Array.<Array.<number>>=} domain Override for the possible max/min values (i.e something different than 65535 for uint16/'<u2').
  * @property {Array.<number>=} boundingBoxColor [r, g, b] color of the bounding box (default: [255, 0, 0]).
  * @property {number=} boundingBoxOutlineWidth Width of the bounding box in px (default: 1).
  * @property {Array.<number>=} viewportOutlineColor [r, g, b] color of the outline (default: [255, 190, 0]).
  * @property {number=} viewportOutlineWidth Viewport outline width in px (default: 2).
  * @property {String=} id Unique identifier for this layer.
+ * @property {Array=} extensions [deck.gl extensions](https://deck.gl/docs/developer-guide/custom-layers/layer-extensions) to add to the layers.
  */
 
 /**

--- a/packages/loaders/src/omexml.ts
+++ b/packages/loaders/src/omexml.ts
@@ -93,7 +93,7 @@ const UuidSchema = z
   .object({})
   .extend({
     attr: z.object({
-      UUID: z.string()
+      FileName: z.string()
     })
   })
   .transform(flattenAttributes);

--- a/sites/docs/src/API_STRUCTURE.md
+++ b/sites/docs/src/API_STRUCTURE.md
@@ -35,6 +35,8 @@ which accept `PixelSource` arguments for data fetching. These layers handle the 
 and setting up the rendering by wrapping the `XRLayer`, `XR3DLayer` and `BitmapLayer`, which are the lower level rendering layers.  
 The `XRLayer` (eXtended Range Layer) and `XR3DLayer` enable multi-channel additive blending of `Uint32`, `Uint16`, `Uint8` and `Float32` data on the GPU.
 
+A crucial part of the layer is the `extensions` prop - these control the per-fragment (pixel) rendering. The default on all layers is `ColorPaletteExtension` and it will provide a default `colors` prop - thus all that is necessary for controlling rendering is the `contrastLimits`. But if you wish to do something different, for example to use a "colormap" like `viridis`, you will need to pass in `extensions: [new AdditiveColormapExtension()]` and `colormap: viridis`. Please see deck.gl's [documentation](https://deck.gl/docs/api-reference/extensions/overview) for more information.
+
 #### Loader (Pixel Sources)
 
 Viv wraps both Tiff- and Zarr-based data sources in a unified `PixelSource` interface. A pixel

--- a/sites/docs/src/SAMPLES.md
+++ b/sites/docs/src/SAMPLES.md
@@ -80,6 +80,8 @@ function App() {
     <PictureInPictureViewer
       loader={loader.data}
       contrastLimits={autoProps.contrastLimits}
+      // Default extension is ColorPaletteExtension so no need to specify it if
+      // that is the desired rendering, using the `colors` prop.
       colors={autoProps.colors}
       channelsVisible={autoProps.channelsVisible}
       selections={autoProps.selections}


### PR DESCRIPTION
#### Background
Addresses https://github.com/hms-dbmi/viv/issues/533#issuecomment-1009432218
#### Change List
- Add a default `extension` prop for `OverviewLayer`
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
