### PR TITLE
fix: run versioning script directly in GH Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: changesets/action@v1
         with:
           title: Create Release
-          version: pnpm version
+          version: node scripts/version.mjs
           publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "test": "pnpm -r --parallel test",
     "check-format": "prettier --check --ignore-path .gitignore tsconfig.json sites/avivator packages/",
     "lint": "npm run check-format && eslint \"packages/*/src/**/*\" \"sites/avivator/src/**/*\"",
-    "format": "npm run check-format -- --write",
-    "version": "node scripts/version.mjs"
+    "format": "npm run check-format -- --write"
   },
   "dependencies": {
     "@deck.gl/core": "~8.8.27",

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -32,6 +32,31 @@ function updateContentsWithAffectedPackages(changeset) {
   return contentLines.join('\n');
 }
 
+/**
+ * Collects all the changesets (for all packages) and collects
+ * them into a single changeset for the main package.
+ *
+ * For example:
+ *
+ * ```md
+ * ---
+ *  "@vivjs/loaders": minor
+ *  "@vivjs/constants": patch
+ * ---
+ *
+ *  Fixes a bug in loaders.
+ * ```
+ *
+ * becomes:
+ *
+ * ```md
+ * ---
+ *  "@hms-dbmi/viv": minor
+ * ---
+ *  Fixes a bug in loaders. (`@vivjs/loaders`, `@vivjs/constants`)
+ * ```
+ *
+ */
 async function preChangesetsVersion(){
   const entries = fs.readdirSync(path.resolve(__dirname, '../.changeset'));
   for (const file of entries) {
@@ -46,6 +71,12 @@ async function preChangesetsVersion(){
   }
 }
 
+/**
+ * Reads the main package's changelog and removes all the dependency
+ * updates for individual packages.
+ *
+ * Deletes all the other changelogs.
+ */
 async function postChangesetsVersion() {
   const contents = fs.readFileSync(
     path.resolve(__dirname, '..', 'packages', 'main', 'CHANGELOG.md'),


### PR DESCRIPTION
The workflow used `pnpm version` which is a reserved command in `pnpm`, breaking the action. This PR just calls the node script for versioning directly in CI.
