### PR TITLE
(fix): ci pinned to ubuntu 20

### DIFF
--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm --filter=avivator build
 
   test-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       DISPLAY: :0
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added support for loading local TIFFs using GeoTIFF's `fromFile` loader.
 - Added `Color` attribute support for  `Channel` meta-tag.
+- Run tests only on ubuntu 20 in CI to prevent WebGL context creation failures.
 
 ### Changed
 


### PR DESCRIPTION
see https://github.com/hms-dbmi/viv/actions/runs/3656876866 for failure