### PR TITLE
chore: Set `fixed` versioning scheme

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
   "changelog": "@changesets/cli/changelog",
+  "fixed": [["@hms-dbmi/viv", "@vivjs/*"]],
   "commit": false,
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
Keeps the current behavior of versioning viv with all sub packages together.
