### PR TITLE
avivator images in private s3 presigned url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Use correct deck.gl 8.8 `getTileData` args.
 - Replace `postversion` script with `version` script for CI release.
 - Remove `package-lock.json` from root (since we use pnpm)
+- Update HTTP response check to `!==200` in `avivator/utils.js`, and changed variable name `isOffsets404` to `isOffsetsNot200`
 
 ## 0.13.1
 

--- a/sites/avivator/src/utils.js
+++ b/sites/avivator/src/utils.js
@@ -102,7 +102,7 @@ export async function createLoader(
       }
       const url = urlOrFile;
       const res = await fetch(url.replace(/ome\.tif(f?)/gi, 'offsets.json'));
-      const isOffsets404 = res.status === 404;
+      const isOffsets404 = res.status !== 200;
       const offsets = !isOffsets404 ? await res.json() : undefined;
       // TODO(2021-05-06): temporarily disable `pool` until inline worker module is fixed.
       const source = await loadOmeTiff(urlOrFile, {


### PR DESCRIPTION
<!-- For other PRs without open issue -->

avivator does not work for ome-tiff in private s3. 

change in utils.js, check http code !==200 instead of ===404

this is related to #634 @jkh1
