### PR TITLE
Allow for passing slice type

### DIFF
--- a/packages/loaders/src/index.ts
+++ b/packages/loaders/src/index.ts
@@ -2,7 +2,8 @@ export { loadOmeTiff, loadMultiTiff } from './tiff';
 export { loadBioformatsZarr, loadOmeZarr } from './zarr';
 
 export { default as TiffPixelSource } from './tiff/pixel-source';
-export { default as ZarrPixelSource } from './zarr/pixel-source';
+export { default as ZarrPixelSource } from './zarr/pixel-source-zarrjs';
+export { default as ZarritaPixelSource } from './zarr/pixel-source-zarrita';
 
 export {
   getChannelStats,

--- a/packages/loaders/src/zarr/ome-zarr.ts
+++ b/packages/loaders/src/zarr/ome-zarr.ts
@@ -1,7 +1,7 @@
 import type { ZarrArray } from 'zarr';
 import type { Labels } from '@vivjs/types';
 import { loadMultiscales, guessTileSize } from './lib/utils';
-import ZarrPixelSource from './pixel-source';
+import ZarrPixelSource from './pixel-source-zarrjs';
 
 interface Channel {
   channelsVisible: boolean;

--- a/packages/loaders/src/zarr/pixel-source-zarrita.ts
+++ b/packages/loaders/src/zarr/pixel-source-zarrita.ts
@@ -1,0 +1,17 @@
+import type { ZarrArray } from 'zarr';
+import type { Labels } from '@vivjs/types';
+import AbstractZarrPixelSource from './pixel-source';
+import { KeyError } from '@zarrita/core'; // TODO: is this the right error type?
+import { slice } from '@zarrita/indexing';
+
+class ZarritaPixelSource<S extends string[]> extends AbstractZarrPixelSource<S> {
+  constructor(
+    data: ZarrArray,
+    public labels: Labels<S>,
+    public tileSize: number,
+  ) {
+    super(data, labels, tileSize, KeyError, slice);
+  }
+}
+
+export default ZarritaPixelSource;

--- a/packages/loaders/src/zarr/pixel-source-zarrjs.ts
+++ b/packages/loaders/src/zarr/pixel-source-zarrjs.ts
@@ -1,0 +1,16 @@
+import type { ZarrArray } from 'zarr';
+import type { Labels } from '@vivjs/types';
+import AbstractZarrPixelSource from './pixel-source';
+import { BoundsCheckError, slice } from 'zarr';
+
+class ZarrPixelSource<S extends string[]> extends AbstractZarrPixelSource<S> {
+  constructor(
+    data: ZarrArray,
+    public labels: Labels<S>,
+    public tileSize: number,
+  ) {
+    super(data, labels, tileSize, BoundsCheckError, slice);
+  }
+}
+
+export default ZarrPixelSource;


### PR DESCRIPTION

#### Background
<!-- For all the PRs -->

ZarrJS cannot currently be tree-shaken-out of the `ZarrPixelSource` class because it imports `slice` and `BoundsCheckError`.

#### Change List
- Create an internal parent class which takes a `slice` function and error type as constructor parameters. Use `super()` in the subclasses to enable `super(zarr.slice, zarr.BoundsCheckError)` and `super(zarrita.slice, zarrita.BoundsCheckError)`
  - @manzt is there a Zarrita equivalent of ZarrJS BoundsCheckError?
 
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
