### PR TITLE
fix: extract channel colors from omero metadata

### DIFF
--- a/sites/avivator/src/utils.js
+++ b/sites/avivator/src/utils.js
@@ -240,7 +240,10 @@ export async function createLoader(
       // extract metadata into OME-XML-like form
       const metadata = {
         Pixels: {
-          Channels: channels.map(c => ({ Name: c.label, SamplesPerPixel: 1 }))
+          Channels: channels.map(c => ({ 
+            Name: c.label, 
+            SamplesPerPixel: 1,
+            Color: c.color ? [...hexToRgb(c.color), 255] : undefined }))
         }
       };
       source = { data: res.data, metadata };


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #917 
<!-- For all the PRs -->
#### Change List
- In `utils.js`, when extracting metadata of OME-Zarr files in `createLoader`, extract the hex colors from the OMERO metadata, if available. Convert to rgb and assign to the Color attribute of Channels in the new OME-XML-like formatted metadata. If the OMERO metadata is not present or does not have color data available, the Color attribute in the new metadata is `undefined`, and the default color palette from `constants.js` is applied as in the current version.
#### Checklist
 Not applicable: ~- [ ] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.~
 - [X] Make sure Avivator works as expected with your change.
