### PR TITLE
update zarr.js to 0.6.3

### DIFF
--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -29,7 +29,7 @@
     "geotiff": "^2.0.5",
     "lzw-tiff-decoder": "^0.1.1",
     "quickselect": "^2.0.0",
-    "zarr": "^0.6.2",
+    "zarr": "^0.6.3",
     "zod": "^3.22.4"
   },
   "unbuild": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,7 +208,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       zarr:
-        specifier: ^0.6.2
+        specifier: ^0.6.3
         version: 0.6.3
       zod:
         specifier: ^3.22.4


### PR DESCRIPTION
#### Background
The latest version of zarr.js fixes issue with passing error messages. We would like to use that in our project, but are also using vivjs and would like to update viv as to not need to have two versions of zarr.js.

#### Change List
- Updates zarr.js from 0.6.2 to 0.6.3
#### Checklist
 - [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ ] Make sure Avivator works as expected with your change.
