### PR TITLE
Upgrade Geotiff to Fix File Size Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Fix geotiff file size check, implemented when fixing 416 issue.  Not all servers return file size as part of response.
 
 ## 0.12.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7976,8 +7976,8 @@
       "dev": true
     },
     "geotiff": {
-      "version": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.3.tar.gz",
-      "integrity": "sha512-4k0bAdYvPArX3SPFrLe5AXd3CSFLGzgU9FCOLVhr+9OgN1hcynsBT82O5zLW38bjE/6hARNh6CxSUltDEhiWHQ==",
+      "version": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.4.tar.gz",
+      "integrity": "sha512-pyZTspixWFUrFEQE9izjICtfWXlcbvYWyzJtcDpHwiz3jP5IKF1ItLfgekMhsvGJ9eLXOgF0OEp25baMz5iAgQ==",
       "requires": {
         "@petamoriken/float16": "^1.0.7",
         "content-type-parser": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@math.gl/culling": "^3.4.2",
     "fast-deep-equal": "^3.1.3",
     "fast-xml-parser": "^3.16.0",
-    "geotiff": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.3.tar.gz",
+    "geotiff": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.4.tar.gz",
     "math.gl": "^3.3.0",
     "quickselect": "^2.0.0",
     "zarr": "^0.5.1"


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes https://github.com/hms-dbmi/viv/discussions/546#discussioncomment-2025372.  I introduced this with #563 and this should resolve it.
<!-- For all the PRs -->
#### Change List
- Upgrade geotiff fork to 0.0.4 to fix file size check
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
