### PR TITLE
feat: Support mutifile & multiscale OME-TIFF

### DIFF
--- a/.changeset/popular-steaks-end.md
+++ b/.changeset/popular-steaks-end.md
@@ -1,0 +1,5 @@
+---
+'@vivjs/loaders': patch
+---
+
+feat: Support multiscale multifile-OME-TIFFs

--- a/.changeset/popular-steaks-end.md
+++ b/.changeset/popular-steaks-end.md
@@ -1,5 +1,13 @@
 ---
-'@vivjs/loaders': patch
+'@vivjs/loaders': minor
 ---
 
 feat: Support multiscale multifile-OME-TIFFs
+
+This release extends Viv's multifile OME-TIFF data-loading capabilities to multiscale TIFFs as well. The `loadOmeTiff` utility now recognizes and loads multiresolution images described in a `companion.ome` metadata file.
+
+```js
+import { loadOmeTiff } from '@vivjs/loaders';
+
+let loader = await loadOmeTiff("http://localhost:8080/data.companion.ome");
+```

--- a/packages/loaders/src/omexml.ts
+++ b/packages/loaders/src/omexml.ts
@@ -165,18 +165,18 @@ const ImageSchema = z
   })
   .transform(flattenAttributes);
 
-const OmeSchema = z
-  .object({
-    Image: z.preprocess(ensureArray, ImageSchema.array())
-  })
-  .extend({
-    attr: z.object({
-      xmlns: z.string(),
-      'xmlns:xsi': z.string(),
-      'xsi:schemaLocation': z.string()
-    })
-  })
-  .transform(flattenAttributes);
+const OmeSchema = z.object({
+  Image: z.preprocess(ensureArray, ImageSchema.array())
+});
+// TODO: Verify that these attributes are always present
+// .extend({
+//   attr: z.object({
+//     'xmlns': z.string(),
+//     'xmlns:xsi': z.string(),
+//     'xsi:schemaLocation': z.string()
+//   })
+// })
+// .transform(flattenAttributes);
 
 export function fromString(str: string) {
   const raw = parseXML(str);

--- a/packages/loaders/src/tiff/lib/indexers.ts
+++ b/packages/loaders/src/tiff/lib/indexers.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-use-before-define */
 import { GeoTIFFImage, GeoTIFF } from 'geotiff';
 import type { OmeTiffSelection } from './utils';
-import type { DimensionOrder } from '../../omexml';
 import type { MultiTiffImage } from '../multi-tiff';
 
 type ImageFileDirectory = Awaited<ReturnType<GeoTIFF['parseFileDirectoryAt']>>;
@@ -11,6 +10,18 @@ export type OmeTiffIndexer = (
   resolutionLevel: number
 ) => Promise<GeoTIFFImage>;
 
+/**
+ * A function that resolves a given selection to a GeoTIFF and IFD index.
+ *
+ * Ideally we could just return the GeoTIFFImage, but for the legacy
+ * bioformats case we need to return the GeoTIFF object and the IFD index.
+ */
+export type OmeTiffResolver = {
+  (sel: OmeTiffSelection):
+    | { tiff: GeoTIFF; ifdIndex: number }
+    | Promise<{ tiff: GeoTIFF; ifdIndex: number }>;
+};
+
 /*
  * An "indexer" for a GeoTIFF-based source is a function that takes a
  * "selection" (e.g. { z, t, c }) and returns a Promise for the GeoTIFFImage
@@ -18,27 +29,18 @@ export type OmeTiffIndexer = (
  *
  * For OME-TIFF images, the "selection" object is the same regardless of
  * the format version. However, modern version of Bioformats have a different
- * memory layout for pyramidal resolutions. Thus, we have two different "indexers"
+ * memory layout for pyramidal resolutions. Thus, we have different "indexers"
  * depending on which format version is detected.
- *
- * TODO: We currently only support indexing the first image in the OME-TIFF with
- * our indexers. There can be multiple images in an OME-TIFF, so supporting these
- * images will require extending these indexers or creating new methods.
  */
-export function extendResolverWithBaseIndexer(
-  resolveImageLocation: (sel: OmeTiffSelection) =>
-    | Promise<{
-        tiff: GeoTIFF;
-        ifdIndex: number;
-      }>
-    | {
-        tiff: GeoTIFF;
-        ifdIndex: number;
-      }
+export function createOmeImageIndexerFromResolver(
+  resolveBaseResolutionImageLocation: OmeTiffResolver,
+  image: {
+    size: { z: number; t: number; c: number };
+  }
 ) {
   const ifdCache: ImageFileDirectory[] = [];
   return async (sel: OmeTiffSelection, pyramidLevel: number) => {
-    const { tiff, ifdIndex } = await resolveImageLocation(sel);
+    const { tiff, ifdIndex } = await resolveBaseResolutionImageLocation(sel);
     const baseImage = await tiff.getImage(ifdIndex);
 
     // It's the highest resolution, no need to look up SubIFDs.
@@ -46,12 +48,21 @@ export function extendResolverWithBaseIndexer(
       return baseImage;
     }
 
-    const index = baseImage.fileDirectory.SubIFDs[pyramidLevel - 1];
+    let index;
+    if (baseImage.fileDirectory.SubIFDs) {
+      index = baseImage.fileDirectory.SubIFDs[pyramidLevel - 1];
+    } else {
+      // Legacy Bioformats OME-TIFFs don't have SubIFDs, and instead
+      // store each resolution level in a separate IFD at the end
+      // of the base image.
+      const resolutionOffset =
+        pyramidLevel * image.size.z * image.size.t * image.size.c;
+      index = ifdIndex + resolutionOffset;
+    }
 
     if (!ifdCache[index]) {
       ifdCache[index] = await tiff.parseFileDirectoryAt(index);
     }
-
     const ifd = ifdCache[index];
 
     // Create a new image object manually from IFD
@@ -64,33 +75,6 @@ export function extendResolverWithBaseIndexer(
       tiff.source
     );
   };
-}
-
-/*
- * Returns a function that computes the image index based on the dimension
- * order and dimension sizes.
- */
-export function getRelativeIfdIndexer(
-  size: { z: number; t: number; c: number },
-  dimensionOrder: DimensionOrder
-): (sel: OmeTiffSelection) => number {
-  switch (dimensionOrder) {
-    case 'XYZCT':
-      return ({ t, c, z }) => t * size.z * size.c + c * size.z + z;
-    case 'XYZTC':
-      return ({ t, c, z }) => c * size.z * size.t + t * size.z + z;
-    case 'XYCTZ':
-      return ({ t, c, z }) => z * size.c * size.t + t * size.c + c;
-    case 'XYCZT':
-      return ({ t, c, z }) => t * size.c * size.z + z * size.c + c;
-    case 'XYTCZ':
-      return ({ t, c, z }) => z * size.t * size.c + c * size.t + t;
-    case 'XYTZC':
-      return ({ t, c, z }) => c * size.t * size.z + z * size.t + t;
-    default: {
-      throw new Error(`Invalid OME-XML DimensionOrder, got ${dimensionOrder}.`);
-    }
-  }
 }
 
 export function getMultiTiffIndexer(tiffs: MultiTiffImage[]) {

--- a/packages/loaders/src/tiff/lib/utils.ts
+++ b/packages/loaders/src/tiff/lib/utils.ts
@@ -67,9 +67,7 @@ export function extractDtypeFromPixels(p: OmeXml[number]['Pixels']) {
   return DTYPE_LOOKUP[p.Type as keyof typeof DTYPE_LOOKUP];
 }
 
-export function extractShapeAndLabelsFromPixels(
-  d: OmeXml[number]['Pixels']
-) {
+export function extractShapeAndLabelsFromPixels(d: OmeXml[number]['Pixels']) {
   // e.g. 'XYZCT' -> ['t', 'c', 'z', 'y', 'x']
   const labels = getLabels(d['DimensionOrder']);
 
@@ -89,10 +87,14 @@ export function extractShapeAndLabelsFromPixels(
   return { labels, baseShape };
 }
 
-export function getShapeForResolutionLevel({ baseShape, labels, resolutionLevel: level }: {
-  baseShape: number[],
-  labels: string[],
-  resolutionLevel: number,
+export function getShapeForResolutionLevel({
+  baseShape,
+  labels,
+  resolutionLevel: level
+}: {
+  baseShape: number[];
+  labels: string[];
+  resolutionLevel: number;
 }) {
   const s = [...baseShape];
   s[labels.indexOf('x')] = baseShape[labels.indexOf('x')] >> level;

--- a/packages/loaders/src/tiff/lib/utils.ts
+++ b/packages/loaders/src/tiff/lib/utils.ts
@@ -76,6 +76,8 @@ export function extractShapeAndLabelsFromPixels(d: OmeXml[number]['Pixels']) {
   baseShape[labels.indexOf('t')] = d['SizeT'];
   baseShape[labels.indexOf('c')] = d['SizeC'];
   baseShape[labels.indexOf('z')] = d['SizeZ'];
+  baseShape[labels.indexOf('y')] = d['SizeY'];
+  baseShape[labels.indexOf('x')] = d['SizeX'];
 
   // Push extra dimension if data are interleaved.
   if (d['Interleaved']) {
@@ -87,6 +89,12 @@ export function extractShapeAndLabelsFromPixels(d: OmeXml[number]['Pixels']) {
   return { labels, baseShape };
 }
 
+/**
+ * Compute the shape of the image at a given resolution level.
+ *
+ * Assumes that the image is downsampled by a factor of 2 for each
+ * pyramid level.
+ */
 export function getShapeForResolutionLevel({
   baseShape,
   labels,
@@ -96,19 +104,17 @@ export function getShapeForResolutionLevel({
   labels: string[];
   resolutionLevel: number;
 }) {
-  const s = [...baseShape];
-  s[labels.indexOf('x')] = baseShape[labels.indexOf('x')] >> level;
-  s[labels.indexOf('y')] = baseShape[labels.indexOf('y')] >> level;
-  return s;
+  const shape = [...baseShape];
+  shape[labels.indexOf('x')] = baseShape[labels.indexOf('x')] >> level;
+  shape[labels.indexOf('y')] = baseShape[labels.indexOf('y')] >> level;
+  return shape;
 }
 
 // Inspired by/borrowed from https://geotiffjs.github.io/geotiff.js/geotiffimage.js.html#line297
 function guessImageDataType(image: GeoTIFFImage) {
   // Assuming these are flat TIFFs, just grab the info for the first image/sample.
   const sampleIndex = 0;
-  const format = image.fileDirectory.SampleFormat
-    ? image.fileDirectory.SampleFormat[sampleIndex]
-    : 1;
+  const format = image.fileDirectory?.SampleFormat?.[sampleIndex] ?? 1;
   const bitsPerSample = image.fileDirectory.BitsPerSample[sampleIndex];
   switch (format) {
     case 1: // unsigned integer data

--- a/packages/loaders/src/tiff/lib/utils.ts
+++ b/packages/loaders/src/tiff/lib/utils.ts
@@ -32,24 +32,24 @@ type PhysicalSizes = {
 };
 
 export function extractPhysicalSizesfromPixels(
-  p: OmeXml[number]['Pixels']
+  d: OmeXml[number]['Pixels']
 ): undefined | PhysicalSizes {
   if (
-    !p['PhysicalSizeX'] ||
-    !p['PhysicalSizeY'] ||
-    !p['PhysicalSizeXUnit'] ||
-    !p['PhysicalSizeYUnit']
+    !d['PhysicalSizeX'] ||
+    !d['PhysicalSizeY'] ||
+    !d['PhysicalSizeXUnit'] ||
+    !d['PhysicalSizeYUnit']
   ) {
     return undefined;
   }
   const physicalSizes: PhysicalSizes = {
-    x: { size: p['PhysicalSizeX'], unit: p['PhysicalSizeXUnit'] },
-    y: { size: p['PhysicalSizeY'], unit: p['PhysicalSizeYUnit'] }
+    x: { size: d['PhysicalSizeX'], unit: d['PhysicalSizeXUnit'] },
+    y: { size: d['PhysicalSizeY'], unit: d['PhysicalSizeYUnit'] }
   };
-  if (p['PhysicalSizeZ'] && p['PhysicalSizeZUnit']) {
+  if (d['PhysicalSizeZ'] && d['PhysicalSizeZUnit']) {
     physicalSizes.z = {
-      size: p['PhysicalSizeZ'],
-      unit: p['PhysicalSizeZUnit']
+      size: d['PhysicalSizeZ'],
+      unit: d['PhysicalSizeZUnit']
     };
   }
   return physicalSizes;

--- a/packages/loaders/src/tiff/multi-tiff.ts
+++ b/packages/loaders/src/tiff/multi-tiff.ts
@@ -1,10 +1,10 @@
 import type { GeoTIFFImage } from 'geotiff';
 
 import TiffPixelSource from './pixel-source';
-import { getTiffTileSize } from '../utils';
 import {
   getMultiTiffMetadata,
   getMultiTiffMeta,
+  getTiffTileSize,
   type OmeTiffSelection
 } from './lib/utils';
 import type Pool from './lib/Pool';

--- a/packages/loaders/src/tiff/multi-tiff.ts
+++ b/packages/loaders/src/tiff/multi-tiff.ts
@@ -1,7 +1,7 @@
 import type { GeoTIFFImage } from 'geotiff';
 
 import TiffPixelSource from './pixel-source';
-import { guessTiffTileSize } from '../utils';
+import { getTiffTileSize } from '../utils';
 import {
   getMultiTiffMetadata,
   getMultiTiffMeta,
@@ -56,7 +56,7 @@ export async function load(
     firstImage.fileDirectory;
   // Not sure if we need this or if the order matters for this use case.
   const dimensionOrder = 'XYZCT';
-  const tileSize = guessTiffTileSize(firstImage);
+  const tileSize = getTiffTileSize(firstImage);
   const meta = { photometricInterpretation };
   const indexer = getMultiTiffIndexer(images);
   const { shape, labels, dtype } = getMultiTiffMeta(dimensionOrder, images);

--- a/packages/loaders/src/tiff/multifile-ome-tiff.ts
+++ b/packages/loaders/src/tiff/multifile-ome-tiff.ts
@@ -5,11 +5,11 @@ import {
   extractDtypeFromPixels,
   extractPhysicalSizesfromPixels as extractPhysicalSizesfromPixels,
   type OmeTiffSelection,
-  extractShapeAndLabelsFromPixels
+  extractAxesFromPixels
 } from './lib/utils';
 import { fromString, type OmeXml } from '../omexml';
 import TiffPixelSource from './pixel-source';
-import { guessTiffTileSize, assert } from '../utils';
+import { getTiffTileSize, assert } from '../utils';
 import type Pool from './lib/Pool';
 
 type TiffDataTags = NonNullable<OmeXml[number]['Pixels']['TiffData']>;
@@ -113,16 +113,14 @@ export async function loadMultifileOmeTiff(
   const promises = rootMeta.map(async imgMeta => {
     const indexer = createMultifileOmeTiffIndexer(imgMeta, resolver);
     const physicalSizes = extractPhysicalSizesfromPixels(imgMeta['Pixels']);
-    const { labels, baseShape } = extractShapeAndLabelsFromPixels(
-      imgMeta['Pixels']
-    );
+    const { labels, baseShape } = extractAxesFromPixels(imgMeta['Pixels']);
     const dtype = extractDtypeFromPixels(imgMeta['Pixels']);
     const firstImage = await indexer({ c: 0, t: 0, z: 0 });
     const meta = physicalSizes ? { physicalSizes } : {};
     const source = new TiffPixelSource(
       indexer,
       dtype,
-      guessTiffTileSize(firstImage),
+      getTiffTileSize(firstImage),
       baseShape,
       labels,
       meta,

--- a/packages/loaders/src/tiff/singlefile-ome-tiff.ts
+++ b/packages/loaders/src/tiff/singlefile-ome-tiff.ts
@@ -84,7 +84,7 @@ function createSingleFileOmeTiffPyramidalIndexer(
     const withinImageIndex = getRelativeOmeIfdIndex(sel, image);
     const ifdIndex = withinImageIndex + image.ifdOffset;
     return { tiff, ifdIndex };
-  });
+  }, image);
 }
 
 type OmeTiffImage = {

--- a/packages/loaders/src/tiff/singlefile-ome-tiff.ts
+++ b/packages/loaders/src/tiff/singlefile-ome-tiff.ts
@@ -1,7 +1,10 @@
 import { fromString } from '../omexml';
 
 import TiffPixelSource from './pixel-source';
-import { getOmeTiffIndexer } from './lib/indexers';
+import {
+  extendResolverWithBaseIndexer,
+  getRelativeIfdIndexer
+} from './lib/indexers';
 import {
   createGeoTiff,
   parsePixelDataType,
@@ -9,10 +12,12 @@ import {
   extractAxesFromPixels,
   getShapeForBinaryDownsampleLevel,
   getTiffTileSize,
-  type OmeTiffDims
+  type OmeTiffDims,
+  type OmeTiffSelection
 } from './lib/utils';
 import type Pool from './lib/Pool';
-import type { OmeXml } from '../omexml';
+import type { DimensionOrder, OmeXml } from '../omexml';
+import type GeoTIFF from 'geotiff';
 
 function resolveMetadata(omexml: OmeXml, SubIFDs: number[] | undefined) {
   if (SubIFDs) {
@@ -23,6 +28,21 @@ function resolveMetadata(omexml: OmeXml, SubIFDs: number[] | undefined) {
   // We do not allow multi-images for legacy format.
   const firstImageMetadata = omexml[0];
   return { levels: omexml.length, rootMeta: [firstImageMetadata] };
+}
+
+function createSingleFileResolver(
+  tiff: GeoTIFF,
+  options: {
+    size: { t: number; z: number; c: number };
+    dimensionOrder: DimensionOrder;
+    imageIfdOffset: number;
+  }
+) {
+  const { size, dimensionOrder, imageIfdOffset } = options;
+  const getRelativeIfdIndex = getRelativeIfdIndexer(size, dimensionOrder);
+  return (sel: OmeTiffSelection) => {
+    return { tiff, ifdIndex: getRelativeIfdIndex(sel) + imageIfdOffset };
+  };
 }
 
 type OmeTiffImage = {
@@ -56,11 +76,14 @@ export async function loadSingleFileOmeTiff(
       t: metadata['Pixels']['SizeT']
     };
     const axes = extractAxesFromPixels(metadata['Pixels']);
-    const pyramidIndexer = getOmeTiffIndexer(tiff, {
+    const resolveOmeTiffSelection = createSingleFileResolver(tiff, {
       size,
       imageIfdOffset,
       dimensionOrder: metadata['Pixels']['DimensionOrder']
     });
+    const pyramidIndexer = extendResolverWithBaseIndexer(
+      resolveOmeTiffSelection
+    );
     const dtype = parsePixelDataType(metadata['Pixels']['Type']);
     const tileSize = getTiffTileSize(
       await pyramidIndexer({ c: 0, t: 0, z: 0 }, 0)

--- a/packages/loaders/src/tiff/singlefile-ome-tiff.ts
+++ b/packages/loaders/src/tiff/singlefile-ome-tiff.ts
@@ -1,37 +1,19 @@
-import type { GeoTIFF } from 'geotiff';
 import { fromString } from '../omexml';
 
 import TiffPixelSource from './pixel-source';
-import { getOmeLegacyIndexer, getOmeSubIFDIndexer } from './lib/indexers';
+import { getOmeTiffIndexer } from './lib/indexers';
 import {
   createGeoTiff,
   extractDtypeFromPixels,
   extractPhysicalSizesfromPixels,
-  extractShapeAndLabelsFromPixels,
+  extractAxesFromPixels,
   getShapeForResolutionLevel,
+  type OmeTiffDims,
   type OmeTiffSelection
 } from './lib/utils';
-import { guessTiffTileSize } from '../utils';
+import { getTiffTileSize } from '../utils';
 import type Pool from './lib/Pool';
 import type { OmeXml } from '../omexml';
-
-function getIndexer(
-  tiff: GeoTIFF,
-  omexml: OmeXml,
-  hasSubIFDs: boolean,
-  image: number
-) {
-  /*
-   * Image pyramids are stored differently between versions of Bioformats.
-   * Thus we need a different indexer depending on which format we have.
-   */
-  if (hasSubIFDs) {
-    // Image is >= Bioformats 6.0 and resolutions are stored using SubIFDs.
-    return getOmeSubIFDIndexer(tiff, omexml, image);
-  }
-  // Image is legacy format; resolutions are stored as separate images.
-  return getOmeLegacyIndexer(tiff, omexml);
-}
 
 function resolveMetadata(omexml: OmeXml, SubIFDs: number[] | undefined) {
   if (SubIFDs) {
@@ -40,8 +22,14 @@ function resolveMetadata(omexml: OmeXml, SubIFDs: number[] | undefined) {
   }
   // Image is legacy format; resolutions are stored as separate images.
   // We do not allow multi-images for legacy format.
-  return { levels: omexml.length, rootMeta: [omexml[0]] };
+  const firstImageMetadata = omexml[0];
+  return { levels: omexml.length, rootMeta: [firstImageMetadata] };
 }
+
+type OmeTiffImage = {
+  data: TiffPixelSource<OmeTiffDims>[];
+  metadata: OmeXml[number];
+};
 
 export async function loadSingleFileOmeTiff(
   source: string | URL | File,
@@ -54,43 +42,47 @@ export async function loadSingleFileOmeTiff(
   const { offsets, headers, pool } = options;
   const tiff = await createGeoTiff(source, { headers, offsets });
   const firstImage = await tiff.getImage();
-  const {
-    ImageDescription,
-    SubIFDs,
-    PhotometricInterpretation: photometricInterpretation
-  } = firstImage.fileDirectory;
-  const omexml = fromString(ImageDescription);
-  const { levels, rootMeta } = resolveMetadata(
-    omexml,
+  const { rootMeta, levels } = resolveMetadata(
+    fromString(firstImage.fileDirectory.ImageDescription),
     firstImage.fileDirectory.SubIFDs
   );
-  return rootMeta.map((imgMeta, imageIdx) => {
-    const pyramidIndexer = getIndexer(tiff, omexml, !!SubIFDs, imageIdx);
-    const { baseShape, labels } = extractShapeAndLabelsFromPixels(
-      imgMeta['Pixels']
-    );
-    const physicalSizes = extractPhysicalSizesfromPixels(imgMeta['Pixels']);
+
+  const images: OmeTiffImage[] = [];
+  let imageOffset = 0;
+
+  for (const imgMeta of rootMeta) {
+    const pyramidIndexer = getOmeTiffIndexer(tiff, imgMeta, imageOffset);
+    const axes = extractAxesFromPixels(imgMeta['Pixels']);
     const dtype = extractDtypeFromPixels(imgMeta['Pixels']);
-    return {
-      data: Array.from({ length: levels }).map((_, resolutionLevel) => {
-        const indexer = (sel: OmeTiffSelection) =>
-          pyramidIndexer(sel, resolutionLevel);
-        const meta = { photometricInterpretation, physicalSizes };
-        return new TiffPixelSource(
-          indexer,
-          dtype,
-          guessTiffTileSize(firstImage),
-          getShapeForResolutionLevel({
-            baseShape,
-            labels,
-            resolutionLevel
-          }),
-          labels,
-          meta,
-          pool
-        );
-      }),
-      metadata: imgMeta
+    const baseImage = await pyramidIndexer({ c: 0, t: 0, z: 0 }, 0);
+    const meta = {
+      photometricInterpretation:
+        firstImage.fileDirectory.PhotometricInterpretation,
+      physicalSizes: extractPhysicalSizesfromPixels(imgMeta['Pixels'])
     };
-  });
+
+    const data: TiffPixelSource<OmeTiffDims>[] = [];
+    for (
+      let resolutionLevel = 0;
+      resolutionLevel <= levels;
+      resolutionLevel++
+    ) {
+      const pixelSource = new TiffPixelSource(
+        (sel: OmeTiffSelection) => pyramidIndexer(sel, resolutionLevel),
+        dtype,
+        getTiffTileSize(baseImage),
+        getShapeForResolutionLevel({ axes, resolutionLevel }),
+        axes.labels,
+        meta,
+        pool
+      );
+      data.push(pixelSource);
+    }
+
+    images.push({ data, metadata: imgMeta });
+    imageOffset +=
+      imgMeta['Pixels']['SizeT'] *
+      imgMeta['Pixels']['SizeZ'] *
+      imgMeta['Pixels']['SizeC'];
+  }
 }

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -224,6 +224,7 @@ function xmlToJson(
 
 export function parseXML(xmlString: string) {
   const parser = new DOMParser();
+  // Remove trailing null character, which can break XML parsing in Firefox
   const doc = parser.parseFromString(
     xmlString.replace(/\u0000$/, ''), // eslint-disable-line no-control-regex
     'application/xml'

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -1,4 +1,3 @@
-import type { GeoTIFFImage } from 'geotiff';
 import quickselect from 'quickselect';
 import type { OmeXml } from './omexml';
 import type { TypedArray } from 'zarr';
@@ -151,14 +150,6 @@ export function prevPowerOf2(x: number) {
 }
 
 export const SIGNAL_ABORTED = '__vivSignalAborted';
-
-export function guessTiffTileSize(image: GeoTIFFImage) {
-  const tileWidth = image.getTileWidth();
-  const tileHeight = image.getTileHeight();
-  const size = Math.min(tileWidth, tileHeight);
-  // deck.gl requirement for power-of-two tile size.
-  return prevPowerOf2(size);
-}
 
 function isElement(node: Node): node is HTMLElement {
   return node.nodeType === 1;


### PR DESCRIPTION
Extends on #740 

This release PR Viv's multifile OME-TIFF data-loading capabilities to multiscale TIFFs as well. The `loadOmeTiff` utility now recognizes and loads multiresolution images described in a `companion.ome` metadata file. 

The API stays the same for end users. Multifile OME-TIFFs are detected from URLs with path suffixes of `*companion.ome`.

```js
import { loadOmeTiff } from '@vivjs/loaders';

let loader = await loadOmeTiff("http://localhost:8080/data.companion.ome");
```