### PR TITLE
feat(loaders): Relax `IFD` and `PlaneCount` strictness in OME-XML

### DIFF
--- a/.changeset/wicked-planets-raise.md
+++ b/.changeset/wicked-planets-raise.md
@@ -1,0 +1,5 @@
+---
+'@vivjs/loaders': patch
+---
+
+Relax `IFD` and `PlaneCount` strictness in OME-XML validation

--- a/packages/loaders/src/omexml.ts
+++ b/packages/loaders/src/omexml.ts
@@ -106,8 +106,8 @@ const TiffDataSchema = z
   .object({ UUID: UuidSchema.optional() })
   .extend({
     attr: z.object({
-      IFD: z.coerce.number(),
-      PlaneCount: z.coerce.number(),
+      IFD: z.coerce.number().default(0),
+      PlaneCount: z.coerce.number().optional(),
       FirstT: z.coerce.number().optional(),
       FirstC: z.coerce.number().optional(),
       FirstZ: z.coerce.number().optional()

--- a/packages/loaders/src/tiff/lib/indexers.ts
+++ b/packages/loaders/src/tiff/lib/indexers.ts
@@ -17,9 +17,7 @@ export type OmeTiffIndexer = (
  * bioformats case we need to return the GeoTIFF object and the IFD index.
  */
 export type OmeTiffResolver = {
-  (
-    sel: OmeTiffSelection
-  ):
+  (sel: OmeTiffSelection):
     | { tiff: GeoTIFF; ifdIndex: number }
     | Promise<{ tiff: GeoTIFF; ifdIndex: number }>;
 };

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -3,7 +3,7 @@ import type { Matrix4 } from 'math.gl';
 
 export type SupportedDtype = keyof typeof DTYPE_VALUES;
 export type SupportedTypedArray = InstanceType<
-  (typeof globalThis)[`${SupportedDtype}Array`]
+  typeof globalThis[`${SupportedDtype}Array`]
 >;
 
 export interface PixelData {
@@ -63,7 +63,7 @@ type ColorPaletteExtensionProps = {
 };
 
 type AdditiveColormapExtensionProps = {
-  colormap: (typeof COLORMAPS)[number];
+  colormap: typeof COLORMAPS[number];
   opacity: number;
   useTransparentColor: boolean;
 };
@@ -82,7 +82,7 @@ type ColorPalette3DExtensionProps = {
 };
 
 type AdditiveColormap3DExtensionProps = {
-  colormap: (typeof COLORMAPS)[number];
+  colormap: typeof COLORMAPS[number];
 };
 
 // types to be refined _if_ on LayerProps
@@ -101,8 +101,8 @@ type ExtractLoader<LayerProps, S extends string[]> = LayerProps extends {
 }
   ? { loader: PixelSource<S>[] }
   : LayerProps extends { loader: object }
-    ? { loader: PixelSource<S> }
-    : unknown;
+  ? { loader: PixelSource<S> }
+  : unknown;
 
 // Add optional extention props to layer if 'extensions' is defined on LayerProps.
 type WithExtensionProps<LayerProps> = LayerProps extends { extensions: unknown }

--- a/sites/avivator/index.html
+++ b/sites/avivator/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
Fixes #782

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
