### PR TITLE
Fix typo in luma texture format for Float32Array (`r32float`)

### DIFF
--- a/.changeset/twelve-flowers-beam.md
+++ b/.changeset/twelve-flowers-beam.md
@@ -1,0 +1,5 @@
+---
+"@vivjs/constants": patch
+---
+
+Fix typo in luma texture format for Float32Array (`r32float`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,10 @@ jobs:
       - run: biome ci .
 
   Test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
           run_install: true
-      - name: Run headless test
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: pnpm test
+      - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - run: biome ci .
 
   Test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       DISPLAY: :0
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,19 +32,12 @@ jobs:
 
   Test:
     runs-on: ubuntu-latest
-    env:
-      DISPLAY: :0
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
           run_install: true
-
-      - name: Setup xvf (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install -y xvfb
-          # start xvfb in the background
-          sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
-
-      - run: pnpm test
+      - name: Run headless test
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: pnpm test

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -70,7 +70,7 @@ export const DTYPE_VALUES = {
   },
   // Cast Float64 as 32 bit float point so it can be rendered.
   Float64: {
-    format: 'r32sfloat',
+    format: 'r32float',
     dataFormat: GL.RED,
     type: GL.FLOAT,
     // Not sure what to do about this one - a good use case for channel stats, I suppose:


### PR DESCRIPTION
Reverts accidental change introduced in #865. We should really use a TypeScript to help us with these kind of things.

#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
