### PR TITLE
(fix): Broken interpolation setting at highest zoom level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Changed
 
+- Fix visualization of interpolation at highest level to be pixelated in `MultiscaleImageLayer` after breaking in deck.gl 8.8
+
 ## 0.13.2
 
 ### Added

--- a/packages/layers/src/multiscale-image-layer/utils.js
+++ b/packages/layers/src/multiscale-image-layer/utils.js
@@ -11,9 +11,7 @@ export function range(len) {
 export function renderSubLayers(props) {
   const {
     bbox: { left, top, right, bottom },
-    x,
-    y,
-    z
+    index: { x, y, z }
   } = props.tile;
   const { data, id, loader, maxZoom } = props;
   // Only render in positive coorinate system


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #646
<!-- For other PRs without open issue -->
#### Change List
- Use `index` for getting `z` info of tile for determining `interpolation` setting for `XRLayer`

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
