### PR TITLE
Adds support for loading local TIFFs using GeoTIFF's fromFile loader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added support for loading local TIFFs using GeoTIFF's `fromFile` loader.
+
 ### Changed
 
 ## 0.13.3

--- a/packages/loaders/src/tiff/index.ts
+++ b/packages/loaders/src/tiff/index.ts
@@ -30,7 +30,7 @@ interface MultiTiffOptions {
 
 type MultiImage = Awaited<ReturnType<typeof loadOme>>; // get return-type from `load`
 
-const FILE_PREFIX = 'file://';
+export const FILE_PREFIX = 'file://';
 
 /** @ignore */
 export async function loadOmeTiff(

--- a/packages/loaders/src/tiff/index.ts
+++ b/packages/loaders/src/tiff/index.ts
@@ -54,7 +54,8 @@ export async function loadOmeTiff(
 /**
  * Opens an OME-TIFF via URL and returns data source and associated metadata for first or all images in files.
  *
- * @param {(string | File)} source url or File object.
+ * @param {(string | File)} source url or File object. If the url is prefixed with file:// will attempt to load with GeoTIFF's 'fromFile',
+ * which requires access to Node's fs module.
  * @param {Object} opts
  * @param {Headers=} opts.headers - Headers passed to each underlying fetch request.
  * @param {Array<number>=} opts.offsets - [Indexed-Tiff](https://github.com/hms-dbmi/generate-tiff-offsets) IFD offsets.
@@ -130,6 +131,7 @@ function getImageSelectionName(
  *
  * @param {Array<[OmeTiffSelection | (OmeTiffSelection | undefined)[], (string | File)]>} sources
  * Pairs of `[Selection | (OmeTiffSelection | undefined)[], string | File]` entries indicating the multidimensional selection in the virtual stack in image source (url string, or `File`).
+ * If the url is prefixed with file:// will attempt to load with GeoTIFF's 'fromFile', which requires access to Node's fs module.
  * You should only provide (OmeTiffSelection | undefined)[] when loading from stacked tiffs. In this case the array index corresponds to the image index in the stack, and the selection is the
  * selection that image corresponds to. Undefined selections are for images that should not be loaded.
  * @param {Object} opts


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #637
<!-- For all the PRs -->
#### Change List
- Adds support for loading image files using GeoTIFF's `fromFile` method if the url is prefixed with `file://`.

#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
