### PR TITLE
(fix): Revert `Float64` Reversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Fix `Float64` reversion from the fix in 0.12.8
 
 ## 0.13.6
 

--- a/packages/layers/src/xr-layer/utils.js
+++ b/packages/layers/src/xr-layer/utils.js
@@ -1,0 +1,61 @@
+import GL from '@luma.gl/constants';
+import { isWebGL2 } from '@luma.gl/core';
+import { hasFeature, FEATURES } from '@luma.gl/webgl';
+import { getDtypeValues } from '../utils';
+
+import fs from './xr-layer-fragment.glsl';
+import vs from './xr-layer-vertex.glsl';
+
+const coreShaderModule = { fs, vs };
+
+function validateWebGL2Filter(gl, interpolation) {
+  const canShowFloat = hasFeature(gl, FEATURES.TEXTURE_FLOAT);
+  const canShowLinear = hasFeature(gl, FEATURES.TEXTURE_FILTER_LINEAR_FLOAT);
+
+  if (!canShowFloat) {
+    throw new Error(
+      'WebGL1 context does not support floating point textures.  Unable to display raster data.'
+    );
+  }
+
+  if (!canShowLinear && interpolation === GL.LINEAR) {
+    console.warn(
+      'LINEAR filtering not supported in WebGL1 context.  Falling back to NEAREST.'
+    );
+    return GL.NEAREST;
+  }
+
+  return interpolation;
+}
+
+export function getRenderingAttrs(dtype, gl, interpolation) {
+  if (!isWebGL2(gl)) {
+    return {
+      format: GL.LUMINANCE,
+      dataFormat: GL.LUMINANCE,
+      type: GL.FLOAT,
+      sampler: 'sampler2D',
+      shaderModule: coreShaderModule,
+      filter: validateWebGL2Filter(gl, interpolation),
+      cast: data => new Float32Array(data)
+    };
+  }
+  // Linear filtering only works when the data type is cast to Float32.
+  const isLinear = interpolation === GL.LINEAR;
+  // Need to add es version tag so that shaders work in WebGL2 since the tag is needed for using usampler2d with WebGL2.
+  // Very cursed!
+  const upgradedShaderModule = { ...coreShaderModule };
+  const version300str = '#version 300 es\n';
+  upgradedShaderModule.fs = version300str.concat(upgradedShaderModule.fs);
+  upgradedShaderModule.vs = version300str.concat(upgradedShaderModule.vs);
+  const values = getDtypeValues(isLinear ? 'Float32' : dtype);
+  // Check if a cast function is present in the returned data for the dtype
+  const identity = x => x;
+  const cast = typeof values.cast === 'function' ? values.cast : identity;
+  return {
+    ...values,
+    shaderModule: upgradedShaderModule,
+    filter: interpolation,
+    cast: isLinear ? data => new Float32Array(data) : cast
+  };
+}

--- a/packages/layers/src/xr-layer/utils.js
+++ b/packages/layers/src/xr-layer/utils.js
@@ -49,13 +49,10 @@ export function getRenderingAttrs(dtype, gl, interpolation) {
   upgradedShaderModule.fs = version300str.concat(upgradedShaderModule.fs);
   upgradedShaderModule.vs = version300str.concat(upgradedShaderModule.vs);
   const values = getDtypeValues(isLinear ? 'Float32' : dtype);
-  // Check if a cast function is present in the returned data for the dtype
-  const identity = x => x;
-  const cast = typeof values.cast === 'function' ? values.cast : identity;
   return {
-    ...values,
     shaderModule: upgradedShaderModule,
     filter: interpolation,
-    cast: isLinear ? data => new Float32Array(data) : cast
+    cast: isLinear ? data => new Float32Array(data) : data => data,
+    ...values
   };
 }

--- a/packages/layers/src/xr-layer/xr-layer.js
+++ b/packages/layers/src/xr-layer/xr-layer.js
@@ -3,68 +3,11 @@
 // we live in place for now, hence some of the not-destructuring
 import GL from '@luma.gl/constants';
 import { COORDINATE_SYSTEM, Layer, project32, picking } from '@deck.gl/core';
-import { Model, Geometry, Texture2D, isWebGL2 } from '@luma.gl/core';
+import { Model, Geometry, Texture2D } from '@luma.gl/core';
 import { ProgramManager } from '@luma.gl/engine';
-import { hasFeature, FEATURES } from '@luma.gl/webgl';
 import channels from './shader-modules/channel-intensity';
