### PR TITLE
fix(loaders): trim trailing `\u0000` in OME-XML string for Firefox compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 ### Changed
-- Sanitize XML string for Firefox to remove unsupported characters
+- Trim trailing `\u0000` from OME-XML string for Firefox parsing compatibility.
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Sanitize XML string for Firefox to remove unsupported characters
 
 ## 0.14.0
 

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -252,7 +252,7 @@ function xmlToJson(
 export function parseXML(xmlString: string) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(
-    xmlString.replace(/\u0000$/, ''),
+    xmlString.replace(/\u0000$/, ''), // eslint-disable-line no-control-regex
     'application/xml'
   );
   return xmlToJson(doc.documentElement, { attrtibutesKey: 'attr' });

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -258,7 +258,6 @@ function sanitizeXmlString(xmlString: string) {
   return xmlString.replace(UNSAFE_XML_1_0_CHARS, '');
 }
 
-
 export function parseXML(xmlString: string) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -249,19 +249,10 @@ function xmlToJson(
   return xmlObj;
 }
 
-// https://github.com/MylesBorins/xml-sanitizer/blob/main/index.js
-const UNSAFE_XML_1_0_CHARS =
-  // eslint-disable-next-line no-control-regex
-  /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007f-\u0084\u0086-\u009f\uD800-\uDFFF\uFDD0-\uFDFF\uFFFF\uC008]/g;
-
-function sanitizeXmlString(xmlString: string) {
-  return xmlString.replace(UNSAFE_XML_1_0_CHARS, '');
-}
-
 export function parseXML(xmlString: string) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(
-    sanitizeXmlString(xmlString),
+    xmlString.replace(/\u0000$/, ''),
     'application/xml'
   );
   return xmlToJson(doc.documentElement, { attrtibutesKey: 'attr' });

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -250,13 +250,20 @@ function xmlToJson(
 }
 
 // https://github.com/MylesBorins/xml-sanitizer/blob/main/index.js
-const BAD_CHARACTERS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007f-\u0084\u0086-\u009f\uD800-\uDFFF\uFDD0-\uFDFF\uFFFF\uC008]/g;
+const UNSAFE_XML_1_0_CHARS =
+  // eslint-disable-next-line no-control-regex
+  /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007f-\u0084\u0086-\u009f\uD800-\uDFFF\uFDD0-\uFDFF\uFFFF\uC008]/g;
+
 function sanitizeXmlString(xmlString: string) {
-  return xmlString.replace(BAD_CHARACTERS, '');
+  return xmlString.replace(UNSAFE_XML_1_0_CHARS, '');
 }
+
 
 export function parseXML(xmlString: string) {
   const parser = new DOMParser();
-  const doc = parser.parseFromString(sanitizeXmlString(xmlString), 'application/xml');
+  const doc = parser.parseFromString(
+    sanitizeXmlString(xmlString),
+    'application/xml'
+  );
   return xmlToJson(doc.documentElement, { attrtibutesKey: 'attr' });
 }

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -249,8 +249,14 @@ function xmlToJson(
   return xmlObj;
 }
 
-export function parseXML(xmlStr: string) {
+// https://github.com/MylesBorins/xml-sanitizer/blob/main/index.js
+const BAD_CHARACTERS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007f-\u0084\u0086-\u009f\uD800-\uDFFF\uFDD0-\uFDFF\uFFFF\uC008]/g;
+function sanitizeXmlString(xmlString: string) {
+  return xmlString.replace(BAD_CHARACTERS, '');
+}
+
+export function parseXML(xmlString: string) {
   const parser = new DOMParser();
-  const doc = parser.parseFromString(xmlStr, 'application/xml');
+  const doc = parser.parseFromString(sanitizeXmlString(xmlString), 'application/xml');
   return xmlToJson(doc.documentElement, { attrtibutesKey: 'attr' });
 }


### PR DESCRIPTION
Fixes weird case in Firefox where XML-parsing breaks with a trailing null byte in XML string.

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
