### PR TITLE
fix: Fixing overview click event not firing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## In Progress
 
+### Changed
+- Fixed `click` event not firing on Overview panel
+
 ### Added
 
 ### Changed

--- a/packages/views/src/OverviewView.js
+++ b/packages/views/src/OverviewView.js
@@ -8,11 +8,9 @@ import { getVivId } from './utils';
 
 export const OVERVIEW_VIEW_ID = 'overview';
 
-class OverviewState {}
-
 class OverviewController extends Controller {
   constructor(props) {
-    super(OverviewState, props);
+    super(props);
     this.events = ['click'];
   }
 
@@ -21,7 +19,7 @@ class OverviewController extends Controller {
       return;
     }
     let [x, y] = this.getCenter(event);
-    const { width, height, zoom, scale } = this.controllerStateProps;
+    const { width, height, zoom, scale } = this.props;
     if (x < 0 || y < 0 || x > width || y > height) {
       return;
     }


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #645
<!-- For other PRs without open issue -->
#### Background
- Clicking on overview was not centering main viewer. It seems that there's contradiction in deck.gl documentation:
https://deck.gl/docs/api-reference/core/controller. Specifically, `Controller` class is only accepting `props` without the `Viewstate`. Passing `Viewstate` to `super` instead of props was causing the lack of response on mouse events, as `props` contain, among others, `EventManager` which subscribes to user events.
#### Change List
- Fixed the issue where clicking on overview window did not center the main viewer accordingly
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
