### PR TITLE
fix(loaders): Allow optional TiffData in OME-XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Fix Avivator demo for OME-Zarr with only spatial axes
+- Allow OME-XML to omit `TiffData` tags
 
 ## 0.14.1
 

--- a/packages/loaders/src/omexml.ts
+++ b/packages/loaders/src/omexml.ts
@@ -114,7 +114,7 @@ const TiffDataSchema = z
 const PixelsSchema = z
   .object({
     Channel: z.preprocess(ensureArray, ChannelSchema.array()),
-    TiffData: z.preprocess(ensureArray, TiffDataSchema.array())
+    TiffData: z.preprocess(ensureArray, TiffDataSchema.array()).optional()
   })
   .extend({
     attr: z.object({


### PR DESCRIPTION
Allows for `METADATA.ome.xml` to omit TiffData tags.

#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
