### PR TITLE
fix: use `version` script instead of `postversion` for creating tagged release commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Replace `postversion` script with `version` script for CI release.
 
 ## 0.13.1
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check-format": "prettier --check --ignore-path .gitignore tsconfig.json sites/avivator packages/",
     "lint": "npm run check-format && eslint \"packages/*/src/**/*\" \"sites/avivator/src/**/*\"",
     "format": "npm run check-format -- --write",
-    "postversion": "pnpm meta-updater && ./version.sh && git commit --all --amend --no-edit"
+    "version": "pnpm meta-updater && ./version.sh && git add packages/*/package.json CHANGELOG.md"
   },
   "dependencies": {
     "@deck.gl/core": "8.6.7",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check-format": "prettier --check --ignore-path .gitignore tsconfig.json sites/avivator packages/",
     "lint": "npm run check-format && eslint \"packages/*/src/**/*\" \"sites/avivator/src/**/*\"",
     "format": "npm run check-format -- --write",
-    "version": "pnpm meta-updater && ./version.sh && git add packages/*/package.json CHANGELOG.md"
+    "version": "pnpm meta-updater && ./version.sh && git add ."
   },
   "dependencies": {
     "@deck.gl/core": "8.6.7",


### PR DESCRIPTION
The `postversion` script modified the commit history _after_ the tagged commit was made. This PR fixes the release behavior so that the tagged commit has the latest changes.
