### PR TITLE
feat: Validate expected OME-XML metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Narrow required interface for `ZarrPixelSource`.
 - Update dev dependencies
 - Drop `fast-xml-parser` dependency in `@vivjs/loaders`
+- Validate expected OME-XML data-types
 
 ## 0.13.8
 

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -29,7 +29,8 @@
     "geotiff": "^2.0.5",
     "lzw-tiff-decoder": "^0.1.1",
     "quickselect": "^2.0.0",
-    "zarr": "^0.6.2"
+    "zarr": "^0.6.2",
+    "zod": "^3.22.4"
   },
   "unbuild": {
     "entries": [

--- a/packages/loaders/src/omexml.ts
+++ b/packages/loaders/src/omexml.ts
@@ -1,8 +1,7 @@
 import { ensureArray, intToRgba, parseXML } from './utils';
 import * as z from 'zod';
 
-export type OMEXML = ReturnType<typeof fromString>;
-export type DimensionOrder = z.infer<typeof DimensionOrderSchema>;
+export type OmeXml = ReturnType<typeof fromString>;
 
 type Prettify<T> = {
   [K in keyof T]: T[K];
@@ -16,6 +15,7 @@ function flattenAttributes<T extends { attr: Record<string, unknown> }>({
   return { ...attr, ...rest };
 }
 
+export type DimensionOrder = z.infer<typeof DimensionOrderSchema>;
 const DimensionOrderSchema = z.enum([
   'XYZCT',
   'XYZTC',
@@ -39,7 +39,8 @@ const PixelTypeSchema = z.enum([
   'double-complex'
 ]);
 
-const UnitLengthSchema = z.enum([
+export type UnitsLength = z.infer<typeof UnitsLengthSchema>;
+const UnitsLengthSchema = z.enum([
   'Ym',
   'Zm',
   'Em',
@@ -120,18 +121,18 @@ const PixelsSchema = z
       ID: z.string(),
       DimensionOrder: DimensionOrderSchema,
       Type: PixelTypeSchema,
+      SizeT: z.coerce.number(),
+      SizeC: z.coerce.number(),
+      SizeZ: z.coerce.number(),
+      SizeY: z.coerce.number(),
+      SizeX: z.coerce.number(),
       PhysicalSizeX: z.coerce.number().optional(),
       PhysicalSizeY: z.coerce.number().optional(),
       PhysicalSizeZ: z.coerce.number().optional(),
       SignificantBits: z.coerce.number().optional(),
-      SizeT: z.coerce.number().optional(),
-      SizeC: z.coerce.number().optional(),
-      SizeZ: z.coerce.number().optional(),
-      SizeY: z.coerce.number().optional(),
-      SizeX: z.coerce.number().optional(),
-      PhysicalSizeXUnit: UnitLengthSchema.optional(),
-      PhysicalSizeYUnit: UnitLengthSchema.optional(),
-      PhysicalSizeZUnit: UnitLengthSchema.optional(),
+      PhysicalSizeXUnit: UnitsLengthSchema.optional(),
+      PhysicalSizeYUnit: UnitsLengthSchema.optional(),
+      PhysicalSizeZUnit: UnitsLengthSchema.optional(),
       BigEndian: z
         .string()
         .transform(v => v.toLowerCase() === 'true')

--- a/packages/loaders/src/omexml.ts
+++ b/packages/loaders/src/omexml.ts
@@ -1,173 +1,201 @@
 import { ensureArray, intToRgba, parseXML } from './utils';
+import * as z from 'zod';
+
+export type OMEXML = ReturnType<typeof fromString>;
+export type DimensionOrder = z.infer<typeof DimensionOrderSchema>;
+
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {}; // eslint-disable-line
+
+function flattenAttributes<T extends { attr: Record<string, unknown> }>({
+  attr,
+  ...rest
+}: T): Prettify<Pick<T, Exclude<keyof T, 'attr'>> & T['attr']> {
+  // @ts-expect-error - TS doesn't like the prettify type
+  return { ...attr, ...rest };
+}
+
+const DimensionOrderSchema = z.enum([
+  'XYZCT',
+  'XYZTC',
+  'XYCTZ',
+  'XYCZT',
+  'XYTCZ',
+  'XYTZC'
+]);
+
+const PixelTypeSchema = z.enum([
+  'int8',
+  'int16',
+  'int32',
+  'uint8',
+  'uint16',
+  'uint32',
+  'float',
+  'bit',
+  'double',
+  'complex',
+  'double-complex'
+]);
+
+const UnitLengthSchema = z.enum([
+  'Ym',
+  'Zm',
+  'Em',
+  'Pm',
+  'Tm',
+  'Gm',
+  'Mm',
+  'km',
+  'hm',
+  'dam',
+  'm',
+  'dm',
+  'cm',
+  'mm',
+  'µm',
+  'nm',
+  'pm',
+  'fm',
+  'am',
+  'zm',
+  'ym',
+  'Å',
+  'thou',
+  'li',
+  'in',
+  'ft',
+  'yd',
+  'mi',
+  'ua',
+  'ly',
+  'pc',
+  'pt',
+  'pixel',
+  'reference frame'
+]);
+
+const ChannelSchema = z
+  .object({})
+  .extend({
+    attr: z.object({
+      ID: z.string(),
+      SamplesPerPixel: z.coerce.number().optional(),
+      Name: z.string().optional(),
+      Color: z.coerce.number().transform(intToRgba).optional()
+    })
+  })
+  .transform(flattenAttributes);
+
+const UuidSchema = z
+  .object({})
+  .extend({
+    attr: z.object({
+      UUID: z.string()
+    })
+  })
+  .transform(flattenAttributes);
+
+const TiffDataSchema = z
+  .object({ UUID: UuidSchema.optional() })
+  .extend({
+    attr: z.object({
+      IFD: z.coerce.number(),
+      PlaneCount: z.coerce.number(),
+      FirstT: z.coerce.number().optional(),
+      FirstC: z.coerce.number().optional(),
+      FirstZ: z.coerce.number().optional()
+    })
+  })
+  .transform(flattenAttributes);
+
+const PixelsSchema = z
+  .object({
+    Channel: z.preprocess(ensureArray, ChannelSchema.array()),
+    TiffData: z.preprocess(ensureArray, TiffDataSchema.array())
+  })
+  .extend({
+    attr: z.object({
+      ID: z.string(),
+      DimensionOrder: DimensionOrderSchema,
+      Type: PixelTypeSchema,
+      PhysicalSizeX: z.coerce.number().optional(),
+      PhysicalSizeY: z.coerce.number().optional(),
+      PhysicalSizeZ: z.coerce.number().optional(),
+      SignificantBits: z.coerce.number().optional(),
+      SizeT: z.coerce.number().optional(),
+      SizeC: z.coerce.number().optional(),
+      SizeZ: z.coerce.number().optional(),
+      SizeY: z.coerce.number().optional(),
+      SizeX: z.coerce.number().optional(),
+      PhysicalSizeXUnit: UnitLengthSchema.optional(),
+      PhysicalSizeYUnit: UnitLengthSchema.optional(),
+      PhysicalSizeZUnit: UnitLengthSchema.optional(),
+      BigEndian: z
+        .string()
+        .transform(v => v.toLowerCase() === 'true')
+        .optional(),
+      Interleaved: z
+        .string()
+        .transform(v => v.toLowerCase() === 'true')
+        .optional()
+    })
+  })
+  .transform(flattenAttributes)
+  // Rename the `Channel` key to `Channels` for backwards compatibility
+  .transform(({ Channel, ...rest }) => ({ Channels: Channel, ...rest }));
+
+const ImageSchema = z
+  .object({
+    AquisitionDate: z.string().optional().default(''),
+    Description: z.string().optional().default(''),
+    Pixels: PixelsSchema
+  })
+  .extend({
+    attr: z.object({
+      ID: z.string(),
+      Name: z.string().optional()
+    })
+  })
+  .transform(flattenAttributes);
+
+const OmeSchema = z
+  .object({
+    Image: z.preprocess(ensureArray, ImageSchema.array())
+  })
+  .extend({
+    attr: z.object({
+      xmlns: z.string(),
+      'xmlns:xsi': z.string(),
+      'xsi:schemaLocation': z.string()
+    })
+  })
+  .transform(flattenAttributes);
 
 export function fromString(str: string) {
-  const res = parseXML(str);
-  if (!isOme(res)) {
-    throw Error('Failed to parse OME-XML metadata.');
-  }
-  return ensureArray(res.Image).map(img => {
-    const Channels = ensureArray(img.Pixels.Channel).map(c => {
-      if ('Color' in c.attr) {
-        return { ...c.attr, Color: intToRgba(c.attr.Color) };
-      }
-      return { ...c.attr };
-    });
-    const { AquisitionDate = '', Description = '' } = img;
-    const image = {
-      ...img.attr,
-      AquisitionDate,
-      Description,
-      Pixels: {
-        ...img.Pixels.attr,
-        Channels
-      }
-    };
+  const raw = parseXML(str);
+  return OmeSchema.parse(raw).Image.map(img => {
     return {
-      ...image,
+      ...img,
       format() {
-        const { Pixels } = image;
-
         const sizes = (['X', 'Y', 'Z'] as const)
           .map(name => {
-            const size = Pixels[`PhysicalSize${name}` as const];
-            const unit = Pixels[`PhysicalSize${name}Unit` as const];
+            const size = img.Pixels[`PhysicalSize${name}` as const];
+            const unit = img.Pixels[`PhysicalSize${name}Unit` as const];
             return size && unit ? `${size} ${unit}` : '-';
           })
           .join(' x ');
 
         return {
-          'Acquisition Date': image.AquisitionDate,
-          'Dimensions (XY)': `${Pixels.SizeX} x ${Pixels.SizeY}`,
-          'Pixels Type': Pixels.Type,
+          'Acquisition Date': img.AquisitionDate,
+          'Dimensions (XY)': `${img.Pixels['SizeX']} x ${img.Pixels['SizeY']}`,
+          'Pixels Type': img.Pixels['Type'],
           'Pixels Size (XYZ)': sizes,
-          'Z-sections/Timepoints': `${Pixels.SizeZ} x ${Pixels.SizeT}`,
-          Channels: Pixels.SizeC
+          'Z-sections/Timepoints': `${img.Pixels['SizeZ']} x ${img.Pixels['SizeT']}`,
+          Channels: img.Pixels['SizeC']
         };
       }
     };
   });
-}
-
-export type OMEXML = ReturnType<typeof fromString>;
-export type DimensionOrder =
-  | 'XYZCT'
-  | 'XYZTC'
-  | 'XYCTZ'
-  | 'XYCZT'
-  | 'XYTCZ'
-  | 'XYTZC';
-
-// Structure of node is determined by the PARSER_OPTIONS.
-type Node<T, A> = T & { attr: A };
-type Attrs<Fields extends string, T = string> = { [K in Fields]: T };
-type AttrsOnlyNode<A> = Node<unknown, A>;
-
-type OMEAttrs = Attrs<'xmlns' | 'xmlns:xsi' | 'xsi:schemaLocation'>;
-type OME = Node<{ Insturment: Insturment; Image: Image | Image[] }, OMEAttrs>;
-
-type Insturment = Node<
-  { Objective: AttrsOnlyNode<Attrs<'ID' | 'Model' | 'NominalMagnification'>> },
-  Attrs<'ID'>
->;
-
-interface ImageNodes {
-  AquisitionDate?: string;
-  Description?: string;
-  Pixels: Pixels;
-  InstrumentRef: AttrsOnlyNode<{ ID: string }>;
-  ObjectiveSettings: AttrsOnlyNode<{ ID: string }>;
-}
-type Image = Node<ImageNodes, Attrs<'ID' | 'Name'>>;
-
-type PixelType =
-  | 'int8'
-  | 'int16'
-  | 'int32'
-  | 'uint8'
-  | 'uint16'
-  | 'uint32'
-  | 'float'
-  | 'bit'
-  | 'double'
-  | 'complex'
-  | 'double-complex';
-
-export type UnitsLength =
-  | 'Ym'
-  | 'Zm'
-  | 'Em'
-  | 'Pm'
-  | 'Tm'
-  | 'Gm'
-  | 'Mm'
-  | 'km'
-  | 'hm'
-  | 'dam'
-  | 'm'
-  | 'dm'
-  | 'cm'
-  | 'mm'
-  | 'µm'
-  | 'nm'
-  | 'pm'
-  | 'fm'
-  | 'am'
-  | 'zm'
-  | 'ym'
-  | 'Å'
-  | 'thou'
-  | 'li'
-  | 'in'
-  | 'ft'
-  | 'yd'
-  | 'mi'
-  | 'ua'
-  | 'ly'
-  | 'pc'
-  | 'pt'
-  | 'pixel'
-  | 'reference frame';
-
-type PhysicalSize<Name extends string> = `PhysicalSize${Name}`;
-type PhysicalSizeUnit<Name extends string> = `PhysicalSize${Name}Unit`;
-type Size<Names extends string> = `Size${Names}`;
-
-type PixelAttrs = Attrs<
-  | PhysicalSize<'X' | 'Y' | 'Z'>
-  | 'SignificantBits'
-  | Size<'T' | 'C' | 'Z' | 'Y' | 'X'>,
-  number
-> &
-  Attrs<PhysicalSizeUnit<'X' | 'Y' | 'Z'>, UnitsLength> &
-  Attrs<'BigEndian' | 'Interleaved', boolean> & {
-    ID: string;
-    DimensionOrder: DimensionOrder;
-    Type: PixelType;
-  };
-
-type Pixels = Node<
-  {
-    Channel: Channel | Channel[];
-    TiffData: AttrsOnlyNode<Attrs<'IFD' | 'PlaneCount'>>;
-  },
-  PixelAttrs
->;
-
-type ChannelAttrs =
-  | {
-      ID: string;
-      SamplesPerPixel: number;
-      Name?: string;
-    }
-  | {
-      ID: string;
-      SamplesPerPixel: number;
-      Name?: string;
-      Color: number;
-    };
-
-type Channel = AttrsOnlyNode<ChannelAttrs>;
-
-function isOme(obj: unknown): obj is OME {
-  return typeof obj === 'object' && obj !== null && 'Image' in obj;
 }

--- a/packages/loaders/src/tiff/lib/indexers.ts
+++ b/packages/loaders/src/tiff/lib/indexers.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
 import { GeoTIFFImage, GeoTIFF } from 'geotiff';
 import type { OmeTiffSelection } from './utils';
-import type { OMEXML } from '../../omexml';
+import type { OmeXml } from '../../omexml';
 import type { MultiTiffImage } from '../multi-tiff';
 
 export type OmeTiffIndexer = (
@@ -30,7 +30,7 @@ export type OmeTiffIndexer = (
  */
 export function getOmeLegacyIndexer(
   tiff: GeoTIFF,
-  rootMeta: OMEXML
+  rootMeta: OmeXml
 ): OmeTiffIndexer {
   const { SizeT, SizeC, SizeZ } = rootMeta[0].Pixels;
   const ifdIndexer = getOmeIFDIndexer(rootMeta, 0);
@@ -61,7 +61,7 @@ export function getOmeLegacyIndexer(
  */
 export function getOmeSubIFDIndexer(
   tiff: GeoTIFF,
-  rootMeta: OMEXML,
+  rootMeta: OmeXml,
   image = 0
 ): OmeTiffIndexer {
   const ifdIndexer = getOmeIFDIndexer(rootMeta, image);
@@ -110,7 +110,7 @@ export function getOmeSubIFDIndexer(
  * order and dimension sizes.
  */
 function getOmeIFDIndexer(
-  rootMeta: OMEXML,
+  rootMeta: OmeXml,
   image = 0
 ): (sel: OmeTiffSelection) => number {
   const { SizeC, SizeZ, SizeT, DimensionOrder } = rootMeta[image].Pixels;

--- a/packages/loaders/src/tiff/ome-tiff.ts
+++ b/packages/loaders/src/tiff/ome-tiff.ts
@@ -7,11 +7,11 @@ import { getOmePixelSourceMeta, type OmeTiffSelection } from './lib/utils';
 import { guessTiffTileSize } from '../utils';
 import type Pool from './lib/Pool';
 import type { OmeTiffIndexer } from './lib/indexers';
-import type { OMEXML } from '../omexml';
+import type { OmeXml } from '../omexml';
 
 function getIndexer(
   tiff: GeoTIFF,
-  omexml: OMEXML,
+  omexml: OmeXml,
   SubIFDs: number[] | undefined,
   image: number
 ) {
@@ -49,7 +49,7 @@ export async function load(tiff: GeoTIFF, pool?: Pool) {
   const getSource = (
     resolution: number,
     pyramidIndexer: OmeTiffIndexer,
-    imgMeta: OMEXML[0]
+    imgMeta: OmeXml[0]
   ) => {
     const { labels, getShape, physicalSizes, dtype } =
       getOmePixelSourceMeta(imgMeta);

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -1,6 +1,6 @@
 import type { GeoTIFFImage } from 'geotiff';
 import quickselect from 'quickselect';
-import type { OMEXML } from './omexml';
+import type { OmeXml } from './omexml';
 import type { TypedArray } from 'zarr';
 import type { Labels, PixelSource } from '@vivjs/types';
 
@@ -138,7 +138,7 @@ type Sel<Dim extends string> =
   Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}` // eslint-disable-line @typescript-eslint/no-unused-vars
     ? [C, B, A]
     : never;
-export function getLabels(dimOrder: OMEXML[0]['Pixels']['DimensionOrder']) {
+export function getLabels(dimOrder: OmeXml[0]['Pixels']['DimensionOrder']) {
   return dimOrder.toLowerCase().split('').reverse() as Labels<
     Sel<Lowercase<typeof dimOrder>>
   >;

--- a/packages/loaders/src/zarr/lib/utils.ts
+++ b/packages/loaders/src/zarr/lib/utils.ts
@@ -1,6 +1,6 @@
 import { openGroup } from 'zarr';
 import type { ZarrArray } from 'zarr';
-import type { OMEXML } from '../../omexml';
+import type { OmeXml } from '../../omexml';
 import { getLabels, isInterleaved, prevPowerOf2 } from '../../utils';
 
 import type { Labels } from '@vivjs/types';
@@ -9,7 +9,7 @@ import type { RootAttrs, Axis } from '../ome-zarr';
 /*
  * Returns true if data shape is that expected for OME-Zarr.
  */
-function isOmeZarr(dataShape: number[], Pixels: OMEXML[0]['Pixels']) {
+function isOmeZarr(dataShape: number[], Pixels: OmeXml[0]['Pixels']) {
   const { SizeT, SizeC, SizeZ, SizeY, SizeX } = Pixels;
   // OME-Zarr dim order is always ['t', 'c', 'z', 'y', 'x']
   const omeZarrShape = [SizeT, SizeC, SizeZ, SizeY, SizeX];
@@ -27,7 +27,7 @@ function isOmeZarr(dataShape: number[], Pixels: OMEXML[0]['Pixels']) {
  */
 export function guessBioformatsLabels(
   { shape }: ZarrArray,
-  { Pixels }: OMEXML[0]
+  { Pixels }: OmeXml[0]
 ) {
   if (isOmeZarr(shape, Pixels)) {
     // It's an OME-Zarr Image,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       zarr:
         specifier: ^0.6.2
         version: 0.6.2
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
     devDependencies:
       xmldom:
         specifier: ^0.6.0
@@ -11370,6 +11373,10 @@ packages:
     dependencies:
       numcodecs: 0.2.2
       p-queue: 7.3.0
+    dev: false
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
   /zustand@3.7.2(react@17.0.2):


### PR DESCRIPTION
Replaces TS types with `zod` definitions, for runtime validation. This way, if some expectation about types is broken, there will be a nicer error message in the console. 

This is important for handling #697

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
