### PR TITLE
feat(loaders): Drop `fast-xml-parser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bump `gl` to v6 and move to Node.js 18 in CI.
 - Narrow required interface for `ZarrPixelSource`.
 - Update dev dependencies
+- Drop `fast-xml-parser` dependency in `@vivjs/loaders`
 
 ## 0.13.8
 

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@vivjs/types": "workspace:*",
-    "fast-xml-parser": "^3.16.0",
     "geotiff": "^2.0.5",
     "lzw-tiff-decoder": "^0.1.1",
     "quickselect": "^2.0.0",

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -36,5 +36,8 @@
       "src/index"
     ],
     "declaration": true
+  },
+  "devDependencies": {
+    "xmldom": "^0.6.0"
   }
 }

--- a/packages/loaders/src/omexml.ts
+++ b/packages/loaders/src/omexml.ts
@@ -1,28 +1,11 @@
-import * as parser from 'fast-xml-parser';
-import { ensureArray, intToRgba } from './utils';
-
-// WARNING: Changes to the parser options _will_ effect the types in types/omexml.d.ts.
-const PARSER_OPTIONS = {
-  // Nests attributes withtout prefix under 'attr' key for each node
-  attributeNamePrefix: '',
-  attrNodeName: 'attr',
-
-  // Parses numbers for both attributes and nodes
-  parseNodeValue: true,
-  parseAttributeValue: true,
-
-  // Forces attributes to be parsed
-  ignoreAttributes: false
-};
-
-const parse = (str: string): Root => parser.parse(str, PARSER_OPTIONS);
+import { ensureArray, intToRgba, parseXML } from './utils';
 
 export function fromString(str: string) {
-  const res = parse(str);
-  if (!res.OME) {
+  const res = parseXML(str);
+  if (!isOme(res)) {
     throw Error('Failed to parse OME-XML metadata.');
   }
-  return ensureArray(res.OME.Image).map(img => {
+  return ensureArray(res.Image).map(img => {
     const Channels = ensureArray(img.Pixels.Channel).map(c => {
       if ('Color' in c.attr) {
         return { ...c.attr, Color: intToRgba(c.attr.Color) };
@@ -185,4 +168,6 @@ type ChannelAttrs =
 
 type Channel = AttrsOnlyNode<ChannelAttrs>;
 
-type Root = { OME: OME };
+function isOme(obj: unknown): obj is OME {
+  return typeof obj === 'object' && obj !== null && 'Image' in obj;
+}

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -249,7 +249,7 @@ function xmlToJson(
   for (let i = 0; i < xmlNode.childNodes.length; i++) {
     const childNode = xmlNode.childNodes[i];
     if (!isElement(childNode)) {
-      throw new Error('Unexpected child node type');
+      continue;
     }
     const childJson = xmlToJson(childNode, options);
     if (childJson !== undefined && childJson !== '') {

--- a/packages/loaders/tests/index.spec.js
+++ b/packages/loaders/tests/index.spec.js
@@ -1,4 +1,4 @@
-import { DOMParser } from "xmldom";
+import { DOMParser } from 'xmldom';
 globalThis.DOMParser = DOMParser;
 
 import './utils.spec';

--- a/packages/loaders/tests/index.spec.js
+++ b/packages/loaders/tests/index.spec.js
@@ -1,3 +1,6 @@
+import { DOMParser } from "xmldom";
+globalThis.DOMParser = DOMParser;
+
 import './utils.spec';
 
 import './ome-tiff.spec';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,9 +178,6 @@ importers:
       '@vivjs/types':
         specifier: workspace:*
         version: link:../types
-      fast-xml-parser:
-        specifier: ^3.16.0
-        version: 3.21.1
       geotiff:
         specifier: ^2.0.5
         version: 2.0.5
@@ -5260,13 +5257,6 @@ packages:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
     dev: true
 
-  /fast-xml-parser@3.21.1:
-    resolution: {integrity: sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==}
-    hasBin: true
-    dependencies:
-      strnum: 1.0.5
-    dev: false
-
   /fastq@1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
     dependencies:
@@ -10094,10 +10084,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
     dev: true
-
-  /strnum@1.0.5:
-    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
-    dev: false
 
   /subarg@1.0.0:
     resolution: {integrity: sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,10 @@ importers:
       zarr:
         specifier: ^0.6.2
         version: 0.6.2
+    devDependencies:
+      xmldom:
+        specifier: ^0.6.0
+        version: 0.6.0
 
   packages/main:
     dependencies:
@@ -2497,6 +2501,7 @@ packages:
 
   /@types/node@18.7.13:
     resolution: {integrity: sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==}
+    requiresBuild: true
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -2924,6 +2929,7 @@ packages:
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       color-convert: 1.9.3
 
@@ -3652,6 +3658,7 @@ packages:
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    requiresBuild: true
     dependencies:
       color-name: 1.1.3
 
@@ -3664,6 +3671,7 @@ packages:
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    requiresBuild: true
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -4479,6 +4487,7 @@ packages:
   /encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
+    requiresBuild: true
     dev: true
 
   /encoding@0.1.13:
@@ -5993,6 +6002,7 @@ packages:
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
+    requiresBuild: true
 
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -8455,6 +8465,7 @@ packages:
   /pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dev: true
 
   /pify@5.0.0:
@@ -10121,6 +10132,7 @@ packages:
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       has-flag: 3.0.0
 
@@ -11238,6 +11250,11 @@ packages:
   /xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+    dev: true
+
+  /xmldom@0.6.0:
+    resolution: {integrity: sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==}
+    engines: {node: '>=10.0.0'}
     dev: true
 
   /xtend@2.1.2:


### PR DESCRIPTION
Removes `fast-xml-parser` dependency in favor of using [`DOMParser`](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser) Web API.

All the examples and tests are passing, but I don't think Avivator makes use of much of the metadata. This is probably somewhere that snapshot testing could help us a bit. @keller-mark, I don't anticipate this to be a breaking change but maybe there is something I'm missing wrt what Vitessce relies on (if any) of the parsed and modified OME-XML metadata.

<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
