### PR TITLE
fix: disable vite/plugin-react for ESM build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Upgrade geotiff fork to viv-0.0.3 to resolve 416 issue
+- Disable `@vite/plugin-react` for ESM build
 
 ## 0.12.3
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -71,14 +71,13 @@ const bundleWebWorker = () => {
 };
 
 const plugins = [
-  react(),
   glslify(),
   bundleWebWorker(),
   serveData(process.env.VIV_DATA_DIR || 'avivator/data'),
 ];
 
 const configAvivator = defineConfig({
-  plugins,
+  plugins: [react(), ...plugins],
   base: './',
   root: 'avivator',
   publicDir: 'avivator/public',


### PR DESCRIPTION
Fixes #561 

The `@vite/plugin-react` plugin applies React's automatic jsx runtime (which ended up being exported in the final bundle). This PR disables `@vite/plugin-react` for `npm run build`, deferring to esbuild _alone_ to apply the JSX transformation (`React.createElement`).