### PR TITLE
chore(deps): bump actions/deploy-pages from 4 to 5

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,4 +44,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Fix "Requires authentication" error by aligning deploy-pages version with the upload-pages-artifact v5 bump from #960.

Fixes #
Fix "Requires authentication" error during deployment
#### Background
Fix "Requires authentication" error 
#### Change List
- Align deploy-pages version with the upload-pages-artifact v5 bump
#### Checklist
 - [ N/A] Update [JSdoc types](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) if there is any API change.
 - [ N/A] Make sure Avivator works as expected with your change.
