### PR TITLE
(feat): updated `labels` to work with new `axis` for omengff v0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Issue cloudfront invalidation on deployment.
 - Fixed typos in README
+- Fix loading of omengff `multiscales` by allowing loading `labels` from new `axes` metadata
 
 ## 0.13.5
 

--- a/packages/loaders/src/zarr/lib/utils.ts
+++ b/packages/loaders/src/zarr/lib/utils.ts
@@ -70,8 +70,12 @@ export function getRootPrefix(files: { path: string }[], rootName: string) {
   return first.path.slice(0, prefixLength);
 }
 
-function isAxis(axisOrLabel: Labels<string[]> | Axis[]): axisOrLabel is Axis[] {
+function isAxis(axisOrLabel: string[] | Axis[]): axisOrLabel is Axis[] {
   return typeof axisOrLabel[0] !== 'string';
+}
+
+function castLabels(dimnames: string[]) {
+  return dimnames as Labels<string[]>;
 }
 
 export async function loadMultiscales(store: ZarrArray['store'], path = '') {
@@ -80,15 +84,15 @@ export async function loadMultiscales(store: ZarrArray['store'], path = '') {
 
   let paths = ['0'];
   // Default axes used for v0.1 and v0.2.
-  let labels = ['t', 'c', 'z', 'y', 'x'] as Labels<string[]>;
+  let labels = castLabels(['t', 'c', 'z', 'y', 'x']);
   if ('multiscales' in rootAttrs) {
     const { datasets, axes } = rootAttrs.multiscales[0];
     paths = datasets.map(d => d.path);
     if (axes) {
       if (isAxis(axes)) {
-        labels = axes.map(axis => axis.name) as Labels<string[]>;
+        labels = castLabels(axes.map(axis => axis.name));
       } else {
-        labels = axes as Labels<string[]>;
+        labels = castLabels(axes);
       }
     }
   }

--- a/packages/loaders/src/zarr/ome-zarr.ts
+++ b/packages/loaders/src/zarr/ome-zarr.ts
@@ -34,7 +34,7 @@ export interface Axis {
 
 interface Multiscale {
   datasets: { path: string }[];
-  axes?: Labels<string[]> | Axis[];
+  axes?: string[] | Axis[];
   version?: string;
 }
 

--- a/packages/loaders/src/zarr/ome-zarr.ts
+++ b/packages/loaders/src/zarr/ome-zarr.ts
@@ -25,9 +25,16 @@ interface Omero {
   name?: string;
 }
 
+// See https://ngff.openmicroscopy.org/latest/#axes-md
+export interface Axis {
+  name: string;
+  type?: string;
+  unit?: string;
+}
+
 interface Multiscale {
   datasets: { path: string }[];
-  axes?: Labels<string[]>;
+  axes?: Labels<string[]> | Axis[];
   version?: string;
 }
 


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #586
<!-- For other PRs without open issue -->

#### Change List
- Allow for loading `viv` `labels` from new `axes` metadata to support v0.4
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
