### PR TITLE
Fix Casting Bug for `Float64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Log errors for loading in Avivator
+- Fix casting bug for `Float64`
 
 ## 0.12.7
 

--- a/avivator/src/components/Controller/components/ChannelController.jsx
+++ b/avivator/src/components/Controller/components/ChannelController.jsx
@@ -63,8 +63,9 @@ function ChannelController({
   const rgbColor = toRgb(colormap, color);
   const [min, max] = domain;
   // If the min/max range is and the dtype is float, make the step size smaller so contrastLimits are smoother.
-  const step =
-    max - min < 500 && loader[0]?.dtype === 'Float32' ? (max - min) / 500 : 1;
+  const { dtype } = loader[0];
+  const isFloat = dtype === 'Float32' || dtype === 'Float64';
+  const step = max - min < 500 && isFloat ? (max - min) / 500 : 1;
   const shouldShowPixelValue = !useLinkedView && !use3d;
   return (
     <Grid container direction="column" m={2} justify="center">

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -56,7 +56,8 @@ function getRenderingAttrs(dtype, gl, interpolation) {
   upgradedShaderModule.vs = version300str.concat(upgradedShaderModule.vs);
   const values = getDtypeValues(isLinear ? 'Float32' : dtype);
   // Check if a cast function is present in the returned data for the dtype
-  const cast = values.cast || (data => data);
+  const identity = x => x;
+  const cast = typeof values.cast === 'function' ? values.cast : identity;
   return {
     ...values,
     shaderModule: upgradedShaderModule,

--- a/src/layers/XRLayer/XRLayer.js
+++ b/src/layers/XRLayer/XRLayer.js
@@ -55,11 +55,13 @@ function getRenderingAttrs(dtype, gl, interpolation) {
   upgradedShaderModule.fs = version300str.concat(upgradedShaderModule.fs);
   upgradedShaderModule.vs = version300str.concat(upgradedShaderModule.vs);
   const values = getDtypeValues(isLinear ? 'Float32' : dtype);
+  // Check if a cast function is present in the returned data for the dtype
+  const cast = values.cast || (data => data);
   return {
     ...values,
     shaderModule: upgradedShaderModule,
     filter: interpolation,
-    cast: isLinear ? data => new Float32Array(data) : data => data
+    cast: isLinear ? data => new Float32Array(data) : cast
   };
 }
 


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes https://github.com/hms-dbmi/viv/issues/591#issuecomment-1119098351
<!-- For other PRs without open issue -->
#### Change List
- Make sure to actually use `cast` function in `XRLayer` when it is returned with the value for a given `dtype`
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
