### PR TITLE
(fix): disallow multiple samples per pixel in multi-channel tiff

### DIFF
--- a/packages/loaders/src/tiff/index.ts
+++ b/packages/loaders/src/tiff/index.ts
@@ -168,6 +168,9 @@ export async function loadMultiTiff(
           const curSelection = imageSelections[i];
           if (curSelection) {
             const tiff = await curImage.getImage(i);
+            if(tiff.fileDirectory.SamplesPerPixel > 1) {
+              throw new Error(`Multiple samples per pixel in tiff not supported as part of a multi-tiff, found ${tiff.fileDirectory.SamplesPerPixel} samples per pixel`);
+            }
             tiffImage.push({ selection: curSelection, tiff });
             channelNames[curSelection.c] = getImageSelectionName(
               name,

--- a/packages/loaders/src/tiff/index.ts
+++ b/packages/loaders/src/tiff/index.ts
@@ -168,8 +168,10 @@ export async function loadMultiTiff(
           const curSelection = imageSelections[i];
           if (curSelection) {
             const tiff = await curImage.getImage(i);
-            if(tiff.fileDirectory.SamplesPerPixel > 1) {
-              throw new Error(`Multiple samples per pixel in tiff not supported as part of a multi-tiff, found ${tiff.fileDirectory.SamplesPerPixel} samples per pixel`);
+            if (tiff.fileDirectory.SamplesPerPixel > 1) {
+              throw new Error(
+                `Multiple samples per pixel in tiff not supported as part of a multi-tiff, found ${tiff.fileDirectory.SamplesPerPixel} samples per pixel`
+              );
             }
             tiffImage.push({ selection: curSelection, tiff });
             channelNames[curSelection.c] = getImageSelectionName(


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #881 (in so far as it gives a better warning)
<!-- For other PRs without open issue -->
#### Background
This part of things is quite messy.  We probably can't remove this feature for multiple-tiff files, but the whole feature introduced the ability to visualize multi-channel tiff files (my mistake) unintentionally to Avivator, when it should have been disallowed.  At least now, we can provide a clearer warning for when someone tries to visualize something that won't even appear on screen.

#### Change List
- Add a check on `SamplesPerPixel` in the `multi-tiff` lodare
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