-import { padContrastLimits, getDtypeValues } from '../utils';
-
-import fs from './xr-layer-fragment.glsl';
-import vs from './xr-layer-vertex.glsl';
-
-const coreShaderModule = { fs, vs };
-
-function validateWebGL2Filter(gl, interpolation) {
-  const canShowFloat = hasFeature(gl, FEATURES.TEXTURE_FLOAT);
-  const canShowLinear = hasFeature(gl, FEATURES.TEXTURE_FILTER_LINEAR_FLOAT);
-
-  if (!canShowFloat) {
-    throw new Error(
-      'WebGL1 context does not support floating point textures.  Unable to display raster data.'
-    );
-  }
-
-  if (!canShowLinear && interpolation === GL.LINEAR) {
-    console.warn(
-      'LINEAR filtering not supported in WebGL1 context.  Falling back to NEAREST.'
-    );
-    return GL.NEAREST;
-  }
-
-  return interpolation;
-}
-
-function getRenderingAttrs(dtype, gl, interpolation) {
-  if (!isWebGL2(gl)) {
-    return {
-      format: GL.LUMINANCE,
-      dataFormat: GL.LUMINANCE,
-      type: GL.FLOAT,
-      sampler: 'sampler2D',
-      shaderModule: coreShaderModule,
-      filter: validateWebGL2Filter(gl, interpolation),
-      cast: data => new Float32Array(data)
-    };
-  }
-  // Linear filtering only works when the data type is cast to Float32.
-  const isLinear = interpolation === GL.LINEAR;
-  // Need to add es version tag so that shaders work in WebGL2 since the tag is needed for using usampler2d with WebGL2.
-  // Very cursed!
-  const upgradedShaderModule = { ...coreShaderModule };
-  const version300str = '#version 300 es\n';
-  upgradedShaderModule.fs = version300str.concat(upgradedShaderModule.fs);
-  upgradedShaderModule.vs = version300str.concat(upgradedShaderModule.vs);
-  const values = getDtypeValues(isLinear ? 'Float32' : dtype);
-  // Check if a cast function is present in the returned data for the dtype
-  const identity = x => x;
-  const cast = typeof values.cast === 'function' ? values.cast : identity;
-  return {
-    ...values,
-    shaderModule: upgradedShaderModule,
-    filter: interpolation,
-    cast: isLinear ? data => new Float32Array(data) : cast
-  };
-}
+import { padContrastLimits } from '../utils';
+import { getRenderingAttrs } from './utils';
 
 const defaultProps = {
   pickable: { type: 'boolean', value: true, compare: true },

--- a/packages/layers/src/xr-layer/xr-layer.js
+++ b/packages/layers/src/xr-layer/xr-layer.js
@@ -55,11 +55,14 @@ function getRenderingAttrs(dtype, gl, interpolation) {
   upgradedShaderModule.fs = version300str.concat(upgradedShaderModule.fs);
   upgradedShaderModule.vs = version300str.concat(upgradedShaderModule.vs);
   const values = getDtypeValues(isLinear ? 'Float32' : dtype);
+  // Check if a cast function is present in the returned data for the dtype
+  const identity = x => x;
+  const cast = typeof values.cast === 'function' ? values.cast : identity;
   return {
     ...values,
     shaderModule: upgradedShaderModule,
     filter: interpolation,
-    cast: isLinear ? data => new Float32Array(data) : data => data
+    cast: isLinear ? data => new Float32Array(data) : cast
   };
 }
 

--- a/packages/layers/tests/utils.spec.js
+++ b/packages/layers/tests/utils.spec.js
@@ -1,66 +1,167 @@
 import test from 'tape-catch';
 import { range } from '../src/multiscale-image-layer/utils';
 import { padWithDefault, padContrastLimits } from '../src/utils';
+import { createTestContext } from '@luma.gl/test-utils';
+import GL from '@luma.gl/constants';
+import { FEATURES } from '@luma.gl/webgl';
+
+import { getRenderingAttrs } from '../src/xr-layer/utils';
+import { DTYPE_VALUES } from '../../constants';
+import { hasFeature } from '@luma.gl/webgl';
+
+const dtypes = Object.keys(DTYPE_VALUES);
+const interpolations = [GL.NEAREST, GL.LINEAR];
 
 test('range test', t => {
-  const expected = [0, 1, 2];
-  t.deepEqual(range(3), expected, 'Create list for range(3)');
-  t.deepEqual(range(0), [], 'Empty list for range(0)');
+  t.plan(2);
+  try {
+    const expected = [0, 1, 2];
+    t.deepEqual(range(3), expected, 'Create list for range(3)');
+    t.deepEqual(range(0), [], 'Empty list for range(0)');
+  } catch (e) {
+    t.fail(e);
+  }
   t.end();
 });
 
 test('padWithDefault test', t => {
-  const expected = [3, 4, 5, 2, 2];
-  t.deepEqual(
-    padWithDefault([3, 4, 5], 2, 2),
-    expected,
-    "Pad with two's to five places."
-  );
+  t.plan(1);
+  try {
+    const expected = [3, 4, 5, 2, 2];
+    t.deepEqual(
+      padWithDefault([3, 4, 5], 2, 2),
+      expected,
+      "Pad with two's to five places."
+    );
+  } catch (e) {
+    t.fail(e);
+  }
   t.end();
 });
 
 test('padContrastLimits test', t => {
-  const expectedChannelOff = [
-    0, 5, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
-  ];
+  t.plan(2);
+  try {
+    const expectedChannelOff = [
+      0, 5, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+    ];
 
-  const expected16Bit = [
-    0,
-    5,
-    0,
-    5,
-    2 ** 16 - 1,
-    2 ** 16 - 1,
-    2 ** 16 - 1,
-    2 ** 16 - 1,
-    2 ** 16 - 1,
-    2 ** 16 - 1,
-    2 ** 16 - 1,
-    2 ** 16 - 1
-  ];
-  t.deepEqual(
-    padContrastLimits({
-      contrastLimits: [
-        [0, 5],
-        [0, 5]
-      ],
-      channelsVisible: [true, false],
-      dtype: 'Uint8'
-    }),
-    expectedChannelOff,
-    'Pads with one channel turned off'
-  );
-  t.deepEqual(
-    padContrastLimits({
-      contrastLimits: [
-        [0, 5],
-        [0, 5]
-      ],
-      channelsVisible: [true, true],
-      dtype: 'Uint16'
-    }),
-    expected16Bit,
-    'Pads with high bit depth'
-  );
+    const expected16Bit = [
+      0,
+      5,
+      0,
+      5,
+      2 ** 16 - 1,
+      2 ** 16 - 1,
+      2 ** 16 - 1,
+      2 ** 16 - 1,
+      2 ** 16 - 1,
+      2 ** 16 - 1,
+      2 ** 16 - 1,
+      2 ** 16 - 1
+    ];
+    t.deepEqual(
+      padContrastLimits({
+        contrastLimits: [
+          [0, 5],
+          [0, 5]
+        ],
+        channelsVisible: [true, false],
+        dtype: 'Uint8'
+      }),
+      expectedChannelOff,
+      'Pads with one channel turned off'
+    );
+    t.deepEqual(
+      padContrastLimits({
+        contrastLimits: [
+          [0, 5],
+          [0, 5]
+        ],
+        channelsVisible: [true, true],
+        dtype: 'Uint16'
+      }),
+      expected16Bit,
+      'Pads with high bit depth'
+    );
+  } catch (e) {
+    t.fail(e);
+  }
+  t.end();
+});
+
+test('getRenderingAttrs WebGL1', t => {
+  t.plan(dtypes.length * interpolations * 6);
+  try {
+    const gl = createTestContext({ webgl1: true, webgl2: false });
+    interpolations.forEach(interpolation => {
+      dtypes.forEach(dtype => {
+        const attrs = getRenderingAttrs(dtype, gl, interpolation);
+        t.deepEqual(
+          attrs.cast(new Uint16Array([1, 2, 3])),
+          new Float32Array([1, 2, 3]),
+          `always cast ${dtype} to Float32`
+        );
+        t.equal(
+          attrs.sampler,
+          'sampler2D',
+          `always return sampler2D as sampler`
+        );
+        t.equal(attrs.type, GL.FLOAT, `always return FLOAT as dtype`);
+        t.equal(
+          attrs.dataFormat,
+          GL.LUMINANCE,
+          `always return LUMINANCE as dataFormat`
+        );
+        t.equal(
+          attrs.format,
+          GL.LUMINANCE,
+          `always return LUMINANCE as format`
+        );
+        t.equal(
+          attrs.filter,
+          hasFeature(gl, FEATURES.TEXTURE_FILTER_LINEAR_FLOAT)
+            ? interpolation
+            : GL.NEAREST,
+          `use interpolation ${interpolation} if gl context supports LINEAR - otherwise return NEAREST`
+        );
+      });
+    });
+  } catch (e) {
+    t.fail(e);
+  }
+  t.end();
+});
+
+test('getRenderingAttrs WebGL2', t => {
+  t.plan(dtypes.length * interpolations.length * 2);
+  try {
+    const gl = createTestContext({ webgl2: true, webgl1: false });
+    interpolations.forEach(interpolation => {
+      dtypes.forEach(dtype => {
+        const attrs = getRenderingAttrs(dtype, gl, interpolation);
+        if (interpolation == GL.LINEAR || dtype == 'Float64') {
+          t.deepEqual(
+            attrs.cast(new Uint16Array([1, 2, 3])),
+            new Float32Array([1, 2, 3]),
+            'always cast to Float32 for LINEAR or Float64'
+          );
+        } else {
+          t.deepEqual(
+            attrs.cast(new Uint16Array([1, 2, 3])),
+            new Uint16Array([1, 2, 3]),
+            `identity cast function for ${dtype} or non-LINEAR interpolation`
+          );
+        }
+        t.equal(
+          attrs.filter,
+          interpolation,
+          `always use interpolation ${interpolation}`
+        );
+      });
+    });
+  } catch (e) {
+    t.fail(e);
+  }
   t.end();
 });


### PR DESCRIPTION
#### Background
We noticed that image pyramids for `Float64` data had stopped working in HuBMAP and it turns out there was a reversion here: https://github.com/hms-dbmi/viv/pull/606/files#diff-2c110f17c1fdf417f10e305da452bca1673357b88d8815dd47cd7698d81a5424

This is a little bit concerning considering the size of that PR but I made another pass at it and didn't notice anything else.  cc @manzt 
#### Change List
- Revert the `Float64` fix reversion
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
