### PR TITLE
chore: add `@luma.gl/engine` to development environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Issue cloudfront invalidation on deployment.
 - Fixed typos in README
+- Fix loading of omengff `multiscales` by allowing loading `labels` from new `axes` metadata
 
 ## 0.13.5
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@deck.gl/react": "~8.8.6",
     "@luma.gl/constants": "~8.5.16",
     "@luma.gl/core": "~8.5.16",
+    "@luma.gl/engine": "~8.5.16",
     "@luma.gl/shadertools": "~8.5.16",
     "@luma.gl/webgl": "~8.5.16"
   },

--- a/packages/loaders/src/zarr/ome-zarr.ts
+++ b/packages/loaders/src/zarr/ome-zarr.ts
@@ -25,9 +25,16 @@ interface Omero {
   name?: string;
 }
 
+// See https://ngff.openmicroscopy.org/latest/#axes-md
+export interface Axis {
+  name: string;
+  type?: string;
+  unit?: string;
+}
+
 interface Multiscale {
   datasets: { path: string }[];
-  axes?: Labels<string[]>;
+  axes?: Labels<string[]> | Axis[];
   version?: string;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ importers:
       '@esbuild-plugins/node-modules-polyfill': ^0.1.4
       '@luma.gl/constants': ~8.5.16
       '@luma.gl/core': ~8.5.16
+      '@luma.gl/engine': ~8.5.16
       '@luma.gl/shadertools': ~8.5.16
       '@luma.gl/test-utils': ~8.5.16
       '@luma.gl/webgl': ~8.5.16
@@ -43,6 +44,7 @@ importers:
       '@deck.gl/react': 8.8.9_mrt7sh7ykgvh6cgbf4xlv4tad4
       '@luma.gl/constants': 8.5.16
       '@luma.gl/core': 8.5.16
+      '@luma.gl/engine': 8.5.16
       '@luma.gl/shadertools': 8.5.16
       '@luma.gl/webgl': 8.5.16
     devDependencies:
@@ -79,12 +81,10 @@ importers:
 
   packages/extensions:
     specifiers:
-      '@deck.gl/core': ~8.8.6
       '@vivjs/constants': workspace:*
       '@vivjs/types': workspace:*
       glsl-colormap: ^1.0.1
     dependencies:
-      '@deck.gl/core': 8.8.9
       '@vivjs/constants': link:../constants
     devDependencies:
       '@vivjs/types': link:../types
@@ -92,13 +92,6 @@ importers:
 
   packages/layers:
     specifiers:
-      '@deck.gl/core': ~8.8.6
-      '@deck.gl/geo-layers': ~8.8.6
-      '@deck.gl/layers': ~8.8.6
-      '@luma.gl/constants': ~8.5.16
-      '@luma.gl/core': ~8.5.16
-      '@luma.gl/engine': ~8.5.16
-      '@luma.gl/webgl': ~8.5.16
       '@math.gl/core': ^3.5.7
       '@math.gl/culling': ^3.5.7
       '@vivjs/constants': workspace:*
@@ -106,13 +99,6 @@ importers:
       '@vivjs/loaders': workspace:*
       '@vivjs/types': workspace:*
     dependencies:
-      '@deck.gl/core': 8.8.9
-      '@deck.gl/geo-layers': 8.8.9_5tyofsnqrjg2duiii3sbd7hw24
-      '@deck.gl/layers': 8.8.9_dpsvlm4pqc63w7kzqdhu56rqqa
-      '@luma.gl/constants': 8.5.16
-      '@luma.gl/core': 8.5.16
-      '@luma.gl/engine': 8.5.16
-      '@luma.gl/webgl': 8.5.16
       '@math.gl/core': 3.6.3
       '@math.gl/culling': 3.6.3
       '@vivjs/constants': link:../constants
@@ -164,31 +150,23 @@ importers:
 
   packages/viewers:
     specifiers:
-      '@deck.gl/react': ~8.8.6
       '@vivjs/constants': workspace:*
       '@vivjs/extensions': workspace:*
       '@vivjs/views': workspace:*
       fast-deep-equal: ^3.1.3
-      react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@deck.gl/react': 8.8.9_gqe3s7saqvf66wakynnhsn6efq
       '@vivjs/constants': link:../constants
       '@vivjs/extensions': link:../extensions
       '@vivjs/views': link:../views
       fast-deep-equal: 3.1.3
-      react: 17.0.2
 
   packages/views:
     specifiers:
-      '@deck.gl/core': ~8.8.6
-      '@deck.gl/layers': ~8.8.6
       '@math.gl/core': ^3.5.7
       '@vivjs/layers': workspace:*
       '@vivjs/loaders': workspace:*
       math.gl: ^3.5.7
     dependencies:
-      '@deck.gl/core': 8.8.9
-      '@deck.gl/layers': 8.8.9_dpsvlm4pqc63w7kzqdhu56rqqa
       '@math.gl/core': 3.6.3
       '@vivjs/layers': link:../layers
       '@vivjs/loaders': link:../loaders
@@ -672,20 +650,6 @@ packages:
       - '@luma.gl/engine'
       - '@luma.gl/gltools'
       - '@luma.gl/webgl'
-
-  /@deck.gl/react/8.8.9_gqe3s7saqvf66wakynnhsn6efq:
-    resolution: {integrity: sha512-muCUYVnpKuvxvPnOajpMUADeYQCSemnWjsZgUZGyItn00CbntWWQK889TnZFUNLsBY04XZV3oLTqV9SXL+PaoQ==}
-    peerDependencies:
-      '@deck.gl/core': ^8.0.0
-      '@types/react': '>= 16.3'
-      react: '>=16.3'
-      react-dom: '>=16.3'
-    dependencies:
-      '@deck.gl/core': 8.8.9
-      '@types/react': 18.0.17
-      react: 17.0.2
-      react-dom: 18.2.0_react@17.0.2
-    dev: false
 
   /@deck.gl/react/8.8.9_mrt7sh7ykgvh6cgbf4xlv4tad4:
     resolution: {integrity: sha512-muCUYVnpKuvxvPnOajpMUADeYQCSemnWjsZgUZGyItn00CbntWWQK889TnZFUNLsBY04XZV3oLTqV9SXL+PaoQ==}
@@ -7902,16 +7866,6 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
-    dev: false
-
-  /react-dom/18.2.0_react@17.0.2:
-    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
-    peerDependencies:
-      react: ^18.2.0
-    dependencies:
-      loose-envify: 1.4.0
-      react: 17.0.2
-      scheduler: 0.23.0
     dev: false
 
   /react-dom/18.2.0_react@18.2.0:


### PR DESCRIPTION
#### Background
Noticed we are missing a dependency in the root that is necessary.

#### Change List
-
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
