### PR TITLE
Stacked tiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `@pnpm/meta-updater` added to project
+- Added support for loading stacked TIFFs to the Multi TIFF loader.
 
 ### Changed
 

--- a/packages/loaders/src/tiff/index.ts
+++ b/packages/loaders/src/tiff/index.ts
@@ -100,7 +100,7 @@ export async function loadOmeTiff(
 function getImageSelectionName(
   imageName: string,
   imageNumber: number,
-  imageSelections: [number, OmeTiffSelection][]
+  imageSelections: (OmeTiffSelection | undefined)[]
 ) {
   return imageSelections.length === 1
     ? imageName
@@ -116,16 +116,16 @@ function getImageSelectionName(
  * const { data, metadata } = await loadMultiTiff([
  *  [{ c: 0, t: 0, z: 0 }, 'https://example.com/channel_0.tif'],
  *  [{ c: 1, t: 0, z: 0 }, 'https://example.com/channel_1.tif'],
- *  [[[0, { c: 2, t: 0, z: 0 }], [1, { c: 3, t: 0, z: 0 }]], 'https://example.com/channels_2-3.tif'],
+ *  [{ c: 2, t: 0, z: 0 }, undefined, { c: 3, t: 0, z: 0 }], 'https://example.com/channels_2-3.tif'],
  * ]);
  *
  * await data.getRaster({ selection: { c: 0, t: 0, z: 0 } });
  * // { data: Uint16Array[...], width: 500, height: 500 }
  *
- * @param {Array<[OmeTiffSelection | [number, OmeTiffSelection][], (string | File)]>} sources
- * Pairs of `[Selection | [number, Selection][], string | File]` entries indicating the multidimensional selection in the virtual stack in image source (url string, or `File`).
- * You should only provide [number, Selection][] when loading from stacked tiffs. In this case the number corresponds to the image index in the stack, and the selection is the
- * selection that image corresponds to.
+ * @param {Array<[OmeTiffSelection | (OmeTiffSelection | undefined)[], (string | File)]>} sources
+ * Pairs of `[Selection | (OmeTiffSelection | undefined)[], string | File]` entries indicating the multidimensional selection in the virtual stack in image source (url string, or `File`).
+ * You should only provide (OmeTiffSelection | undefined)[] when loading from stacked tiffs. In this case the array index corresponds to the image index in the stack, and the selection is the
+ * selection that image corresponds to. Undefined selections are for images that should not be loaded.
  * @param {Object} opts
  * @param {GeoTIFF.Pool} [opts.pool] - A geotiff.js [Pool](https://geotiffjs.github.io/geotiff.js/module-pool-Pool.html) for decoding image chunks.
  * @param {string} [opts.name='MultiTiff'] - a name for the "virtual" image stack.
@@ -134,7 +134,7 @@ function getImageSelectionName(
  */
 export async function loadMultiTiff(
   sources: [
-    OmeTiffSelection | [number, OmeTiffSelection][],
+    OmeTiffSelection | (OmeTiffSelection | undefined)[],
     string | (File & { path: string })
   ][],
   opts: MultiTiffOptions = {}
@@ -145,9 +145,7 @@ export async function loadMultiTiff(
 
   for (const source of sources) {
     const [s, file] = source;
-    const imageSelections: [number, OmeTiffSelection][] = Array.isArray(s)
-      ? s
-      : [[0, s]];
+    const imageSelections = Array.isArray(s) ? s : [s];
     if (typeof file === 'string') {
       // If the file is a string then we're dealing with loading from a URL.
       const parsedFilename = parseFilename(file);
@@ -155,17 +153,22 @@ export async function loadMultiTiff(
       if (extension === 'tif' || extension === 'tiff') {
         const tiffImageName = parsedFilename.name;
         if (tiffImageName) {
-          for (const imageSelection of imageSelections) {
-            const [imageNumber, selection] = imageSelection;
-            const tiff = await (
-              await fromUrl(file, { headers, cacheSize: Infinity })
-            ).getImage(imageNumber);
-            tiffImage.push({ selection, tiff });
-            channelNames[selection.c] = getImageSelectionName(
-              tiffImageName,
-              imageNumber,
-              imageSelections
-            );
+          const curImage = await fromUrl(file, {
+            headers,
+            cacheSize: Infinity
+          });
+          for (let i = 0; i < imageSelections.length; i++) {
+            const curSelection = imageSelections[i];
+
+            if (curSelection) {
+              const tiff = await curImage.getImage(i);
+              tiffImage.push({ selection: curSelection, tiff });
+              channelNames[curSelection.c] = getImageSelectionName(
+                tiffImageName,
+                i,
+                imageSelections
+              );
+            }
           }
         }
       }
@@ -173,23 +176,22 @@ export async function loadMultiTiff(
       // If the file is not a string then we're loading from a File/Blob.
       const { name } = parseFilename(file.path);
       if (name) {
-        for (const imageSelection of imageSelections) {
-          const [imageNumber, selection] = imageSelection;
-          const tiff = await (await fromBlob(file)).getImage(imageNumber);
-          tiffImage.push({ selection, tiff });
-          channelNames[selection.c] = getImageSelectionName(
-            name,
-            imageNumber,
-            imageSelections
-          );
+        const curImage = await fromBlob(file);
+        for (let i = 0; i < imageSelections.length; i++) {
+          const curSelection = imageSelections[i];
+          if (curSelection) {
+            const tiff = await curImage.getImage(i);
+            tiffImage.push({ selection: curSelection, tiff });
+            channelNames[curSelection.c] = getImageSelectionName(
+              name,
+              i,
+              imageSelections
+            );
+          }
         }
       }
     }
   }
-  // eslint-disable-next-line no-console
-  console.log(channelNames);
-  // eslint-disable-next-line no-console
-  console.log(opts.channelNames);
 
   if (tiffImage.length > 0) {
     return loadMulti(name, tiffImage, opts.channelNames || channelNames, pool);

--- a/packages/loaders/src/tiff/lib/utils.ts
+++ b/packages/loaders/src/tiff/lib/utils.ts
@@ -146,7 +146,15 @@ function getChannelSamplesPerPixel(
   const channelSamplesPerPixel = Array(numChannels).fill(0);
   for (const tiff of tiffs) {
     const curChannel = tiff.selection.c;
-    channelSamplesPerPixel[curChannel] = tiff.tiff.getSamplesPerPixel();
+    const curSamplesPerPixel = tiff.tiff.getSamplesPerPixel();
+    const existingSamplesPerPixel = channelSamplesPerPixel[curChannel];
+    if (
+      existingSamplesPerPixel &&
+      existingSamplesPerPixel != curSamplesPerPixel
+    ) {
+      throw Error('Channel samples per pixel mismatch');
+    }
+    channelSamplesPerPixel[curChannel] = curSamplesPerPixel;
   }
   return channelSamplesPerPixel;
 }

--- a/packages/loaders/src/tiff/lib/utils.ts
+++ b/packages/loaders/src/tiff/lib/utils.ts
@@ -137,6 +137,20 @@ function getMultiTiffShapeMap(tiffs: MultiTiffImage[]): {
   };
 }
 
+// If a channel has multiple z or t slices with different samples per pixel
+// this function will just use the samples per pixel from a random slice.
+function getChannelSamplesPerPixel(
+  tiffs: MultiTiffImage[],
+  numChannels: number
+): number[] {
+  const channelSamplesPerPixel = Array(numChannels).fill(0);
+  for (const tiff of tiffs) {
+    const curChannel = tiff.selection.c;
+    channelSamplesPerPixel[curChannel] = tiff.tiff.getSamplesPerPixel();
+  }
+  return channelSamplesPerPixel;
+}
+
 export function getMultiTiffMeta(
   dimensionOrder: DimensionOrder,
   tiffs: MultiTiffImage[]
@@ -158,14 +172,16 @@ function getMultiTiffPixelMedatata(
   dimensionOrder: DimensionOrder,
   shapeMap: { [key: string]: number },
   dType: string,
-  tiffs: MultiTiffImage[]
+  tiffs: MultiTiffImage[],
+  channelNames: string[],
+  channelSamplesPerPixel: number[]
 ) {
   const channelMetadata = [];
-  for (let i = 0; i < tiffs.length; i += 1) {
+  for (let i = 0; i < shapeMap.c; i += 1) {
     channelMetadata.push({
       ID: `Channel:${imageNumber}:${i}`,
-      Name: tiffs[i].name,
-      SamplesPerPixel: tiffs[i].tiff.getSamplesPerPixel()
+      Name: channelNames[i],
+      SamplesPerPixel: channelSamplesPerPixel[i]
     });
   }
   return {
@@ -185,6 +201,7 @@ function getMultiTiffPixelMedatata(
 export function getMultiTiffMetadata(
   imageName: string,
   tiffImages: MultiTiffImage[],
+  channelNames: string[],
   dimensionOrder: DimensionOrder,
   dType: string
 ) {
@@ -193,13 +210,24 @@ export function getMultiTiffMetadata(
   const date = '';
   const description = '';
   const shapeMap = getMultiTiffShapeMap(tiffImages);
+  const channelSamplesPerPixel = getChannelSamplesPerPixel(
+    tiffImages,
+    shapeMap.c
+  );
+
+  if (channelNames.length !== shapeMap.c)
+    throw Error(
+      'Wrong number of channel names for number of channels provided'
+    );
 
   const pixels = getMultiTiffPixelMedatata(
     imageNumber,
     dimensionOrder,
     shapeMap,
     dType,
-    tiffImages
+    tiffImages,
+    channelNames,
+    channelSamplesPerPixel
   );
 
   const format = () => {

--- a/packages/loaders/src/tiff/multi-tiff.ts
+++ b/packages/loaders/src/tiff/multi-tiff.ts
@@ -11,7 +11,6 @@ import type Pool from './lib/Pool';
 import { getMultiTiffIndexer } from './lib/indexers';
 
 export interface MultiTiffImage {
-  name: string;
   selection: OmeTiffSelection;
   tiff: GeoTIFFImage;
 }
@@ -26,7 +25,7 @@ function assertSameResolution(images: MultiTiffImage[]) {
   }
 }
 
-async function assertCompleteStack<T>(
+async function assertCompleteStack(
   images: MultiTiffImage[],
   indexer: (sel: OmeTiffSelection) => Promise<GeoTIFFImage>
 ) {
@@ -46,6 +45,7 @@ async function assertCompleteStack<T>(
 export async function load(
   imageName: string,
   images: MultiTiffImage[],
+  channelNames: string[],
   pool?: Pool
 ) {
   // Before doing any work make sure all of the images have the same resolution
@@ -63,6 +63,7 @@ export async function load(
   const metadata = getMultiTiffMetadata(
     imageName,
     images,
+    channelNames,
     dimensionOrder,
     dtype
   );

--- a/packages/loaders/tests/multi-tiff.spec.js
+++ b/packages/loaders/tests/multi-tiff.spec.js
@@ -24,29 +24,27 @@ async function loadImage() {
     imageName: 'tiff-folder',
     tiffs: [
       {
-        name: 'Channel 0',
         selection: { c: 0, t: 0, z: 0 },
         tiff: await (await fromFile(CHANNEL_0_FIXTURE)).getImage(0)
       },
       {
-        name: 'Channel 1',
         selection: { c: 1, t: 0, z: 0 },
         tiff: await (await fromFile(CHANNEL_1_FIXTURE)).getImage(0)
       },
       {
-        name: 'Channel 2',
         selection: { c: 2, t: 0, z: 0 },
         tiff: await (await fromFile(CHANNEL_2_FIXTURE)).getImage(0)
       }
-    ]
+    ],
+    channelNames: ['Channel 0', 'Channel 1', 'Channel 2']
   };
 }
 
 test('Creates correct TiffPixelSource for MultiTIFF.', async t => {
   t.plan(5);
   try {
-    const { imageName, tiffs } = await loadImage();
-    const { data } = await load(imageName, tiffs);
+    const { imageName, tiffs, channelNames } = await loadImage();
+    const { data } = await load(imageName, tiffs, channelNames);
     t.equal(data.length, 1, 'image should not be pyramidal.');
     const [base] = data;
     t.deepEqual(
@@ -73,8 +71,8 @@ test('Creates correct TiffPixelSource for MultiTIFF.', async t => {
 test('Get raster data for MultiTIFF.', async t => {
   t.plan(13);
   try {
-    const { imageName, tiffs } = await loadImage();
-    const { data } = await load(imageName, tiffs);
+    const { imageName, tiffs, channelNames } = await loadImage();
+    const { data } = await load(imageName, tiffs, channelNames);
     const [base] = data;
 
     for (let c = 0; c < 3; c += 1) {
@@ -107,8 +105,8 @@ test('Get raster data for MultiTIFF.', async t => {
 test('Correct MultiTIFF metadata.', async t => {
   t.plan(10);
   try {
-    const { imageName, tiffs } = await loadImage();
-    const { metadata } = await load(imageName, tiffs);
+    const { imageName, tiffs, channelNames } = await loadImage();
+    const { metadata } = await load(imageName, tiffs, channelNames);
     const { Name, Pixels } = metadata;
     t.equal(Name, 'tiff-folder', `Name should be 'tiff-folder'.`);
     t.equal(Pixels.SizeC, 3, 'Should have three channels.');

--- a/sites/avivator/src/utils.js
+++ b/sites/avivator/src/utils.js
@@ -27,16 +27,76 @@ function isOMETIFF(urlOrFile) {
   return name.includes('ome.tiff') || name.includes('ome.tif');
 }
 
-function isMultiTiff(urlOrFile) {
-  const filenames = Array.isArray(urlOrFile)
-    ? urlOrFile.map(f => f.name)
-    : urlOrFile.split(',');
+/**
+ * Gets an array of filenames for a multi tiff input.
+ * @param {string | File | File[]} urlOrFiles
+ */
+function getMultiTiffFilenames(urlOrFiles) {
+  if (Array.isArray(urlOrFiles)) {
+    return urlOrFiles.map(f => f.name);
+  } else if (urlOrFiles instanceof File) {
+    return [urlOrFiles.name];
+  } else {
+    return urlOrFiles.split(',');
+  }
+}
+
+/**
+ * Guesses whether string URL or File is one or multiple standard TIFF images.
+ * @param {string | File | File[]} urlOrFiles
+ */
+function isMultiTiff(urlOrFiles) {
+  const filenames = getMultiTiffFilenames(urlOrFiles);
   for (const filename of filenames) {
     const lowerCaseName = filename.toLowerCase();
     if (!(lowerCaseName.includes('.tiff') || lowerCaseName.includes('.tif')))
       return false;
   }
   return true;
+}
+
+/**
+ * Turns an input string of one or many urls, file, or file array into a uniform array.
+ * @param {string | File | File[]} urlOrFiles
+ */
+async function generateMultiTiffFileArray(urlOrFiles) {
+  if (Array.isArray(urlOrFiles)) {
+    return urlOrFiles;
+  } else if (urlOrFiles instanceof File) {
+    return [urlOrFiles];
+  } else {
+    return urlOrFiles.split(',');
+  }
+}
+
+/**
+ * Gets the basic image count for a TIFF using geotiff's getImageCount.
+ * @param {string | File} src
+ */
+async function getTiffImageCount(src) {
+  const from = typeof src === 'string' ? fromUrl : fromBlob;
+  const tiff = await from(src);
+  return tiff.getImageCount();
+}
+
+/**
+ * Guesses whether string URL or File is one or multiple standard TIFF images.
+ * @param {string | File | File[]} urlOrFiles
+ */
+async function generateMultiTiffSources(urlOrFiles) {
+  const multiTiffFiles = await generateMultiTiffFileArray(urlOrFiles);
+  const sources = [];
+  let c = 0;
+  for (const tiffFile of multiTiffFiles) {
+    const selections = [];
+    const numImages = await getTiffImageCount(tiffFile);
+    for (let i = 0; i < numImages; i++) {
+      selections.push([i, { c, z: 0, t: 0 }]);
+      c += 1;
+    }
+    sources.push([selections, tiffFile]);
+  }
+  return sources;
 }
 
 class UnsupportedBrowserError extends Error {
@@ -139,13 +199,7 @@ export async function createLoader(
 
     // Multiple flat tiffs
     if (isMultiTiff(urlOrFile)) {
-      const multiTiffFiles = Array.isArray(urlOrFile)
-        ? urlOrFile
-        : urlOrFile.split(',');
-      const mutiTiffSources = multiTiffFiles.map((e, i) => [
-        { c: i, z: 0, t: 0 },
-        e
-      ]);
+      const mutiTiffSources = await generateMultiTiffSources(urlOrFile);
       const source = await loadMultiTiff(mutiTiffSources, {
         images: 'all',
         pool: false

--- a/sites/avivator/src/utils.js
+++ b/sites/avivator/src/utils.js
@@ -91,7 +91,7 @@ async function generateMultiTiffSources(urlOrFiles) {
     const selections = [];
     const numImages = await getTiffImageCount(tiffFile);
     for (let i = 0; i < numImages; i++) {
-      selections.push([i, { c, z: 0, t: 0 }]);
+      selections.push({ c, z: 0, t: 0 });
       c += 1;
     }
     sources.push([selections, tiffFile]);


### PR DESCRIPTION
#### Background
See #636 

#### Change List
- Adds support for loading stacked TIFFs to the MultiTIFF loader and to Avivator.

#### Checklist
 - [X] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [X] Make sure Avivator works as expected with your change.
