### PR TITLE
chore: update `loadMultiTiff` docs and remove name inference 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added support for loading multiple single channel TIFFs.
 
 ### Changed
+- Update doc strings for `loadMultiTiff`
 
 ## 0.13.0
 

--- a/packages/loaders/src/tiff/index.ts
+++ b/packages/loaders/src/tiff/index.ts
@@ -11,7 +11,7 @@ import { load as loadMulti, MultiTiffImage } from './multi-tiff';
 addDecoder(5, () => LZWDecoder);
 
 interface TiffOptions {
-  headers?: object;
+  headers?: Headers | Record<string, string>,
   offsets?: number[];
   pool?: Pool;
   images?: 'first' | 'all';
@@ -23,10 +23,11 @@ interface OmeTiffOptions extends TiffOptions {
 
 interface MultiTiffOptions {
   pool?: Pool;
+  name?: string;
+  headers?: Headers | Record<string, string>,
 }
 
-type UnwrapPromise<T> = T extends Promise<infer Inner> ? Inner : T;
-type MultiImage = UnwrapPromise<ReturnType<typeof loadOme>>; // get return-type from `load`
+type MultiImage = Awaited<ReturnType<typeof loadOme>>; // get return-type from `load`
 
 /** @ignore */
 export async function loadOmeTiff(
@@ -52,10 +53,10 @@ export async function loadOmeTiff(
  *
  * @param {(string | File)} source url or File object.
  * @param {Object} opts
- * @param {Headers=} opts.header - Headers passed to each underlying fetch request.
+ * @param {Headers=} opts.headers - Headers passed to each underlying fetch request.
  * @param {Array<number>=} opts.offsets - [Indexed-Tiff](https://github.com/hms-dbmi/generate-tiff-offsets) IFD offsets.
- * @param {pool} [opts.bool=true] - Whether to use a multi-threaded pool of image decoders.
- * @param {images} [opts.images='first'] - Whether to return 'all' or only the 'first' image in the OME-TIFF.
+ * @param {GeoTIFF.Pool} [opts.pool] - A geotiff.js [Pool](https://geotiffjs.github.io/geotiff.js/module-pool-Pool.html) for decoding image chunks.
+ * @param {("first" | "all")} [opts.images='first'] - Whether to return 'all' or only the 'first' image in the OME-TIFF.
  * Promise<{ data: TiffPixelSource[], metadata: ImageMeta }>[] is returned.
  * @return {Promise<{ data: TiffPixelSource[], metadata: ImageMeta }> | Promise<{ data: TiffPixelSource[], metadata: ImageMeta }>[]} data source and associated OME-Zarr metadata.
  */
@@ -63,7 +64,7 @@ export async function loadOmeTiff(
   source: string | File,
   opts: OmeTiffOptions = {}
 ) {
-  const { headers, offsets, pool, images = 'first' } = opts;
+  const { headers = {}, offsets, pool, images = 'first' } = opts;
 
   let tiff: GeoTIFF;
 
@@ -72,7 +73,7 @@ export async function loadOmeTiff(
     // https://github.com/ilan-gold/geotiff.js/tree/viv#abortcontroller-support
     // https://www.npmjs.com/package/lru-cache#options
     // Cache size needs to be infinite due to consistency issues.
-    tiff = await fromUrl(source, { ...headers, cacheSize: Infinity });
+    tiff = await fromUrl(source, { headers, cacheSize: Infinity });
   } else {
     tiff = await fromBlob(source);
   }
@@ -98,28 +99,32 @@ export async function loadOmeTiff(
 const DEFAULT_MULTI_IMAGE_NAME = 'MultiTiff';
 
 /**
- * Opens a folder of multiple tiffs each containing one image (no stacks, timepoints, or pyramids).
- * Loads each tiff as a channel.
- * Expects one of two possible inputs:
+ * Opens multiple tiffs as a multidimensional "stack" of 2D planes. Returns the data source and OME-TIFF-like metadata.
  *
- * string - A single URL or a comma separated list of URLs where each URL points to a flat TIFF.
- * In this case the name of the parent path element for the first image will be used as the image name
- * and the file names will be used as the channel names.
  *
- * (File & { path: string })[] - A list of file objects paired with their paths. In this case
- * the parent folder name of the first image will be used as the image name and the file names
- * will be used to as the channel names.
+ * @example
+ * const { data, metadata } = await loadMultiTiff([
+ *  [{ c: 0, t: 0, z: 0 }, 'https://example.com/channel_0.tif'],
+ *  [{ c: 1, t: 0, z: 0 }, 'https://example.com/channel_1.tif'],
+ *  [{ c: 2, t: 0, z: 0 }, 'https://example.com/channel_1.tif'],
+ * ]);
  *
- * @param {string | File[]} source url or files with paths
- * @param {{ fetchOptions: (undefined | RequestInit) }} options
- * @return {Promise<{ data: TiffFolderPixelSource[], metadata: ImageMeta }>} data source and associated metadata.
+ * await data.getRaster({ selection: { c: 0, t: 0, z: 0 } });
+ * // { data: Uint16Array[...], width: 500, height: 500 }
+ *
+ * @param {Array<[OmeTiffSelection, (string | File)]>} sources pairs of `[Selection, string | File]` entries indicating the multidimensional selection in the virtual stack in image source (url string, or `File`).
+ * @param {Object} opts
+ * @param {GeoTIFF.Pool} [opts.pool] - A geotiff.js [Pool](https://geotiffjs.github.io/geotiff.js/module-pool-Pool.html) for decoding image chunks.
+ * @param {string} [opts.name] - a name for the "virtual" image stack. If none is provided a name is inferred from the source paths or defaults to "MultiTiff".
+ * @param {Headers=} opts.headers - Headers passed to each underlying fetch request.
+ * @return {Promise<{ data: TiffPixelSource[], metadata: ImageMeta }>} data source and associated metadata.
  */
 export async function loadMultiTiff(
   sources: [OmeTiffSelection, string | (File & { path: string })][],
   opts: MultiTiffOptions = {}
 ) {
   let imageName: string | undefined;
-  const { pool } = opts;
+  const { pool, headers = {} } = opts;
   const tiffImage: MultiTiffImage[] = [];
 
   const firstSource = sources[0];
@@ -147,7 +152,7 @@ export async function loadMultiTiff(
         const tiffImageName = parsedFilename.name;
         if (tiffImageName) {
           const tiff = await (
-            await fromUrl(file, { cacheSize: Infinity })
+            await fromUrl(file, { headers, cacheSize: Infinity })
           ).getImage(0);
           tiffImage.push({ name: tiffImageName, selection, tiff });
         }


### PR DESCRIPTION
Updates JSDoc for `loadMultiTiff` and adds additional `header` and `name` options to `MultiTiffOptions`. Also removes name inference (which incorrectly used negative indexing), the `opts.name` should be preferred to provide an explicit name for the image if desired.
