### PR TITLE
(fix): `getTileData` args changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,20 @@
 ### Added
 
 ### Changed
+
 - Upgrade deck.gl to 8.8
+- Use correct deck.gl 8.8 `getTileData` args.
 - Replace `postversion` script with `version` script for CI release.
 - Remove `package-lock.json` from root (since we use pnpm)
 
 ## 0.13.1
 
 ### Added
+
 - Added support for loading multiple single channel TIFFs.
 
 ### Changed
+
 - Update doc strings for `loadMultiTiff`
 - Update release notes in `README.md`
 
@@ -23,6 +27,7 @@
 ### Added
 
 ### Changed
+
 - Migrate to pnpm monorepo
 - Fix all image URLs in README
 - Only run CHANGELOG action on pull_requests

--- a/packages/layers/src/multiscale-image-layer/multiscale-image-layer.js
+++ b/packages/layers/src/multiscale-image-layer/multiscale-image-layer.js
@@ -83,7 +83,6 @@ const MultiscaleImageLayer = class extends CompositeLayer {
       // The image-tile example works without, this but I have a feeling there is something
       // going on with our pyramids and/or rendering that is different.
       const resolution = Math.round(-z);
-      console.log(resolution, z);
       const getTile = selection => {
         const config = { x, y, selection, signal };
         return loader[resolution].getTile(config);

--- a/packages/layers/src/multiscale-image-layer/multiscale-image-layer.js
+++ b/packages/layers/src/multiscale-image-layer/multiscale-image-layer.js
@@ -66,12 +66,11 @@ const MultiscaleImageLayer = class extends CompositeLayer {
     } = this.props;
     // Get properties from highest resolution
     const { tileSize, dtype } = loader[0];
-
     // This is basically to invert:
     // https://github.com/visgl/deck.gl/pull/4616/files#diff-4d6a2e500c0e79e12e562c4f1217dc80R128
     // The z level can be wrong for showing the correct scales because of the calculation deck.gl does
     // so we need to invert it for fetching tiles and minZoom/maxZoom.
-    const getTileData = async ({ x, y, z, signal }) => {
+    const getTileData = async ({ index: { x, y, z }, signal }) => {
       // Early return if no selections
       if (!selections || selections.length === 0) {
         return null;
@@ -84,6 +83,7 @@ const MultiscaleImageLayer = class extends CompositeLayer {
       // The image-tile example works without, this but I have a feeling there is something
       // going on with our pyramids and/or rendering that is different.
       const resolution = Math.round(-z);
+      console.log(resolution, z);
       const getTile = selection => {
         const config = { x, y, selection, signal };
         return loader[resolution].getTile(config);


### PR DESCRIPTION
#### Background
In deck.gl 8.8 this must have changed? Not sure what happened here...

#### Change List
- Use new `getTileData` arguments.

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
