### PR TITLE
feat(loaders): accept pre-constructed GeoTIFF in loadOmeTiff

### DIFF
--- a/.changeset/rotten-streets-dance.md
+++ b/.changeset/rotten-streets-dance.md
@@ -1,0 +1,5 @@
+---
+"@vivjs/loaders": patch
+---
+
+Support an options.source parameter for loadSingleFileOmeTiff, as an optional way to bypass the internal createGeoTiff function when users already have their own GeoTIFF instance to provide.

--- a/packages/loaders/src/tiff/index.ts
+++ b/packages/loaders/src/tiff/index.ts
@@ -1,5 +1,5 @@
 import { addDecoder, fromBlob } from 'geotiff';
-import type { Pool } from 'geotiff';
+import type { GeoTIFF, Pool } from 'geotiff';
 
 import LZWDecoder from './lib/lzw-decoder';
 import {
@@ -21,6 +21,16 @@ interface TiffOptions {
   headers?: Headers | Record<string, string>;
   offsets?: number[];
   pool?: Pool;
+  /**
+   * A pre-constructed GeoTIFF instance. When provided, the loader skips
+   * its internal HTTP client and uses this GeoTIFF for all data access.
+   * This enables custom transport layers (e.g., AWS SigV4 request signing)
+   * via geotiff's `fromCustomClient()`.
+   *
+   * Only applies to single-file OME-TIFFs. Ignored for companion
+   * (multifile) OME-TIFFs which open multiple GeoTIFFs internally.
+   */
+  source?: GeoTIFF;
 }
 
 interface OmeTiffOptions extends TiffOptions {

--- a/packages/loaders/src/tiff/lib/utils.ts
+++ b/packages/loaders/src/tiff/lib/utils.ts
@@ -351,9 +351,11 @@ export async function createGeoTiff(
   options: {
     headers?: Headers | Record<string, string>;
     offsets?: number[];
+    /** Pre-constructed GeoTIFF — skips internal HTTP client when provided. */
+    source?: GeoTIFF;
   } = {}
 ): Promise<GeoTIFF> {
-  const tiff = await createGeoTiffObject(source, options);
+  const tiff = options.source ?? (await createGeoTiffObject(source, options));
   /*
    * Performance enhancement. If offsets are provided, we
    * create a proxy that intercepts calls to `tiff.getImage`

--- a/packages/loaders/src/tiff/singlefile-ome-tiff.ts
+++ b/packages/loaders/src/tiff/singlefile-ome-tiff.ts
@@ -98,10 +98,15 @@ export async function loadSingleFileOmeTiff(
     pool?: Pool;
     headers?: Headers | Record<string, string>;
     offsets?: number[];
+    source?: GeoTIFF;
   } = {}
 ) {
-  const { offsets, headers, pool } = options;
-  const tiff = await createGeoTiff(source, { headers, offsets });
+  const { offsets, headers, pool, source: prebuiltSource } = options;
+  const tiff = await createGeoTiff(source, {
+    headers,
+    offsets,
+    source: prebuiltSource
+  });
   const firstImage = await tiff.getImage();
   const { rootMeta, levels } = resolveMetadata(
     fromString(firstImage.fileDirectory.ImageDescription),


### PR DESCRIPTION
Adds an optional `source` property to `TiffOptions` that accepts a pre-constructed `GeoTIFF` instance. When provided, `createGeoTiff` skips its internal HTTP client and uses the given instance directly.

This is the TIFF equivalent of #933 / #944 — where `loadOmeZarrFromStore` was exported to enable custom stores with dynamic auth. The TIFF loader had no equivalent extension point.

### Use case

Serving OME-TIFFs from S3 with STS temporary credentials and client-side SigV4 request signing. Each range request requires a unique `Authorization` header, which rules out both presigned URLs and static headers. geotiff's `fromCustomClient()` handles this — this change lets the resulting `GeoTIFF` flow into viv's pipeline.

### Relation to #954

The store-level unification proposed in #954 would make this unnecessary long-term — a single zarrita store (with custom auth) would serve both TIFF and zarr. This PR is an interim solution until that lands.

### Changes

- `TiffOptions.source?: GeoTIFF` — new optional property
- `createGeoTiff` — `options.source ?? await createGeoTiffObject(...)`
- `loadSingleFileOmeTiff` — passes `source` through to `createGeoTiff`
- Single-file only; companion (multifile) OME-TIFFs are unaffected

Fully backwards-compatible.