### PR TITLE
fix(layers): Pass through `opts.renderPass`

### DIFF
--- a/packages/layers/src/xr-3d-layer/xr-3d-layer.js
+++ b/packages/layers/src/xr-3d-layer/xr-3d-layer.js
@@ -251,6 +251,11 @@ const XR3DLayer = class extends Layer {
    */
   draw(opts) {
     const { uniforms } = opts;
+    /** @type {{
+     *    textures: Record<string, import('@luma.gl/core').Binding>,
+     *    model: Model
+     *    scaleMatrix: Matrix4,
+     *  }} */
     const { textures, model, scaleMatrix } = this.state;
     const {
       contrastLimits,
@@ -324,7 +329,7 @@ const XR3DLayer = class extends Layer {
         { disableWanings: false }
       );
       model.setBindings(textures);
-      model.draw(opts);
+      model.draw(opts.renderPass);
     }
   }
 

--- a/packages/layers/src/xr-layer/xr-layer.js
+++ b/packages/layers/src/xr-layer/xr-layer.js
@@ -244,6 +244,7 @@ const XRLayer = class extends Layer {
    */
   draw(opts) {
     const { uniforms } = opts;
+    /** @type {{ textures: Record<string, import('@luma.gl/core').Binding>, model: Model }} */
     const { textures, model } = this.state;
     if (textures && model) {
       const { contrastLimits, domain, dtype, channelsVisible } = this.props;
@@ -265,7 +266,7 @@ const XRLayer = class extends Layer {
         { disableWarnings: false }
       );
       model.setBindings(textures);
-      model.draw(opts);
+      model.draw(opts.renderPass);
     }
   }
 


### PR DESCRIPTION
Fixes #854, which I believe was introduced in #805.

<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
