### PR TITLE
Support passing in additional layers to VivViewer through deckProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ### Changed
 
+## 0.12.9
+
+### Added
+
+- Support passing in additional layers to VivViewer through deckProps
+
+### Changed
+
 ## 0.12.8
 
 ### Added

--- a/src/viewers/VivViewer.jsx
+++ b/src/viewers/VivViewer.jsx
@@ -302,7 +302,11 @@ class VivViewerWrapper extends PureComponent {
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...(deckProps ?? {})}
         layerFilter={this.layerFilter}
-        layers={deckProps?.layers === undefined ? [...this._renderLayers()] : [...this._renderLayers(), ...deckProps.layers]}
+        layers={
+          deckProps?.layers === undefined
+            ? [...this._renderLayers()]
+            : [...this._renderLayers(), ...deckProps.layers]
+        }
         onViewStateChange={this._onViewStateChange}
         views={deckGLViews}
         viewState={viewStates}

--- a/src/viewers/VivViewer.jsx
+++ b/src/viewers/VivViewer.jsx
@@ -302,7 +302,7 @@ class VivViewerWrapper extends PureComponent {
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...(deckProps ?? {})}
         layerFilter={this.layerFilter}
-        layers={this._renderLayers()}
+        layers={[...this._renderLayers(), ...deckProps.layers]}
         onViewStateChange={this._onViewStateChange}
         views={deckGLViews}
         viewState={viewStates}

--- a/src/viewers/VivViewer.jsx
+++ b/src/viewers/VivViewer.jsx
@@ -302,7 +302,7 @@ class VivViewerWrapper extends PureComponent {
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...(deckProps ?? {})}
         layerFilter={this.layerFilter}
-        layers={[...this._renderLayers(), ...deckProps.layers]}
+        layers={deckProps?.layers === undefined ? [...this._renderLayers()] : [...this._renderLayers(), ...deckProps.layers]}
         onViewStateChange={this._onViewStateChange}
         views={deckGLViews}
         viewState={viewStates}


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
See #605
#### Change List
- Support passing in additional layers to VivViewer through deckProps
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [X] Make sure Avivator works as expected with your change.
