### PR TITLE
Fix typo in luma texture format names for signed integers

### DIFF
--- a/.changeset/purple-bobcats-jog.md
+++ b/.changeset/purple-bobcats-jog.md
@@ -1,0 +1,5 @@
+---
+"@vivjs/constants": patch
+---
+
+Restore support for signed integer data formats (`Int8`, `Int16`, `Int32`)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "pnpm -r --parallel build",
     "clean": "pnpm -r exec -- rm -rf node_modules",
     "test": "pnpm -r --parallel test",
-    "fix": "biome check --apply .",
+    "fix": "biome check --write .",
     "version": "node ./scripts/version.mjs",
     "publish": "pnpm build && pnpm changeset publish"
   },

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -48,21 +48,21 @@ export const DTYPE_VALUES = {
     sampler: 'sampler2D'
   },
   Int8: {
-    format: 'r8int',
+    format: 'r8sint',
     dataFormat: GL.RED_INTEGER,
     type: GL.BYTE,
     max: 2 ** (8 - 1) - 1,
     sampler: 'isampler2D'
   },
   Int16: {
-    format: 'r16int',
+    format: 'r16sint',
     dataFormat: GL.RED_INTEGER,
     type: GL.SHORT,
     max: 2 ** (16 - 1) - 1,
     sampler: 'isampler2D'
   },
   Int32: {
-    format: 'r32int',
+    format: 'r32sint',
     dataFormat: GL.RED_INTEGER,
     type: GL.INT,
     max: 2 ** (32 - 1) - 1,
@@ -70,7 +70,7 @@ export const DTYPE_VALUES = {
   },
   // Cast Float64 as 32 bit float point so it can be rendered.
   Float64: {
-    format: 'r32float',
+    format: 'r32sfloat',
     dataFormat: GL.RED,
     type: GL.FLOAT,
     // Not sure what to do about this one - a good use case for channel stats, I suppose:

--- a/sites/avivator/src/utils.js
+++ b/sites/avivator/src/utils.js
@@ -236,13 +236,11 @@ export async function createLoader(
 
       // try ome-zarr
       const res = await loadOmeZarr(urlOrFile, { type: 'multiscales' });
+      const channels = res.metadata?.omero?.channels ?? [{ label: 'image' }];
       // extract metadata into OME-XML-like form
       const metadata = {
         Pixels: {
-          Channels: res.metadata.omero.channels.map(c => ({
-            Name: c.label,
-            SamplesPerPixel: 1
-          }))
+          Channels: channels.map(c => ({ Name: c.label, SamplesPerPixel: 1 }))
         }
       };
       source = { data: res.data, metadata };


### PR DESCRIPTION
Brings back support for signed integer data types (`Int8`, `Int16`, `Int32`).

http://localhost:5173/?image_url=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr/labels/0

![image](https://github.com/user-attachments/assets/644ec76e-a62e-4781-a223-7ccae9540bbd)


<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
