### PR TITLE
feat(loaders): Set default PhysicalSizeUnit to µm

### DIFF
--- a/.changeset/serious-plants-visit.md
+++ b/.changeset/serious-plants-visit.md
@@ -1,0 +1,5 @@
+---
+'@vivjs/loaders': patch
+---
+
+feat: Set default PhysicalSizeUnit to µm

--- a/packages/loaders/src/omexml.ts
+++ b/packages/loaders/src/omexml.ts
@@ -130,9 +130,9 @@ const PixelsSchema = z
       PhysicalSizeY: z.coerce.number().optional(),
       PhysicalSizeZ: z.coerce.number().optional(),
       SignificantBits: z.coerce.number().optional(),
-      PhysicalSizeXUnit: UnitsLengthSchema.optional(),
-      PhysicalSizeYUnit: UnitsLengthSchema.optional(),
-      PhysicalSizeZUnit: UnitsLengthSchema.optional(),
+      PhysicalSizeXUnit: UnitsLengthSchema.optional().default('µm'),
+      PhysicalSizeYUnit: UnitsLengthSchema.optional().default('µm'),
+      PhysicalSizeZUnit: UnitsLengthSchema.optional().default('µm'),
       BigEndian: z
         .string()
         .transform(v => v.toLowerCase() === 'true')
@@ -184,7 +184,7 @@ export function fromString(str: string) {
           .map(name => {
             const size = img.Pixels[`PhysicalSize${name}` as const];
             const unit = img.Pixels[`PhysicalSize${name}Unit` as const];
-            return size && unit ? `${size} ${unit}` : '-';
+            return size ? `${size} ${unit}` : '-';
           })
           .join(' x ');
 


### PR DESCRIPTION
Closes #1296

Uses the `zod` validation to provide the default value.

- https://github.com/vitessce/vitessce/issues/1296

#### Checklist
 - [x] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [x] Make sure Avivator works as expected with your change.
