### PR TITLE
(fix): correct initial zoom for scaled images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 - Fixed `click` event not firing on Overview panel
-
+- Fixed `zoom` in `getDefaultInitialViewState`
 ### Added
 
 ### Changed

--- a/packages/views/src/utils.js
+++ b/packages/views/src/utils.js
@@ -30,17 +30,19 @@ export function getDefaultInitialViewState(
   modelMatrix
 ) {
   const source = Array.isArray(loader) ? loader[0] : loader;
-  const { width, height } = getImageSize(source);
+  const { width: pixelWidth, height: pixelHeight } = getImageSize(source);
+  const scale = (modelMatrix || new Matrix4()).getScale();
+  const [trueWidth, trueHeight] = [scale[0] * pixelWidth, scale[1] * pixelHeight];
   const depth = source.shape[source.labels.indexOf('z')];
   const zoom =
-    Math.log2(Math.min(viewSize.width / width, viewSize.height / height)) -
+    Math.log2(Math.min(viewSize.width / trueWidth, viewSize.height / trueHeight)) -
     zoomBackOff;
   const physicalSizeScalingMatrix = getPhysicalSizeScalingMatrix(source);
   const loaderInitialViewState = {
     target: (modelMatrix || new Matrix4()).transformPoint(
       (use3d ? physicalSizeScalingMatrix : new Matrix4()).transformPoint([
-        width / 2,
-        height / 2,
+        pixelWidth / 2,
+        pixelHeight / 2,
         use3d ? depth / 2 : 0
       ])
     ),


### PR DESCRIPTION
#### Background
Scaled images have differently displayed height/width than their pixel height/width.  This is accounted for when setting the `target` by the `modelMatrix` transform but not for the `zoom`
#### Change List
- Account for `modelMatrix` when setting `zoom` level
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
