### PR TITLE
feat(loaders): Introduce more minimal required Zarr interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Bump `gl` to v6 and move to Node.js 18 in CI.
+- Narrow required interface for `ZarrPixelSource`.
 
 ## 0.13.8
 

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -30,7 +30,7 @@
     "geotiff": "^2.0.5",
     "lzw-tiff-decoder": "^0.1.1",
     "quickselect": "^2.0.0",
-    "zarr": "^0.5.1"
+    "zarr": "^0.6.2"
   },
   "unbuild": {
     "entries": [

--- a/packages/loaders/src/zarr/pixel-source.ts
+++ b/packages/loaders/src/zarr/pixel-source.ts
@@ -120,9 +120,8 @@ class ZarrPixelSource<S extends string[]> implements PixelSource<S> {
 
   private async _getRaw(
     selection: (null | Slice | number)[],
-    getOptions?: { storageOptions?: any }
+    getOptions?: { storeOptions?: any }
   ) {
-    // @ts-expect-error - TODO: fix ZarrJS types, this is correct
     const result = await this._data.getRaw(selection, getOptions);
     if (typeof result !== 'object') {
       throw new Error('Expected object from getRaw');
@@ -135,7 +134,7 @@ class ZarrPixelSource<S extends string[]> implements PixelSource<S> {
     signal
   }: RasterSelection<S> | ZarrRasterSelection) {
     const sel = this._chunkIndex(selection, { x: null, y: null });
-    const result = await this._getRaw(sel, { storageOptions: { signal } });
+    const result = await this._getRaw(sel, { storeOptions: { signal } });
     const {
       data,
       shape: [height, width]
@@ -147,7 +146,7 @@ class ZarrPixelSource<S extends string[]> implements PixelSource<S> {
     const { x, y, selection, signal } = props;
     const [xSlice, ySlice] = this._getSlices(x, y);
     const sel = this._chunkIndex(selection, { x: xSlice, y: ySlice });
-    const tile = await this._getRaw(sel, { storageOptions: { signal } });
+    const tile = await this._getRaw(sel, { storeOptions: { signal } });
     const {
       data,
       shape: [height, width]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,8 +188,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       zarr:
-        specifier: ^0.5.1
-        version: 0.5.2
+        specifier: ^0.6.2
+        version: 0.6.2
 
   packages/main:
     dependencies:
@@ -10441,8 +10441,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zarr@0.5.2:
-    resolution: {integrity: sha512-XiAZTlkCTALZyXCAXY2rgfRY45sIaGZd/rKKuQa84+bjpxoyNYXbAU5uaIDTR+CvIuTFABqq8Gc4PfzZHYOvkw==}
+  /zarr@0.6.2:
+    resolution: {integrity: sha512-3gtxrnpziRlDtrz0hz/M+hreCC5YexppeCVHK62Pmb2FSn947h14GHMDj9rQFkY2mPhRKDHhtB+AUGa8wqJW6Q==}
     engines: {node: '>=12'}
     dependencies:
       numcodecs: 0.2.2


### PR DESCRIPTION
An alternative to #698. This removes the code paths for importing from ZarrJS in the `ZarrPixelSource`. It should be straightforward to introduce an adapter for `zarrita` to support the `ZarrSource` interface. 

```javascript
import { FetchStore, open, get } from "zarrita";

function zarrSourceAdapter(arr) {
  return {
    dtype: convertToV2DataType(arr.dtype),
    shape: arr.shape,
    chunks: arr.chunks,
    getRaw: (selection, { storeOptions }) => get(arr, selection, { opts: storeOptions }),
  }
}

let store = new FetchStore("http://localhost:8080/data.zarr");
let arr = await open(store, { kind: "array" });
let pixelSource = new ZarrPixelSource(zarrSourceAdapter(arr), ...);
```

Aligning the TypeScript types for these libraries is really going to be a pain. Some of the typing is really wack in ZarrJS, and the type inference in Zarrita are much more precise so they don't align well. But we can work on that later. The more important thing is making sure ZarrJS can be treeshaken if zarrita is used.


#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
