### PR TITLE
(fix): allow for OME-TIFF with lots fo channels but no default color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 
 ### Changed
 
+- Fix Avivator to not require `Color` attribute.
+
 ## 0.13.4
 
 ### Added
 
 - Added support for loading local TIFFs using GeoTIFF's `fromFile` loader.
-- Added `Color` attribute support for  `Channel` meta-tag.
+- Added `Color` attribute support for `Channel` meta-tag.
 - Run tests only on ubuntu 20 in CI to prevent WebGL context creation failures.
 
 ### Changed

--- a/sites/avivator/src/components/Controller/Controller.jsx
+++ b/sites/avivator/src/components/Controller/Controller.jsx
@@ -28,7 +28,7 @@ import {
   useMetadata
 } from '../../state';
 import { guessRgb, useWindowSize, getSingleSelectionStats } from '../../utils';
-import { GLOBAL_SLIDER_DIMENSION_FIELDS } from '../../constants';
+import { COLOR_PALLETE, GLOBAL_SLIDER_DIMENSION_FIELDS } from '../../constants';
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -120,10 +120,18 @@ const Controller = () => {
         selection,
         use3d
       }).then(({ domain, contrastLimits: newContrastLimit }) => {
-        setPropertiesForChannel(i, {
+        const {
+          Pixels: { Channels }
+        } = metadata;
+        const { c } = selection;
+        const newProps = {
           contrastLimits: newContrastLimit,
           domains: domain
-        });
+        };
+        if (Channels[c].Color) {
+          newProps.colors = Channels[c].Color.slice(0, -1);
+        }
+        setPropertiesForChannel(i, newProps);
         useImageSettingsStore.setState({
           onViewportLoad: () => {
             useImageSettingsStore.setState({ onViewportLoad: () => {} });

--- a/sites/avivator/src/components/Controller/components/AddChannel.jsx
+++ b/sites/avivator/src/components/Controller/components/AddChannel.jsx
@@ -3,12 +3,13 @@ import Button from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/Add';
 import shallow from 'zustand/shallow';
 
-import { MAX_CHANNELS } from '../../../constants';
+import { MAX_CHANNELS, COLOR_PALLETE } from '../../../constants';
 import {
   useChannelsStore,
   useViewerStore,
   useImageSettingsStore,
-  useLoader
+  useLoader,
+  useMetadata
 } from '../../../state';
 import { getSingleSelectionStats } from '../../../utils';
 
@@ -38,6 +39,7 @@ const AddChannel = () => {
     shallow
   );
   const loader = useLoader();
+  const metadata = useMetadata();
   const { labels } = loader[0];
   const handleChannelAdd = useCallback(() => {
     let selection = Object.fromEntries(labels.map(l => [l, 0]));
@@ -60,10 +62,17 @@ const AddChannel = () => {
         }
       });
       addIsChannelLoading(true);
+      const {
+        Pixels: { Channels }
+      } = metadata;
+      const { c } = selection;
       addChannel({
         selections: selection,
         ids: String(Math.random()),
-        channelsVisible: false
+        channelsVisible: false,
+        colors:
+          (Channels[c].Color && Channels[c].Color.slice(0, -1)) ??
+          (COLOR_PALLETE[c] || [255, 255, 255])
       });
     });
   }, [
@@ -75,7 +84,8 @@ const AddChannel = () => {
     addIsChannelLoading,
     selections,
     setIsChannelLoading,
-    setPropertiesForChannel
+    setPropertiesForChannel,
+    metadata
   ]);
   return (
     <Button

--- a/sites/avivator/src/hooks.js
+++ b/sites/avivator/src/hooks.js
@@ -134,8 +134,10 @@ export const useImage = (source, history) => {
         newColors =
           newDomains.length === 1
             ? [[255, 255, 255]]
-            : Channels.map(
-                (c, i) => (c.Color && c.Color.slice(0, -1)) ?? COLOR_PALLETE[i]
+            : newDomains.map(
+                (_, i) =>
+                  (Channels[i].Color && Channels[i].Color.slice(0, -1)) ??
+                  COLOR_PALLETE[i]
               );
         useViewerStore.setState({
           useLens: channelOptions.length !== 1,


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #657 
<!-- For other PRs without open issue -->
#### Change List
- Don't rely on the default color palette or the metadata for determining colors
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
