### PR TITLE
feat: add postversion script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Only run CHANGELOG action on pull_requests
 - fix(main): image URLs in README
 - test release (v0.13.0-alpha.0)
+- add `postversion` script to `package.json`
 
 ## 0.12.9
 

--- a/README.md
+++ b/README.md
@@ -98,12 +98,6 @@ Checkout latest `master` branch, run:
 ```sh
 # commit and tag a new version
 pnpm version [major | minor | patch]
-# sync @vivjs/* package versions with root
-pnpm meta-updater
-# update CHANGELOG.md for release
-./version.sh 
-# add changes to this versioned commit
-git add . && git commit --amend --no-edit 
 # push to `master` & trigger CI for release
 git push --follow-tags
 ```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "pnpm -r --parallel test",
     "check-format": "prettier --check --ignore-path .gitignore tsconfig.json sites/avivator packages/",
     "lint": "npm run check-format && eslint \"packages/*/src/**/*\" \"sites/avivator/src/**/*\"",
-    "format": "npm run check-format -- --write"
+    "format": "npm run check-format -- --write",
+    "postversion": "pnpm meta-updater && ./version.sh && git commit --all --amend --no-edit"
   },
   "dependencies": {
     "@deck.gl/core": "8.6.7",


### PR DESCRIPTION
Adds a `postversion` script to `package.json` to automate the release steps. Now the release workflow should be:

```bash
# pull the latest from master
git checkout master && git pull
# bumps pkg versions, updates CHANGELOG.md, and creates a commit with `v*` tag.
pnpm version [major | minor | patch | prepatch]
# push latest to master; `v*` tag triggers the release GH Action
git push --follow-tags
```
