### PR TITLE
feat(avivator): Drop react-router-dom

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,8 +315,8 @@ importers:
         specifier: ^11.2.3
         version: 11.7.1(react@17.0.2)
       react-router-dom:
-        specifier: ^5.2.0
-        version: 5.3.3(react@17.0.2)
+        specifier: ^6.21.3
+        version: 6.21.3(react-dom@17.0.2)(react@17.0.2)
       zustand:
         specifier: ^3.4.1
         version: 3.7.2(react@17.0.2)
@@ -2290,6 +2290,11 @@ packages:
       - supports-color
       - utf-8-validate
     dev: true
+
+  /@remix-run/router@1.14.2:
+    resolution: {integrity: sha512-ACXpdMM9hmKZww21yEqWwiLws/UPLhNKvimN8RrYSqPSvB3ov7sLvAcfvaxePeLvccTQKGdkDIhLYApZVDFuKg==}
+    engines: {node: '>=14.0.0'}
+    dev: false
 
   /@rollup/plugin-alias@5.0.1(rollup@3.29.4):
     resolution: {integrity: sha512-JObvbWdOHoMy9W7SU0lvGhDtWq9PllP5mjpAy+TUslZG/WzOId9u80Hsqq1vCUn9pFJ0cxpdcnAv+QzU2zFH3Q==}
@@ -5490,17 +5495,6 @@ packages:
     engines: {node: '>=12.0.0'}
     dev: true
 
-  /history@4.10.1:
-    resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
-    dependencies:
-      '@babel/runtime': 7.23.2
-      loose-envify: 1.4.0
-      resolve-pathname: 3.0.0
-      tiny-invariant: 1.2.0
-      tiny-warning: 1.0.3
-      value-equal: 1.0.1
-    dev: false
-
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
@@ -6004,6 +5998,7 @@ packages:
 
   /isarray@0.0.1:
     resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
+    dev: true
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -6922,18 +6917,6 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /mini-create-react-context@0.4.1(prop-types@15.8.1)(react@17.0.2):
-    resolution: {integrity: sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==}
-    peerDependencies:
-      prop-types: ^15.0.0
-      react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@babel/runtime': 7.23.2
-      prop-types: 15.8.1
-      react: 17.0.2
-      tiny-warning: 1.0.3
-    dev: false
-
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -7606,12 +7589,6 @@ packages:
       unique-string: 2.0.0
     dev: true
 
