### PR TITLE
(feat): Add "Color" attribute support for "Channel" meta-tag

### DIFF
--- a/sites/avivator/src/hooks.js
+++ b/sites/avivator/src/hooks.js
@@ -134,7 +134,7 @@ export const useImage = (source, history) => {
         newColors =
           newDomains.length === 1
             ? [[255, 255, 255]]
-            : newDomains.map((_, i) => COLOR_PALLETE[i]);
+            : Channels.map((c, i) => (c.Color && c.Color.slice(0, -1)) ?? COLOR_PALLETE[i]);
         useViewerStore.setState({
           useLens: channelOptions.length !== 1,
           useColormap: true


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background
Some OME Tiff files contain ```Color``` attribute in ```Channel``` tag. This PR has an ability to use the given color information rather using built-in palette colors. The OME Tiff color information has alpha channel which is ignored in Viv for now.
<!-- For all the PRs -->
#### Change List
- Add ```Color``` attribute support for ```Channel``` meta-tag in OME Tiff
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
