### PR TITLE
(bug): Fix `onHover` in `VivViewer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Replace `postversion` script with `version` script for CI release.
 - Remove `package-lock.json` from root (since we use pnpm)
 - Update HTTP response check to `!==200` in `avivator/utils.js`, and changed variable name `isOffsets404` to `isOffsetsNot200`
+- Fix `onHover` function in `VivViewer` after deck.gl 8.8 upgrade.
 
 ## 0.13.1
 

--- a/packages/viewers/src/VivViewer.jsx
+++ b/packages/viewers/src/VivViewer.jsx
@@ -210,7 +210,11 @@ class VivViewerWrapper extends React.PureComponent {
       if (!tile?.content) {
         return null;
       }
-      const { content, bbox, index: { z } } = tile;
+      const {
+        content,
+        bbox,
+        index: { z }
+      } = tile;
       if (!content.data || !bbox) {
         return null;
       }

--- a/packages/viewers/src/VivViewer.jsx
+++ b/packages/viewers/src/VivViewer.jsx
@@ -210,7 +210,7 @@ class VivViewerWrapper extends React.PureComponent {
       if (!tile?.content) {
         return null;
       }
-      const { content, bbox, z } = tile;
+      const { content, bbox, index: { z } } = tile;
       if (!content.data || !bbox) {
         return null;
       }

--- a/sites/avivator/src/utils.js
+++ b/sites/avivator/src/utils.js
@@ -119,7 +119,10 @@ export async function createLoader(
         source.map(s => s.metadata),
         source.map(s => s.data)
       );
-      if (isOffsetsNot200 && totalImageCount > MAX_CHANNELS_FOR_SNACKBAR_WARNING) {
+      if (
+        isOffsetsNot200 &&
+        totalImageCount > MAX_CHANNELS_FOR_SNACKBAR_WARNING
+      ) {
         handleOffsetsNotFound(true);
       }
       return source;


### PR DESCRIPTION
#### Background
Discovered during release testing - the issue was also seen in #632 

#### Change List
- Use `index` instead of `z` directly on the tile in the `onHover` function.

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