-  /path-to-regexp@1.8.0:
-    resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
-    dependencies:
-      isarray: 0.0.1
-    dev: false
-
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -7986,37 +7963,27 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-dom@5.3.3(react@17.0.2):
-    resolution: {integrity: sha512-Ov0tGPMBgqmbu5CDmN++tv2HQ9HlWDuWIIqn4b88gjlAN5IHI+4ZUZRcpz9Hl0azFIwihbLDYw1OiHGRo7ZIng==}
+  /react-router-dom@6.21.3(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-kNzubk7n4YHSrErzjLK72j0B5i969GsuCGazRl3G6j1zqZBLjuSlYBdVdkDOgzGdPIffUOc9nmgiadTEVoq91g==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      react: '>=15'
+      react: '>=16.8'
+      react-dom: '>=16.8'
     dependencies:
-      '@babel/runtime': 7.18.9
-      history: 4.10.1
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
+      '@remix-run/router': 1.14.2
       react: 17.0.2
-      react-router: 5.3.3(react@17.0.2)
-      tiny-invariant: 1.2.0
-      tiny-warning: 1.0.3
+      react-dom: 17.0.2(react@17.0.2)
+      react-router: 6.21.3(react@17.0.2)
     dev: false
 
-  /react-router@5.3.3(react@17.0.2):
-    resolution: {integrity: sha512-mzQGUvS3bM84TnbtMYR8ZjKnuPJ71IjSzR+DE6UkUqvN4czWIqEs17yLL8xkAycv4ev0AiN+IGrWu88vJs/p2w==}
+  /react-router@6.21.3(react@17.0.2):
+    resolution: {integrity: sha512-a0H638ZXULv1OdkmiK6s6itNhoy33ywxmUFT/xtSoVyf9VnC7n7+VT4LjVzdIHSaF5TIh9ylUgxMXksHTgGrKg==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      react: '>=15'
+      react: '>=16.8'
     dependencies:
-      '@babel/runtime': 7.23.2
-      history: 4.10.1
-      hoist-non-react-statics: 3.3.2
-      loose-envify: 1.4.0
-      mini-create-react-context: 0.4.1(prop-types@15.8.1)(react@17.0.2)
-      path-to-regexp: 1.8.0
-      prop-types: 15.8.1
+      '@remix-run/router': 1.14.2
       react: 17.0.2
-      react-is: 16.13.1
-      tiny-invariant: 1.2.0
-      tiny-warning: 1.0.3
     dev: false
 
   /react-transition-group@4.4.5(react-dom@17.0.2)(react@17.0.2):
@@ -8326,10 +8293,6 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
     dev: true
-
-  /resolve-pathname@3.0.0:
-    resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
-    dev: false
 
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -9300,10 +9263,6 @@ packages:
       through: 2.3.8
     dev: true
 
-  /tiny-invariant@1.2.0:
-    resolution: {integrity: sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==}
-    dev: false
-
   /tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
     dev: false
@@ -9742,10 +9701,6 @@ packages:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
     dev: true
-
-  /value-equal@1.0.1:
-    resolution: {integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==}
-    dev: false
 
   /vfile-location@4.1.0:
     resolution: {integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,13 +289,13 @@ importers:
         version: link:../../packages/main
       '@material-ui/core':
         specifier: ^4.11.0
-        version: 4.12.4(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2)
+        version: 4.12.4(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0)
       '@material-ui/icons':
         specifier: ^4.9.1
-        version: 4.11.3(@material-ui/core@4.12.4)(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2)
+        version: 4.11.3(@material-ui/core@4.12.4)(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0)
       '@material-ui/lab':
         specifier: ^4.0.0-alpha.56
-        version: 4.0.0-alpha.61(@material-ui/core@4.12.4)(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2)
+        version: 4.0.0-alpha.61(@material-ui/core@4.12.4)(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0)
       '@math.gl/core':
         specifier: ^3.5.7
         version: 3.6.3
@@ -306,17 +306,17 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       react:
-        specifier: ^16.8.0 || ^17.0.0
-        version: 17.0.2
+        specifier: ^18.2.0
+        version: 18.2.0
       react-dom:
-        specifier: ^16.8.0 || ^17.0.0
-        version: 17.0.2(react@17.0.2)
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       react-dropzone:
         specifier: ^11.2.3
-        version: 11.7.1(react@17.0.2)
+        version: 11.7.1(react@18.2.0)
       zustand:
         specifier: ^3.4.1
-        version: 3.7.2(react@17.0.2)
+        version: 3.7.2(react@18.2.0)
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.1.1
@@ -1743,7 +1743,7 @@ packages:
       '@mapbox/point-geometry': 0.1.0
     dev: false
 
-  /@material-ui/core@4.12.4(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2):
+  /@material-ui/core@4.12.4(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -1755,23 +1755,23 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.18.9
-      '@material-ui/styles': 4.11.5(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2)
-      '@material-ui/system': 4.12.2(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2)
+      '@material-ui/styles': 4.11.5(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0)
+      '@material-ui/system': 4.12.2(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0)
       '@material-ui/types': 5.1.0(@types/react@18.0.17)
-      '@material-ui/utils': 4.11.3(react-dom@17.0.2)(react@17.0.2)
+      '@material-ui/utils': 4.11.3(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.0.17
       '@types/react-transition-group': 4.4.5
       clsx: 1.2.1
       hoist-non-react-statics: 3.3.2
       popper.js: 1.16.1-lts
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       react-is: 17.0.2
-      react-transition-group: 4.4.5(react-dom@17.0.2)(react@17.0.2)
+      react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
-  /@material-ui/icons@4.11.3(@material-ui/core@4.12.4)(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2):
+  /@material-ui/icons@4.11.3(@material-ui/core@4.12.4)(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-IKHlyx6LDh8n19vzwH5RtHIOHl9Tu90aAAxcbWME6kp4dmvODM3UvOHJeMIDzUbd4muuJKHmlNoBN+mDY4XkBA==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -1784,13 +1784,13 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.18.9
-      '@material-ui/core': 4.12.4(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2)
+      '@material-ui/core': 4.12.4(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.0.17
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@material-ui/lab@4.0.0-alpha.61(@material-ui/core@4.12.4)(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2):
+  /@material-ui/lab@4.0.0-alpha.61(@material-ui/core@4.12.4)(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -1803,17 +1803,17 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.18.9
-      '@material-ui/core': 4.12.4(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2)
-      '@material-ui/utils': 4.11.3(react-dom@17.0.2)(react@17.0.2)
+      '@material-ui/core': 4.12.4(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0)
+      '@material-ui/utils': 4.11.3(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.0.17
       clsx: 1.2.1
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       react-is: 17.0.2
     dev: false
 
-  /@material-ui/styles@4.11.5(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2):
+  /@material-ui/styles@4.11.5(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -1827,7 +1827,7 @@ packages:
       '@babel/runtime': 7.23.2
       '@emotion/hash': 0.8.0
       '@material-ui/types': 5.1.0(@types/react@18.0.17)
-      '@material-ui/utils': 4.11.3(react-dom@17.0.2)(react@17.0.2)
+      '@material-ui/utils': 4.11.3(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.0.17
       clsx: 1.2.1
       csstype: 2.6.20
@@ -1841,11 +1841,11 @@ packages:
       jss-plugin-rule-value-function: 10.9.2
       jss-plugin-vendor-prefixer: 10.9.2
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@material-ui/system@4.12.2(@types/react@18.0.17)(react-dom@17.0.2)(react@17.0.2):
+  /@material-ui/system@4.12.2(@types/react@18.0.17)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -1857,12 +1857,12 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.23.2
-      '@material-ui/utils': 4.11.3(react-dom@17.0.2)(react@17.0.2)
+      '@material-ui/utils': 4.11.3(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.0.17
       csstype: 2.6.20
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@material-ui/types@5.1.0(@types/react@18.0.17):
@@ -1876,7 +1876,7 @@ packages:
       '@types/react': 18.0.17
     dev: false
 
-  /@material-ui/utils@4.11.3(react-dom@17.0.2)(react@17.0.2):
+  /@material-ui/utils@4.11.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -1885,8 +1885,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.2
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       react-is: 17.0.2
     dev: false
 
@@ -7931,7 +7931,17 @@ packages:
       scheduler: 0.20.2
     dev: false
 
-  /react-dropzone@11.7.1(react@17.0.2):
+  /react-dom@18.2.0(react@18.2.0):
+    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
+    peerDependencies:
+      react: ^18.2.0
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.2.0
+      scheduler: 0.23.0
+    dev: false
+
+  /react-dropzone@11.7.1(react@18.2.0):
     resolution: {integrity: sha512-zxCMwhfPy1olUEbw3FLNPLhAm/HnaYH5aELIEglRbqabizKAdHs0h+WuyOpmA+v1JXn0++fpQDdNfUagWt5hJQ==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -7940,7 +7950,7 @@ packages:
       attr-accept: 2.2.2
       file-selector: 0.4.0
       prop-types: 15.8.1
-      react: 17.0.2
+      react: 18.2.0
     dev: false
 
   /react-is@16.13.1:
@@ -7955,7 +7965,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-transition-group@4.4.5(react-dom@17.0.2)(react@17.0.2):
+  /react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
       react: '>=16.6.0'
@@ -7965,8 +7975,8 @@ packages:
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react@17.0.2:
@@ -7975,6 +7985,13 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: false
+
+  /react@18.2.0:
+    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
     dev: false
 
   /read-pkg-up@7.0.1:
@@ -8474,6 +8491,12 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: false
+
+  /scheduler@0.23.0:
+    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
+    dependencies:
+      loose-envify: 1.4.0
     dev: false
 
   /scule@1.0.0:
@@ -10128,7 +10151,7 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  /zustand@3.7.2(react@17.0.2):
+  /zustand@3.7.2(react@18.2.0):
     resolution: {integrity: sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
@@ -10137,7 +10160,7 @@ packages:
       react:
         optional: true
     dependencies:
-      react: 17.0.2
+      react: 18.2.0
     dev: false
 
   /zwitch@2.0.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,9 +314,6 @@ importers:
       react-dropzone:
         specifier: ^11.2.3
         version: 11.7.1(react@17.0.2)
-      react-router-dom:
-        specifier: ^6.21.3
-        version: 6.21.3(react-dom@17.0.2)(react@17.0.2)
       zustand:
         specifier: ^3.4.1
         version: 3.7.2(react@17.0.2)
@@ -2290,11 +2287,6 @@ packages:
       - supports-color
       - utf-8-validate
     dev: true
-
-  /@remix-run/router@1.14.2:
-    resolution: {integrity: sha512-ACXpdMM9hmKZww21yEqWwiLws/UPLhNKvimN8RrYSqPSvB3ov7sLvAcfvaxePeLvccTQKGdkDIhLYApZVDFuKg==}
-    engines: {node: '>=14.0.0'}
-    dev: false
 
   /@rollup/plugin-alias@5.0.1(rollup@3.29.4):
     resolution: {integrity: sha512-JObvbWdOHoMy9W7SU0lvGhDtWq9PllP5mjpAy+TUslZG/WzOId9u80Hsqq1vCUn9pFJ0cxpdcnAv+QzU2zFH3Q==}
@@ -7962,29 +7954,6 @@ packages:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /react-router-dom@6.21.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kNzubk7n4YHSrErzjLK72j0B5i969GsuCGazRl3G6j1zqZBLjuSlYBdVdkDOgzGdPIffUOc9nmgiadTEVoq91g==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.14.2
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-router: 6.21.3(react@17.0.2)
-    dev: false
-
-  /react-router@6.21.3(react@17.0.2):
-    resolution: {integrity: sha512-a0H638ZXULv1OdkmiK6s6itNhoy33ywxmUFT/xtSoVyf9VnC7n7+VT4LjVzdIHSaF5TIh9ylUgxMXksHTgGrKg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.14.2
-      react: 17.0.2
-    dev: false
 
   /react-transition-group@4.4.5(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}

--- a/sites/avivator/package.json
+++ b/sites/avivator/package.json
@@ -18,7 +18,6 @@
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",
     "react-dropzone": "^11.2.3",
-    "react-router-dom": "^6.21.3",
     "zustand": "^3.4.1"
   },
   "devDependencies": {

--- a/sites/avivator/package.json
+++ b/sites/avivator/package.json
@@ -15,8 +15,8 @@
     "@math.gl/core": "^3.5.7",
     "geotiff": "^2.0.5",
     "lodash": "^4.17.21",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-dropzone": "^11.2.3",
     "zustand": "^3.4.1"
   },

--- a/sites/avivator/package.json
+++ b/sites/avivator/package.json
@@ -18,7 +18,7 @@
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",
     "react-dropzone": "^11.2.3",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "^6.21.3",
     "zustand": "^3.4.1"
   },
   "devDependencies": {

--- a/sites/avivator/src/Avivator.jsx
+++ b/sites/avivator/src/Avivator.jsx
@@ -18,7 +18,7 @@ import './index.css';
  * @param {Object} args.sources A list of sources for a dropdown menu, like [{ url, description }]
  * */
 export default function Avivator(props) {
-  const { history, source: initSource, isDemoImage } = props;
+  const { source: initSource, isDemoImage } = props;
   const isViewerLoading = useViewerStore(store => store.isViewerLoading);
   const source = useViewerStore(store => store.source);
   const useLinkedView = useViewerStore(store => store.useLinkedView);
@@ -29,7 +29,7 @@ export default function Avivator(props) {
       isNoImageUrlSnackbarOn: isDemoImage
     });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-  useImage(source, history);
+  useImage(source);
   return (
     <>
       <DropzoneWrapper>{!isViewerLoading && <Viewer />}</DropzoneWrapper>

--- a/sites/avivator/src/hooks.js
+++ b/sites/avivator/src/hooks.js
@@ -77,7 +77,7 @@ export const useImage = source => {
         let url = new URL(window.location.href);
         url.search =
           typeof urlOrFile === 'string' ? '?image_url=' + urlOrFile : '';
-        globalThis.history.pushState({}, '', url);
+        window.history.pushState({}, '', url);
       }
     }
     if (source) changeLoader();

--- a/sites/avivator/src/hooks.js
+++ b/sites/avivator/src/hooks.js
@@ -12,16 +12,16 @@ import {
   useViewerStore
 } from './state';
 import {
-  createLoader,
   buildDefaultSelection,
-  guessRgb,
-  getMultiSelectionStats,
+  createLoader,
   getBoundingCube,
+  getMultiSelectionStats,
+  guessRgb,
   isInterleaved
 } from './utils';
 import { COLOR_PALLETE, FILL_PIXEL_VALUE } from './constants';
 
-export const useImage = (source, history) => {
+export const useImage = source => {
   const [use3d, toggleUse3d, toggleIsOffsetsSnackbarOn] = useViewerStore(
     store => [store.use3d, store.toggleUse3d, store.toggleIsOffsetsSnackbarOn],
     shallow
@@ -73,10 +73,11 @@ export const useImage = (source, history) => {
           });
         });
         if (use3d) toggleUse3d();
-        // eslint-disable-next-line no-unused-expressions
-        history?.push(
-          typeof urlOrFile === 'string' ? `?image_url=${urlOrFile}` : ''
-        );
+
+        let url = new URL(window.location.href);
+        url.search =
+          typeof urlOrFile === 'string' ? '?image_url=' + urlOrFile : '';
+        globalThis.history.pushState({}, '', url);
       }
     }
     if (source) changeLoader();

--- a/sites/avivator/src/index.jsx
+++ b/sites/avivator/src/index.jsx
@@ -1,19 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {
-  useLocation,
-  BrowserRouter as Router,
-  Switch,
-  Route
-} from 'react-router-dom';
-import { ThemeProvider, createTheme } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { grey } from '@material-ui/core/colors';
 
 import sources from './source-info';
 import Avivator from './Avivator';
 import { getNameFromUrl } from './utils';
 
-const darkTheme = createTheme({
+const theme = createTheme({
   palette: {
     type: 'dark',
     primary: grey,
@@ -26,48 +20,30 @@ const darkTheme = createTheme({
   }
 });
 
-function getRandomSource() {
-  return sources[Math.floor(Math.random() * sources.length)];
-}
-
-// https://reactrouter.com/web/example/query-parameters
-function useQuery() {
-  return new URLSearchParams(useLocation().search);
-}
-
-function RoutedAvivator(props) {
-  const query = useQuery();
-  const url = query.get('image_url');
-  const {
-    routeProps: { history }
-  } = props;
+/** @param {string | null} url */
+function resolveSource(url) {
   if (url) {
-    const urlSrouce = {
+    return {
       urlOrFile: url,
-      description: getNameFromUrl(url)
+      description: getNameFromUrl(url),
+      isDemoImage: false
     };
-    return (
-      <ThemeProvider theme={darkTheme}>
-        <Avivator source={urlSrouce} history={history} />
-      </ThemeProvider>
-    );
   }
-  const source = getRandomSource();
+  // Pick a random source if none is specified.
+  return {
+    ...sources[Math.floor(Math.random() * sources.length)],
+    isDemoImage: true
+  };
+}
+
+function App() {
+  const query = new URLSearchParams(window.location.search);
+  const source = resolveSource(query.get('image_url'));
   return (
-    <ThemeProvider theme={darkTheme}>
-      <Avivator source={source} history={history} isDemoImage />
+    <ThemeProvider theme={theme}>
+      <Avivator source={source} isDemoImage={source.isDemoImage} />
     </ThemeProvider>
   );
 }
-// eslint-disable-next-line react/no-deprecated
-ReactDOM.render(
-  <Router>
-    <Switch>
-      <Route
-        path="/"
-        render={routeProps => <RoutedAvivator routeProps={routeProps} />}
-      />
-    </Switch>
-  </Router>,
-  document.getElementById('root')
-);
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/sites/avivator/src/index.jsx
+++ b/sites/avivator/src/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { grey } from '@material-ui/core/colors';
 
@@ -46,4 +46,4 @@ function App() {
   );
 }
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
We aren't doing anything sophisticated with routing in Avivator (besides pushing some state to the URL), which can be done without a library.
