### PR TITLE
ci: Setup biome action to reuse pinned biome version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: biomejs/setup-biome@v2
-        with:
-          version: latest
       - run: biome ci .
 
   Test:


### PR DESCRIPTION
Biome is putting out new features which our pinning of `latest` is causing
issues in CI. I had a look at the biome action and saw it actually doesn't
require specifying a version and will reuse the version of biome from a lock
file.
