### PR TITLE
Export loadOmeZarrFromStore for custom store support

### DIFF
--- a/.changeset/export-ome-zarr-from-store.md
+++ b/.changeset/export-ome-zarr-from-store.md
@@ -1,0 +1,5 @@
+---
+"@vivjs/loaders": minor
+---
+
+Export `loadOmeZarrFromStore` to allow loading OME-Zarr data from a custom store, enabling use cases like AWS SigV4 signed requests for private S3 buckets.

--- a/packages/loaders/src/index.ts
+++ b/packages/loaders/src/index.ts
@@ -1,5 +1,10 @@
 export { loadOmeTiff, loadMultiTiff } from './tiff';
-export { loadOmeZarr, DEPRECATED_loadBioformatsZarr } from './zarr';
+export {
+  loadOmeZarr,
+  DEPRECATED_loadBioformatsZarr,
+  loadOmeZarrFromStore
+} from './zarr';
+export type { RootAttrs } from './zarr';
 
 export { default as TiffPixelSource } from './tiff/pixel-source';
 export { default as ZarrPixelSource } from './zarr/pixel-source';

--- a/packages/loaders/src/zarr/index.ts
+++ b/packages/loaders/src/zarr/index.ts
@@ -5,6 +5,9 @@ import { getRootPrefix } from './lib/utils';
 import { load as loadBioformats } from './bioformats-zarr';
 import { load as loadOme } from './ome-zarr';
 
+export { load as loadOmeZarrFromStore } from './ome-zarr';
+export type { RootAttrs } from './ome-zarr';
+
 interface ZarrOptions {
   fetchOptions: RequestInit;
 }


### PR DESCRIPTION
Fixes #933

## Background

`loadOmeZarr` only accepts a URL string, so users needing custom stores (e.g. AWS SigV4 signed requests for private S3 buckets) had to reimplement viv's internal zarr loading logic. The internal `load` function in `ome-zarr.ts` already accepts a store parameter — this PR simply exports it.

## Changes

- Export `load` from `ome-zarr.ts` as `loadOmeZarrFromStore` via `@vivjs/loaders`
- Export `RootAttrs` type for consumers to type the returned metadata
- Add changeset (minor)

## Checklist

- [x] No API changes to existing functions (additive only)
- [x] Update JSdoc types if there is any API change — N/A, additive export only
- [x] Make sure Avivator works as expected with your change — verified with public OME-Zarr URL, no regressions
- [x] `pnpm build` passes
- [x] `pnpm test` passes (68/68)